### PR TITLE
[FLYW-126] root-context 스캔 범위 수정 및 MyBatis 구조 초기 세팅

### DIFF
--- a/src/main/java/com/flyway/user/mapper/UserMapper.java
+++ b/src/main/java/com/flyway/user/mapper/UserMapper.java
@@ -1,0 +1,5 @@
+package com.flyway.user.mapper;
+
+public interface UserMapper {
+    // TODO: queries
+}

--- a/src/main/resources/mapper/user/UserMapper.xml
+++ b/src/main/resources/mapper/user/UserMapper.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper
+        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="com.flyway.user.mapper.UserMapper">
+    <!-- TODO: SQL -->
+</mapper>

--- a/src/main/webapp/WEB-INF/spring/root-context.xml
+++ b/src/main/webapp/WEB-INF/spring/root-context.xml
@@ -12,7 +12,7 @@
       http://mybatis.org/schema/mybatis-spring.xsd">
 
     <!-- Properties 파일 로드 -->
-    <context:property-placeholder location="classpath:config/application-dev.properties" />
+    <context:property-placeholder location="classpath:config/application-dev.properties"/>
 
     <context:component-scan base-package="com.flyway">
         <context:exclude-filter type="annotation" expression="org.springframework.stereotype.Controller"/>
@@ -20,40 +20,39 @@
 
     <!-- HikariCP 설정 (Properties에서 값 주입) -->
     <bean id="hikariConfig" class="com.zaxxer.hikari.HikariConfig">
-        <property name="driverClassName" value="${db.driver}" />
-        <property name="jdbcUrl" value="${db.url}" />
-        <property name="username" value="${db.username}" />
-        <property name="password" value="${db.password}" />
-        <property name="maximumPoolSize" value="${db.hikari.maximum-pool-size}" />
-        <property name="minimumIdle" value="${db.hikari.minimum-idle}" />
-        <property name="connectionTimeout" value="${db.hikari.connection-timeout}" />
+        <property name="driverClassName" value="${db.driver}"/>
+        <property name="jdbcUrl" value="${db.url}"/>
+        <property name="username" value="${db.username}"/>
+        <property name="password" value="${db.password}"/>
+        <property name="maximumPoolSize" value="${db.hikari.maximum-pool-size}"/>
+        <property name="minimumIdle" value="${db.hikari.minimum-idle}"/>
+        <property name="connectionTimeout" value="${db.hikari.connection-timeout}"/>
     </bean>
 
 
     <bean id="dataSource" class="com.zaxxer.hikari.HikariDataSource" destroy-method="close">
-        <constructor-arg ref="hikariConfig" />
+        <constructor-arg ref="hikariConfig"/>
     </bean>
 
     <!-- MyBatis SqlSessionFactory -->
     <bean id="sqlSessionFactory" class="org.mybatis.spring.SqlSessionFactoryBean">
-        <property name="dataSource" ref="dataSource" />
-        <!--  mapper 파일 생성 후 주석 제거   -->
-<!--        <property name="mapperLocations" value="classpath:mapper/**/*.xml" />-->
-        <property name="typeAliasesPackage" value="com.flyway.template.domain" />
+        <property name="dataSource" ref="dataSource"/>
+        <property name="mapperLocations" value="classpath:mapper/**/*.xml"/>
+        <property name="typeAliasesPackage" value="com.flyway"/>
         <property name="configuration">
             <bean class="org.apache.ibatis.session.Configuration">
-                <property name="mapUnderscoreToCamelCase" value="true" />
-                <property name="jdbcTypeForNull" value="NULL" />
+                <property name="mapUnderscoreToCamelCase" value="true"/>
+                <property name="jdbcTypeForNull" value="NULL"/>
             </bean>
         </property>
     </bean>
 
     <!-- MyBatis SqlSession Template -->
     <bean id="sqlSession" class="org.mybatis.spring.SqlSessionTemplate">
-        <constructor-arg ref="sqlSessionFactory" />
+        <constructor-arg ref="sqlSessionFactory"/>
     </bean>
 
     <!-- MyBatis Mapper Scanner -->
-    <mybatis-spring:scan base-package="com.flyway.template.mapper" />
+    <mybatis-spring:scan base-package="com.flyway"/>
 
 </beans>


### PR DESCRIPTION
## 📌 PR 설명
MyBatis 및 Spring 스캔 범위를 설정하였습니다.
<br>

## ✅ 완료한 기능 명세

- [x] root-context.xml 컴포넌트 스캔 범위를 상위 패키지(com.flyway)로 확장

 - [x] MyBatis Mapper 스캔을 상위 패키지(`com.flyway`) 기준으로 설정

 - [x] mapperLocations (classpath:mapper/**/*.xml) 적용

 - [x] Users 도메인 Mapper XML + Interface 구조 초기 세팅


<br>

## 💭 고민과 해결과정
Java Config(@MapperScan) 방식과 비교하여, 도메인 확장 시 설정 변경을 최소화할 수 있는 XML 기반 mapper 스캔 방식이 낫다고 판단하였습니다.

- Mapper는 `com.flyway.<domain>.mapper` 패키지 규칙으로 관리
- `<mybatis-spring:scan base-package="com.flyway"/>` 한 줄로 전체 등록
- `@Mapper` 어노테이션은 사용하지 않아도 됨

  - Notion > 코딩 컨벤션 에 `Mapper 작성 및 스캔 규칙 안내`를 작성했으니 확인 부탁드립니다!



<br>

### 🔗 관련 이슈
Closes #67 

<br>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Established infrastructure for database mapper operations.

* **Chores**
  * Expanded component discovery scope to support broader application architecture.
  * Enabled MyBatis mapper functionality for data persistence operations.
  * Updated configuration to align package scanning across mapper interfaces and type aliases.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->