### PR TITLE
[FLYW-34] 좌석 맵 조회 및 만료 스케줄러 분리

### DIFF
--- a/src/main/java/com/flyway/config/SchedulingConfig.java
+++ b/src/main/java/com/flyway/config/SchedulingConfig.java
@@ -1,0 +1,9 @@
+package com.flyway.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+@EnableScheduling
+@Configuration
+public class SchedulingConfig {
+}

--- a/src/main/java/com/flyway/seat/controller/SeatController.java
+++ b/src/main/java/com/flyway/seat/controller/SeatController.java
@@ -1,0 +1,27 @@
+package com.flyway.seat.controller;
+
+import com.flyway.template.common.ApiResponse;
+import com.flyway.seat.dto.SeatDTO;
+import com.flyway.seat.service.SeatService;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+public class SeatController {
+    private final SeatService seatService;
+
+    public SeatController(SeatService seatService) {
+        this.seatService = seatService;
+    }
+
+    // 항공편별 좌석 맵 조회
+    @GetMapping("/api/flights/{flightId}/seats")
+    public ApiResponse<List<SeatDTO>> getSeatMap(@PathVariable String flightId){
+        return ApiResponse.<List<SeatDTO>>success(seatService.getSeatMap(flightId));
+
+    }
+}

--- a/src/main/java/com/flyway/seat/dto/SeatDTO.java
+++ b/src/main/java/com/flyway/seat/dto/SeatDTO.java
@@ -1,0 +1,28 @@
+package com.flyway.seat.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@ToString
+
+public class SeatDTO {
+    private String flightSeatId;
+    private String flightId;
+
+    private String seatNo;
+    private Integer rowNo;
+    private String colNo;
+
+    private String cabinClassCode;
+    private String seatStatus;
+
+    private LocalDateTime holdExpiresAt;
+
+
+}

--- a/src/main/java/com/flyway/seat/mapper/SeatMapper.java
+++ b/src/main/java/com/flyway/seat/mapper/SeatMapper.java
@@ -1,0 +1,16 @@
+package com.flyway.seat.mapper;
+
+import com.flyway.seat.dto.SeatDTO;
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+
+import java.util.List;
+
+@Mapper
+public interface SeatMapper {
+    // 만료된 HOLD 좌석을 AVAILABLE로 되돌림
+    int releaseExpiredHolds();
+
+    // 항공편별 좌석 맵 조회
+    List<SeatDTO> selectSeatMapByFlightId(@Param("flightId") String flightId);
+}

--- a/src/main/java/com/flyway/seat/scheduler/SeatHoldScheduler.java
+++ b/src/main/java/com/flyway/seat/scheduler/SeatHoldScheduler.java
@@ -1,0 +1,37 @@
+package com.flyway.seat.scheduler;
+
+import com.flyway.seat.service.SeatService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+public class SeatHoldScheduler {
+
+    private static final Logger log = LoggerFactory.getLogger(SeatHoldScheduler.class);
+
+    private final SeatService seatService;
+
+    public SeatHoldScheduler(SeatService seatService) {
+        this.seatService = seatService;
+    }
+
+    /* 예를 들어 HOLD 유효시간이 10분이고, 배치가 1분마다 실행되면
+
+    - 10:00:00에 HOLD 걸림 → hold_expires_at = 10:10:00
+
+    - 좌석은 10:10:00에 만료됐지만
+
+    - 배치는 1분마다라서 10:10:00~10:10:59 사이엔 DB에 HOLD로 남아있을 수 있음
+
+    - 다음 배치가 10:11:00에 돌면 그때 AVAILABLE로 복구됨 */
+    @Scheduled(fixedDelay = 60_000)
+    public void releaseExpiredHoldsJob() {
+        int updated = seatService.releaseExpiredHolds();
+
+        if (updated > 0) {
+            log.info("released expired HOLD seats: {}", updated);
+        }
+    }
+}

--- a/src/main/java/com/flyway/seat/service/SeatService.java
+++ b/src/main/java/com/flyway/seat/service/SeatService.java
@@ -1,0 +1,12 @@
+package com.flyway.seat.service;
+
+import com.flyway.seat.dto.SeatDTO;
+import java.util.List;
+
+public interface SeatService {
+    // 항공편별 좌석 맵 조회
+    List<SeatDTO> getSeatMap(String flightId);
+
+    // 만료된 HOLD 좌석을 AVAILABLE로 복구 (배치/스케줄러에서 호출)
+    int releaseExpiredHolds();
+}

