### PR TITLE
[FLYW-146] flyway v8 마이그레이션 (배치 메타 테이블 추가)

### DIFF
--- a/src/main/resources/db/migration/V8__create_batch_schema.sql
+++ b/src/main/resources/db/migration/V8__create_batch_schema.sql
@@ -1,0 +1,72 @@
+CREATE TABLE BATCH_JOB_INSTANCE  (
+                                     JOB_INSTANCE_ID BIGINT  NOT NULL PRIMARY KEY AUTO_INCREMENT,
+                                     VERSION BIGINT,
+                                     JOB_NAME VARCHAR(100) NOT NULL,
+                                     JOB_KEY VARCHAR(32) NOT NULL,
+                                     constraint JOB_INST_UN unique (JOB_NAME, JOB_KEY)
+) ENGINE=InnoDB;
+
+CREATE TABLE BATCH_JOB_EXECUTION  (
+                                      JOB_EXECUTION_ID BIGINT  NOT NULL PRIMARY KEY AUTO_INCREMENT,
+                                      VERSION BIGINT,
+                                      JOB_INSTANCE_ID BIGINT NOT NULL,
+                                      CREATE_TIME DATETIME(6) NOT NULL,
+                                      START_TIME DATETIME(6) DEFAULT NULL,
+                                      END_TIME DATETIME(6) DEFAULT NULL,
+                                      STATUS VARCHAR(10),
+                                      EXIT_CODE VARCHAR(2500),
+                                      EXIT_MESSAGE VARCHAR(2500),
+                                      LAST_UPDATED DATETIME(6),
+                                      constraint JOB_INST_EXEC_FK foreign key (JOB_INSTANCE_ID)
+                                          references BATCH_JOB_INSTANCE(JOB_INSTANCE_ID)
+) ENGINE=InnoDB;
+
+CREATE TABLE BATCH_JOB_EXECUTION_PARAMS  (
+                                             JOB_EXECUTION_ID BIGINT NOT NULL,
+                                             PARAMETER_NAME VARCHAR(100) NOT NULL,
+                                             PARAMETER_TYPE VARCHAR(100) NOT NULL,
+                                             PARAMETER_VALUE VARCHAR(2500),
+                                             IDENTIFYING CHAR(1) NOT NULL,
+                                             constraint JOB_EXEC_PARAMS_FK foreign key (JOB_EXECUTION_ID)
+                                                 references BATCH_JOB_EXECUTION(JOB_EXECUTION_ID)
+) ENGINE=InnoDB;
+
+CREATE TABLE BATCH_STEP_EXECUTION  (
+                                       STEP_EXECUTION_ID BIGINT  NOT NULL PRIMARY KEY AUTO_INCREMENT,
+                                       VERSION BIGINT NOT NULL,
+                                       STEP_NAME VARCHAR(100) NOT NULL,
+                                       JOB_EXECUTION_ID BIGINT NOT NULL,
+                                       CREATE_TIME DATETIME(6) NOT NULL,
+                                       START_TIME DATETIME(6) DEFAULT NULL,
+                                       END_TIME DATETIME(6) DEFAULT NULL,
+                                       STATUS VARCHAR(10),
+                                       COMMIT_COUNT BIGINT,
+                                       READ_COUNT BIGINT,
+                                       FILTER_COUNT BIGINT,
+                                       WRITE_COUNT BIGINT,
+                                       READ_SKIP_COUNT BIGINT,
+                                       WRITE_SKIP_COUNT BIGINT,
+                                       PROCESS_SKIP_COUNT BIGINT,
+                                       ROLLBACK_COUNT BIGINT,
+                                       EXIT_CODE VARCHAR(2500),
+                                       EXIT_MESSAGE VARCHAR(2500),
+                                       LAST_UPDATED DATETIME(6),
+                                       constraint JOB_EXEC_STEP_FK foreign key (JOB_EXECUTION_ID)
+                                           references BATCH_JOB_EXECUTION(JOB_EXECUTION_ID)
+) ENGINE=InnoDB;
+
+CREATE TABLE BATCH_STEP_EXECUTION_CONTEXT  (
+                                               STEP_EXECUTION_ID BIGINT NOT NULL PRIMARY KEY,
+                                               SHORT_CONTEXT VARCHAR(2500) NOT NULL,
+                                               SERIALIZED_CONTEXT TEXT,
+                                               constraint STEP_EXEC_CTX_FK foreign key (STEP_EXECUTION_ID)
+                                                   references BATCH_STEP_EXECUTION(STEP_EXECUTION_ID)
+) ENGINE=InnoDB;
+
+CREATE TABLE BATCH_JOB_EXECUTION_CONTEXT  (
+                                              JOB_EXECUTION_ID BIGINT NOT NULL PRIMARY KEY,
+                                              SHORT_CONTEXT VARCHAR(2500) NOT NULL,
+                                              SERIALIZED_CONTEXT TEXT,
+                                              constraint JOB_EXEC_CTX_FK foreign key (JOB_EXECUTION_ID)
+                                                  references BATCH_JOB_EXECUTION(JOB_EXECUTION_ID)
+) ENGINE=InnoDB;


### PR DESCRIPTION
## 📌 PR 설명
Spring Batch 메타 데이터 스키마를 추가하는 Flyway v8 마이그레이션을 작성했습니다.
<br>

## ✅ 완료한 기능 명세

- [x] `BATCH_JOB_INSTANCE` : 배치 Job의 생성정보를 담는 테이블
- [x] `BATCH_JOB_EXECUTION` : 배치 Job의 실행정보를 담는 테이블
- [x] `BATCH_JOB_EXECUTION_PARAM` : 배치 Job에서 사용되는 파라미터값들을 담는 테이블
- [x] `BATCH_JOB_EXECUTION_CONTEXT` : 작업중 사용되는 모든 정보가 기록되는 Context를 저장하는 테이블
- [x] `BATCH_STEP_EXECUTION` : 배치 step의 실행정보를 담는 테이블
- [x] `BATCH_STEP_EXECUTIOIN_CONTEXT` : Step에서 사용되는 모든 정보가 기록되는 Context를 저장하는 테이블

<br>

### 🔗 관련 이슈
Closes #112
<br>