### PR TITLE
[FLYW-136] flyway v4 마이그레이션 실패 복구 및 v5 마이그레이션

### DIFF
--- a/src/main/resources/db/migration/V4__trigger.sql
+++ b/src/main/resources/db/migration/V4__trigger.sql
@@ -1,0 +1,3 @@
+-- No-op migration.
+-- Reason: Triggers cannot be created on current RDS settings (SUPER privilege / log_bin restrictions).
+-- The last_priced_at update logic is handled at application/query level instead.

--- a/src/main/resources/db/migration/V5__alter_email_flight.sql
+++ b/src/main/resources/db/migration/V5__alter_email_flight.sql
@@ -1,0 +1,17 @@
+-- 1) user_id FK 제거
+ALTER TABLE email_verification_token
+    DROP FOREIGN KEY fk_evt_user;
+
+-- 2) user_id 인덱스 제거
+ALTER TABLE email_verification_token
+    DROP INDEX idx_evt_user_id;
+
+-- 3) user_id 컬럼 제거
+ALTER TABLE email_verification_token
+    DROP COLUMN user_id;
+
+ALTER TABLE flight_seat
+    ADD UNIQUE KEY uk_flight_seat (flight_id, aircraft_seat_id);
+
+ALTER TABLE flight
+    ADD COLUMN duration_minutes INT COMMENT '비행 시간(분)';


### PR DESCRIPTION
## 📌 PR 설명
Flyway V4 트리거 마이그레이션 실패로 인해 스키마 히스토리가 꼬이며 서버 부팅이 불가했던 문제를 복구하였습니다. RDS 환경에서 트리거 생성 권한(SUPER, binary log 제약)으로 인해 발생한 V4 파일을 비우고, V5 마이그레이션을 적용하였습니다.
<br>

## ✅ 완료한 기능 명세

- [x] Flyway 히스토리 테이블(schema_version) 기준으로 마이그레이션 상태 복구 (repair)
- [x]  RDS 권한 이슈로 실행 불가능한 V4 트리거 마이그레이션을 no-op 처리
- [x]  V5 마이그레이션 적용

<br>

### 🔗 관련 이슈

Closes #89 

<br>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Database Updates**
  * Restructured email verification system to streamline data handling and improve overall system reliability across the platform
  * Implemented unique constraints on flight seat assignments to prevent duplicate bookings and enhance overall data integrity standards
  * Added flight duration tracking in minutes to provide more detailed and comprehensive flight time information for users

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->