--- a/src/main/java/com/flyway/seat/service/SeatServiceImpl.java
+++ b/src/main/java/com/flyway/seat/service/SeatServiceImpl.java
@@ -1,0 +1,37 @@
+package com.flyway.seat.service;
+
+import com.flyway.seat.dto.SeatDTO;
+import com.flyway.seat.mapper.SeatMapper;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+public class SeatServiceImpl implements SeatService {
+
+    private final SeatMapper seatMapper;
+
+    public SeatServiceImpl(SeatMapper seatMapper) {
+        this.seatMapper = seatMapper;
+    }
+
+    /**
+     * 좌석 맵 조회는 조회만 수행 (UPDATE 없음)
+     */
+    @Override
+    @Transactional(readOnly = true)
+    public List<SeatDTO> getSeatMap(String flightId) {
+        return seatMapper.selectSeatMapByFlightId(flightId);
+    }
+
+    /**
+     * 만료된 HOLD 좌석 복구는 배치/스케줄러에서 호출
+     * 트랜잭션은 Service 계층에서 관리
+     */
+    @Override
+    @Transactional
+    public int releaseExpiredHolds() {
+        return seatMapper.releaseExpiredHolds();
+    }
+}

--- a/src/main/resources/mapper/seat/SeatMapper.xml
+++ b/src/main/resources/mapper/seat/SeatMapper.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper
+        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="com.flyway.seat.mapper.SeatMapper">
+
+    <!-- 만료된 HOLD 좌석을 AVAILABLE로 복구 -->
+    <update id="releaseExpiredHolds">
+        UPDATE flight_seat
+        SET seat_status = 'AVAILABLE',
+            hold_expires_at = NULL
+        WHERE seat_status = 'HOLD'
+          AND hold_expires_at IS NOT NULL
+          AND hold_expires_at &lt; NOW()
+    </update>
+
+    <!-- 항공편별 좌석 맵 조회 -->
+    <select id="selectSeatMapByFlightId" resultType="com.flyway.seat.dto.SeatDTO">
+        SELECT
+            fs.flight_seat_id   AS flightSeatId,
+            fs.flight_id        AS flightId,
+            a.seat_no           AS seatNo,
+            a.row_no            AS rowNo,
+            a.col_no            AS colNo,
+            a.cabin_class_code  AS cabinClassCode,
+            fs.seat_status      AS seatStatus,
+            fs.hold_expires_at  AS holdExpiresAt
+        FROM flight_seat fs
+                 JOIN aircraft_seat a
+                      ON fs.aircraft_seat_id = a.airplane_seat_id
+        WHERE fs.flight_id = #{flightId}
+        ORDER BY a.cabin_class_code, a.row_no, a.col_no
+    </select>
+
+</mapper>

--- a/src/main/webapp/WEB-INF/spring/root-context.xml
+++ b/src/main/webapp/WEB-INF/spring/root-context.xml
@@ -64,5 +64,4 @@
 
     <!-- Transaction Annotation 활성화 -->
     <tx:annotation-driven transaction-manager="transactionManager"/>
-
 </beans>


### PR DESCRIPTION
## 📌 PR 설명
<br>
항공편별 좌석 맵 조회 API를 구현.
좌석 HOLD 만료 처리를 조회 로직에서 분리하여 스케줄러 기반으로 개선

## ✅ 완료한 기능 명세

- [x] 항공편 ID 기준 좌석 맵 조회 API 구현
- [x] 좌석 상태(AVAILABLE / HOLD / BOOKED) 조회 분리
- [x] 만료된 HOLD 좌석 복구 로직을 스케줄러로 분리
- [x] 조회 API에서 UPDATE 쿼리 제거

<br>

## 📸 스크린샷

<br>

## 💭 고민과 해결과정
- 기존에는 좌석 조회 시 만료 HOLD를 즉시 복구하는 구조로 조회 API가 상태 변경 책임까지 가지는 문제가 있었음
- 조회와 상태 변경 책임을 분리하기 위해 만료 처리 로직을 @Scheduled 기반 배치로 이동
- 트랜잭션은 Service 계층에서 관리하도록 함
<br>

### 🔗 관련 이슈
Closes #5 

<br>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added seat map retrieval endpoint for flights, allowing users to check seat availability and details
  * Implemented automatic scheduled cleanup that periodically releases expired seat reservations

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->