### PR TITLE
[FLYW-138] 회원가입 이메일 인증 선점 문제 설계 개선

### DIFF
--- a/src/main/java/com/flyway/auth/controller/EmailVerificationApiController.java
+++ b/src/main/java/com/flyway/auth/controller/EmailVerificationApiController.java
@@ -1,5 +1,6 @@
 package com.flyway.auth.controller;
 
+import com.flyway.auth.dto.SignupVerificationIssueResponse;
 import com.flyway.auth.service.EmailVerificationService;
 import com.flyway.template.common.ApiResponse;
 import com.flyway.template.exception.BusinessException;
@@ -24,10 +25,11 @@ public class EmailVerificationApiController {
     private final EmailVerificationService emailVerificationService;
 
     @PostMapping("/api/auth/email/issue")
-    public ResponseEntity<ApiResponse<Void>> issueSignupVerification(@RequestParam String email) {
+    public ResponseEntity<ApiResponse<SignupVerificationIssueResponse>> issueSignupVerification(@RequestParam String email) {
         try {
-            emailVerificationService.issueSignupVerification(email);
-            return ResponseEntity.ok(ApiResponse.success(null, "이메일 인증 메일을 전송했습니다."));
+            String attemptId = emailVerificationService.issueSignupVerification(email);
+            SignupVerificationIssueResponse response = SignupVerificationIssueResponse.builder().attemptId(attemptId).build();
+            return ResponseEntity.ok(ApiResponse.success(response, "이메일 인증 메일을 전송했습니다."));
         } catch (BusinessException e) {
             return ResponseEntity.status(e.getErrorCode().getStatus())
                     .body(ApiResponse.error(
@@ -46,10 +48,11 @@ public class EmailVerificationApiController {
                     ));
         }
     }
+
     @GetMapping("/api/auth/email/status")
-    public ResponseEntity<ApiResponse<Boolean>> checkSignupVerification(@RequestParam String email) {
+    public ResponseEntity<ApiResponse<Boolean>> checkSignupVerification(@RequestParam String email, @RequestParam String attemptId) {
         try {
-            boolean verified = emailVerificationService.isSignupVerified(email);
+            boolean verified = emailVerificationService.isSignupVerified(email, attemptId);
             return ResponseEntity.ok(ApiResponse.success(verified));
         } catch (IllegalArgumentException e) {
             return ResponseEntity.status(HttpStatus.BAD_REQUEST)

--- a/src/main/java/com/flyway/auth/controller/EmailVerificationViewController.java
+++ b/src/main/java/com/flyway/auth/controller/EmailVerificationViewController.java
@@ -14,19 +14,22 @@ public class EmailVerificationViewController {
     private final EmailVerificationService emailVerificationService;
 
     @GetMapping("/auth/email/verify")
-    public String verifySignupToken(@RequestParam String token, Model model) {
+    public String verifySignupToken(@RequestParam String token, @RequestParam String attempt, Model model) {
         try {
-            emailVerificationService.verifySignupToken(token);
-            model.addAttribute("title", "이메일 인증 완료");
-            model.addAttribute("statusMessage", "인증이 완료되었습니다.");
-            model.addAttribute("hintMessage", "회원가입 페이지로 돌아가 인증 확인을 눌러 주세요.");
-            model.addAttribute("success", true);
+            emailVerificationService.verifySignupToken(token, attempt);
+            setResult(model, true, "이메일 인증 완료", "인증이 완료되었습니다.",
+                    "회원가입 페이지로 돌아가 인증 확인을 눌러 주세요.");
         } catch (IllegalArgumentException e) {
-            model.addAttribute("title", "이메일 인증 실패");
-            model.addAttribute("statusMessage", "유효하지 않은 인증 링크입니다.");
-            model.addAttribute("hintMessage", "인증메일을 다시 요청해 주세요.");
-            model.addAttribute("success", false);
+            setResult(model, false, "이메일 인증 실패", "유효하지 않은 인증 링크입니다.",
+                    "인증메일을 다시 요청해 주세요.");
         }
         return "email-verify";
+    }
+
+    private void setResult(Model model, boolean success, String title, String statusMessage, String hintMessage) {
+        model.addAttribute("success", success);
+        model.addAttribute("title", title);
+        model.addAttribute("statusMessage", statusMessage);
+        model.addAttribute("hintMessage", hintMessage);
     }
 }

--- a/src/main/java/com/flyway/auth/domain/EmailVerificationToken.java
+++ b/src/main/java/com/flyway/auth/domain/EmailVerificationToken.java
@@ -20,6 +20,8 @@ public class EmailVerificationToken {
     private LocalDateTime usedAt;
     private LocalDateTime createdAt;
 
+    private String attemptId;
+
     @Builder
     private EmailVerificationToken(
             String emailVerificationTokenId,
@@ -28,7 +30,8 @@ public class EmailVerificationToken {
             String tokenHash,
             LocalDateTime expiresAt,
             LocalDateTime usedAt,
-            LocalDateTime createdAt
+            LocalDateTime createdAt,
+            String attemptId
     ) {
         this.emailVerificationTokenId = emailVerificationTokenId;
         this.email = email;
@@ -37,5 +40,6 @@ public class EmailVerificationToken {
         this.expiresAt = expiresAt;
         this.usedAt = usedAt;
         this.createdAt = createdAt;
+        this.attemptId = attemptId;
     }
 }

--- a/src/main/java/com/flyway/auth/domain/SignUpAttempt.java
+++ b/src/main/java/com/flyway/auth/domain/SignUpAttempt.java
@@ -1,0 +1,44 @@
+package com.flyway.auth.domain;
+
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Getter
+@ToString
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class SignUpAttempt {
+    private String attemptId;
+    private String email;
+    private SignUpStatus status;
+    private LocalDateTime createdAt;
+    private LocalDateTime expiresAt;
+    private LocalDateTime verifiedAt;
+    private LocalDateTime consumedAt;
+
+
+    @Builder
+    private SignUpAttempt(
+            String attemptId,
+            String email,
+            SignUpStatus status,
+            LocalDateTime createdAt,
+            LocalDateTime expiresAt
+    ) {
+        this.attemptId = attemptId;
+        this.email = email;
+        this.status = status;
+        this.createdAt = createdAt;
+        this.expiresAt = expiresAt;
+    }
+
+    public void verify() {
+        this.status = SignUpStatus.VERIFIED;
+        this.verifiedAt = LocalDateTime.now();
+    }
+
+    public void consume() {
+        this.status = SignUpStatus.CONSUMED;
+        this.consumedAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/com/flyway/auth/domain/SignUpStatus.java
+++ b/src/main/java/com/flyway/auth/domain/SignUpStatus.java
@@ -1,0 +1,19 @@
+package com.flyway.auth.domain;
+
+import lombok.Getter;
+
+@Getter
+public enum SignUpStatus {
+    PENDING("진행 중", "회원가입 진행 중"),
+    VERIFIED("인증 완료", "이메일 인증 완료"),
+    CONSUMED("가입 완료", "회원가입 완료"),
+    EXPIRED("만료", "가입 유효 시간 만료");
+
+    private final String displayName;
+    private final String description;
+
+    SignUpStatus(String displayName, String description) {
+        this.displayName = displayName;
+        this.description = description;
+    }
+}

--- a/src/main/java/com/flyway/auth/dto/EmailSignUpRequest.java
+++ b/src/main/java/com/flyway/auth/dto/EmailSignUpRequest.java
@@ -1,6 +1,10 @@
 package com.flyway.auth.dto;
 
-import lombok.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @Getter
 @Setter
@@ -11,4 +15,5 @@ public class EmailSignUpRequest {
     private String name;
     private String email;
     private String rawPassword;
+    private String attemptId;
 }

--- a/src/main/java/com/flyway/auth/dto/SignupVerificationIssueResponse.java
+++ b/src/main/java/com/flyway/auth/dto/SignupVerificationIssueResponse.java
@@ -1,0 +1,10 @@
+package com.flyway.auth.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class SignupVerificationIssueResponse {
+    private String attemptId;
+}

--- a/src/main/java/com/flyway/auth/mapper/EmailVerificationMapper.java
+++ b/src/main/java/com/flyway/auth/mapper/EmailVerificationMapper.java
@@ -18,8 +18,9 @@ public interface EmailVerificationMapper {
             @Param("usedAt") LocalDateTime usedAt
     );
 
-    int countVerifiedByEmailPurpose(
+    int existsUsedTokenByEmailAttempt(
             @Param("email") String email,
+            @Param("attemptId") String attemptId,
             @Param("purpose") String purpose,
             @Param("now") LocalDateTime now
     );

--- a/src/main/java/com/flyway/auth/mapper/SignUpAttemptMapper.java
+++ b/src/main/java/com/flyway/auth/mapper/SignUpAttemptMapper.java
@@ -1,0 +1,36 @@
+package com.flyway.auth.mapper;
+
+import com.flyway.auth.domain.SignUpAttempt;
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+
+import java.time.LocalDateTime;
+
+@Mapper
+public interface SignUpAttemptMapper {
+
+    int insert(SignUpAttempt attempt);
+
+    int expirePendingAttemptsByEmail(
+            @Param("email") String email,
+            @Param("now") LocalDateTime now
+    );
+
+    int markVerifiedIfPending(
+            @Param("attemptId") String attemptId,
+            @Param("verifiedAt") LocalDateTime verifiedAt
+    );
+
+    int consumeIfVerified(
+            @Param("attemptId") String attemptId,
+            @Param("email") String email,
+            @Param("consumedAt") LocalDateTime consumedAt
+    );
+
+    String findStatusById(@Param("attemptId") String attemptId);
+
+    int expireIfPendingAndExpired(
+            @Param("attemptId") String attemptId,
+            @Param("now") LocalDateTime now
+    );
+}

--- a/src/main/java/com/flyway/auth/mapper/SignUpAttemptMapper.java
+++ b/src/main/java/com/flyway/auth/mapper/SignUpAttemptMapper.java
@@ -11,11 +11,6 @@ public interface SignUpAttemptMapper {
 
     int insert(SignUpAttempt attempt);
 
-    int expirePendingAttemptsByEmail(
-            @Param("email") String email,
-            @Param("now") LocalDateTime now
-    );
-
     int markVerifiedIfPending(
             @Param("attemptId") String attemptId,
             @Param("verifiedAt") LocalDateTime verifiedAt

--- a/src/main/java/com/flyway/auth/repository/EmailVerificationRepository.java
+++ b/src/main/java/com/flyway/auth/repository/EmailVerificationRepository.java
@@ -12,5 +12,5 @@ public interface EmailVerificationRepository {
 
     int markTokenUsed(String emailVerificationTokenId, LocalDateTime usedAt);
 
-    int countVerifiedByEmailPurpose(String email, String purpose, LocalDateTime now);
+    int existsUsedTokenByEmailAttempt(String email, String attemptId, String purpose, LocalDateTime now);
 }

--- a/src/main/java/com/flyway/auth/repository/EmailVerificationRepositoryImpl.java
+++ b/src/main/java/com/flyway/auth/repository/EmailVerificationRepositoryImpl.java
@@ -29,7 +29,7 @@ public class EmailVerificationRepositoryImpl implements EmailVerificationReposit
     }
 
     @Override
-    public int countVerifiedByEmailPurpose(String email, String purpose, LocalDateTime now) {
-        return emailVerificationMapper.countVerifiedByEmailPurpose(email, purpose, now);
+    public int existsUsedTokenByEmailAttempt(String email, String attemptId, String purpose, LocalDateTime now) {
+        return emailVerificationMapper.existsUsedTokenByEmailAttempt(email, attemptId, purpose, now);
     }
 }

--- a/src/main/java/com/flyway/auth/repository/SignUpAttemptRepository.java
+++ b/src/main/java/com/flyway/auth/repository/SignUpAttemptRepository.java
@@ -1,0 +1,21 @@
+package com.flyway.auth.repository;
+
+import com.flyway.auth.domain.SignUpAttempt;
+import com.flyway.auth.domain.SignUpStatus;
+
+import java.time.LocalDateTime;
+
+public interface SignUpAttemptRepository {
+
+    void insert(SignUpAttempt attempt);
+
+    int expirePendingAttemptsByEmail(String email, LocalDateTime now);
+
+    int markVerifiedIfPending(String attemptId, LocalDateTime verifiedAt);
+
+    int consumeIfVerified(String attemptId, String email, LocalDateTime consumedAt);
+
+    SignUpStatus findStatusById(String attemptId);
+
+    int expireIfPendingAndExpired(String attemptId, LocalDateTime now);
+}

--- a/src/main/java/com/flyway/auth/repository/SignUpAttemptRepository.java
+++ b/src/main/java/com/flyway/auth/repository/SignUpAttemptRepository.java
@@ -9,8 +9,6 @@ public interface SignUpAttemptRepository {
 
     void insert(SignUpAttempt attempt);
 
-    int expirePendingAttemptsByEmail(String email, LocalDateTime now);
-
     int markVerifiedIfPending(String attemptId, LocalDateTime verifiedAt);
 
     int consumeIfVerified(String attemptId, String email, LocalDateTime consumedAt);

--- a/src/main/java/com/flyway/auth/repository/SignUpAttemptRepositoryImpl.java
+++ b/src/main/java/com/flyway/auth/repository/SignUpAttemptRepositoryImpl.java
@@ -1,0 +1,47 @@
+package com.flyway.auth.repository;
+
+import com.flyway.auth.domain.SignUpAttempt;
+import com.flyway.auth.domain.SignUpStatus;
+import com.flyway.auth.mapper.SignUpAttemptMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDateTime;
+
+@Repository
+@RequiredArgsConstructor
+public class SignUpAttemptRepositoryImpl implements SignUpAttemptRepository {
+
+    private final SignUpAttemptMapper signUpAttemptMapper;
+
+    @Override
+    public void insert(SignUpAttempt attempt) {
+        signUpAttemptMapper.insert(attempt);
+    }
+
+    @Override
+    public int expirePendingAttemptsByEmail(String email, LocalDateTime now) {
+        return signUpAttemptMapper.expirePendingAttemptsByEmail(email, now);
+    }
+
+    @Override
+    public int markVerifiedIfPending(String attemptId, LocalDateTime verifiedAt) {
+        return signUpAttemptMapper.markVerifiedIfPending(attemptId, verifiedAt);
+    }
+
+    @Override
+    public int consumeIfVerified(String attemptId, String email, LocalDateTime consumedAt) {
+        return signUpAttemptMapper.consumeIfVerified(attemptId, email, consumedAt);
+    }
+
+    @Override
+    public SignUpStatus findStatusById(String attemptId) {
+        String status = signUpAttemptMapper.findStatusById(attemptId);
+        return status == null ? null : SignUpStatus.valueOf(status);
+    }
+
+    @Override
+    public int expireIfPendingAndExpired(String attemptId, LocalDateTime now) {
+        return signUpAttemptMapper.expireIfPendingAndExpired(attemptId, now);
+    }
+}

--- a/src/main/java/com/flyway/auth/repository/SignUpAttemptRepositoryImpl.java
+++ b/src/main/java/com/flyway/auth/repository/SignUpAttemptRepositoryImpl.java
@@ -20,11 +20,6 @@ public class SignUpAttemptRepositoryImpl implements SignUpAttemptRepository {
     }
 
     @Override
-    public int expirePendingAttemptsByEmail(String email, LocalDateTime now) {
-        return signUpAttemptMapper.expirePendingAttemptsByEmail(email, now);
-    }
-
-    @Override
     public int markVerifiedIfPending(String attemptId, LocalDateTime verifiedAt) {
         return signUpAttemptMapper.markVerifiedIfPending(attemptId, verifiedAt);
     }

--- a/src/main/java/com/flyway/auth/service/EmailVerificationService.java
+++ b/src/main/java/com/flyway/auth/service/EmailVerificationService.java
@@ -2,18 +2,9 @@ package com.flyway.auth.service;
 
 public interface EmailVerificationService {
 
-    /**
-     * 회원가입 목적 이메일 인증 토큰 발급 및 메일 전송
-     */
-    void issueSignupVerification(String email);
+    String issueSignupVerification(String email);
 
-    /**
-     * 회원가입 이메일 인증 링크 검증
-     */
-    String verifySignupToken(String token);
+    String verifySignupToken(String token, String attemptId);
 
-    /**
-     * 회원가입 이메일 인증 완료 여부 확인
-     */
-    boolean isSignupVerified(String email);
+    boolean isSignupVerified(String email, String attemptId);
 }

--- a/src/main/java/com/flyway/auth/service/EmailVerificationServiceImpl.java
+++ b/src/main/java/com/flyway/auth/service/EmailVerificationServiceImpl.java
@@ -2,7 +2,10 @@ package com.flyway.auth.service;
 
 import com.flyway.auth.domain.EmailVerificationPurpose;
 import com.flyway.auth.domain.EmailVerificationToken;
+import com.flyway.auth.domain.SignUpAttempt;
+import com.flyway.auth.domain.SignUpStatus;
 import com.flyway.auth.repository.EmailVerificationRepository;
+import com.flyway.auth.repository.SignUpAttemptRepository;
 import com.flyway.auth.util.TokenHasher;
 import com.flyway.template.common.mail.MailSender;
 import com.flyway.template.exception.BusinessException;
@@ -15,6 +18,9 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.dao.DuplicateKeyException;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 import org.springframework.util.StringUtils;
 
 import java.net.URLEncoder;
@@ -30,10 +36,14 @@ public class EmailVerificationServiceImpl implements EmailVerificationService {
 
     private static final String SUBJECT = "[Flyway] 이메일 인증 안내";
     private static final int MAX_RETRY = 3;
+    private static final String INVALID_LINK_MESSAGE = "유효하지 않은 인증 링크입니다.";
+    private static final String USED_LINK_MESSAGE = "이미 사용된 인증 링크입니다.";
+    private static final String EXPIRED_LINK_MESSAGE = "만료된 인증 링크입니다.";
     private static final Pattern EMAIL_PATTERN =
             Pattern.compile("^[^@\\s]+@[^@\\s]+\\.[^@\\s]+$");
 
     private final EmailVerificationRepository emailVerificationRepository;
+    private final SignUpAttemptRepository signUpAttemptRepository;
     private final MailSender mailSender;
     private final TokenHasher tokenHasher;
     private final UserMapper userMapper;
@@ -41,82 +51,72 @@ public class EmailVerificationServiceImpl implements EmailVerificationService {
     @Value("${app.base-url}")
     private String baseUrl;
 
-    @Value("${mail.verify.ttl-minutes:15}")
+    @Value("${mail.verify.ttl-minutes}")
     private long ttlMinutes;
 
+    @Value("${signup.attempt.ttl-minutes}")
+    private long attemptTtlMinutes;
+
+    @Transactional
     @Override
-    public void issueSignupVerification(String email) {
+    public String issueSignupVerification(String email) {
         validateEmail(email);
         ensureEmailNotRegistered(email);
 
-        for (int attempt = 1; attempt <= MAX_RETRY; attempt++) {
-            String token = UUID.randomUUID().toString();
-            String tokenHash = tokenHasher.hash(token);
-            LocalDateTime now = LocalDateTime.now();
+        LocalDateTime now = LocalDateTime.now();
 
-            EmailVerificationToken record = EmailVerificationToken.builder()
-                    .emailVerificationTokenId(UUID.randomUUID().toString())
-                    .email(email)
-                    .purpose(EmailVerificationPurpose.SIGNUP)
-                    .tokenHash(tokenHash)
-                    .expiresAt(now.plusMinutes(ttlMinutes))
-                    .createdAt(now)
-                    .build();
+        SignUpAttempt attempt = buildSignUpAttempt(email, now);
+        signUpAttemptRepository.insert(attempt);
 
-            try {
-                emailVerificationRepository.insertEmailVerificationToken(record);
-            } catch (DuplicateKeyException e) {
-                log.warn("[AUTH] duplicate token hash. retry={}", attempt);
-                if (attempt == MAX_RETRY) {
-                    throw e;
-                }
-                continue;
-            } catch (Exception e) {
-                log.error(
-                        "[AUTH] failed to save email verification token. email={}",
-                        MaskUtil.maskEmail(email),
-                        e
-                );
-                throw e;
-            }
-
-            sendVerificationEmail(email, token);
-            return;
-        }
+        String attemptId = attempt.getAttemptId();
+        String token = insertTokenWithRetry(email, attemptId, now);
+        sendVerificationEmailAfterCommit(email, token, attemptId);
+        return attemptId;
     }
 
+    @Transactional
     @Override
-    public String verifySignupToken(String token) {
-        if (!StringUtils.hasText(token)) {
-            throw new IllegalArgumentException("유효하지 않은 인증 링크입니다.");
+    public String verifySignupToken(String token, String attemptId) {
+        if (!StringUtils.hasText(token) || !StringUtils.hasText(attemptId)) {
+            throw new IllegalArgumentException(INVALID_LINK_MESSAGE);
         }
 
         String tokenHash = tokenHasher.hash(token);
         EmailVerificationToken stored = emailVerificationRepository.findByTokenHash(tokenHash);
         if (stored == null) {
-            throw new IllegalArgumentException("유효하지 않은 인증 링크입니다.");
+            throw new IllegalArgumentException(INVALID_LINK_MESSAGE);
         }
         if (stored.getUsedAt() != null) {
-            throw new IllegalArgumentException("이미 사용된 인증 링크입니다.");
+            throw new IllegalArgumentException(USED_LINK_MESSAGE);
+        }
+        if (!attemptId.equals(stored.getAttemptId())) {
+            throw new IllegalArgumentException(INVALID_LINK_MESSAGE);
         }
 
         LocalDateTime now = LocalDateTime.now();
         if (stored.getExpiresAt() != null && stored.getExpiresAt().isBefore(now)) {
-            throw new IllegalArgumentException("만료된 인증 링크입니다.");
+            throw new IllegalArgumentException(EXPIRED_LINK_MESSAGE);
         }
 
-        int updated = emailVerificationRepository.markTokenUsed(stored.getEmailVerificationTokenId(), now);
-        if (updated == 0) {
-            throw new IllegalArgumentException("이미 사용된 인증 링크입니다.");
+        int tokenUpdated = emailVerificationRepository.markTokenUsed(stored.getEmailVerificationTokenId(), now);
+        if (tokenUpdated == 0) {
+            throw new IllegalArgumentException(USED_LINK_MESSAGE);
         }
+
+        int attemptUpdated = signUpAttemptRepository.markVerifiedIfPending(attemptId, now);
+        if (attemptUpdated == 0) {
+            throw new IllegalArgumentException("이미 처리된 인증 요청입니다.");
+        }
+
         return stored.getEmail();
     }
 
     @Override
-    public boolean isSignupVerified(String email) {
+    public boolean isSignupVerified(String email, String attemptId) {
         validateEmail(email);
-        int count = emailVerificationRepository.countVerifiedByEmailPurpose(
+        int count = emailVerificationRepository.existsUsedTokenByEmailAttempt(
                 email,
+                attemptId,
                 EmailVerificationPurpose.SIGNUP.name(),
                 LocalDateTime.now()
         );
@@ -135,8 +135,22 @@ public class EmailVerificationServiceImpl implements EmailVerificationService {
         }
     }
 
-    private void sendVerificationEmail(String email, String token) {
-        String verifyUrl = buildVerifyUrl(token);
+    private void sendVerificationEmailAfterCommit(String email, String token, String attemptId) {
+        if (!TransactionSynchronizationManager.isSynchronizationActive()) {
+            sendVerificationEmail(email, token, attemptId);
+            return;
+        }
+
+        TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+            @Override
+            public void afterCommit() {
+                sendVerificationEmail(email, token, attemptId);
+            }
+        });
+    }
+
+    private void sendVerificationEmail(String email, String token, String attemptId) {
+        String verifyUrl = buildVerifyUrl(token, attemptId);
         String body = ""
                 + "Flyway 이메일 인증 안내입니다.\n\n"
                 + "아래 링크를 클릭하여 인증을 완료해 주세요.\n"
@@ -146,18 +160,58 @@ public class EmailVerificationServiceImpl implements EmailVerificationService {
         try {
             mailSender.sendText(email, SUBJECT, body);
         } catch (Exception e) {
-            log.error(
-                    "[AUTH] failed to send verification email. email={}",
-                    MaskUtil.maskEmail(email),
-                    e
-            );
+            log.error("[AUTH] failed to send verification email. email={}", MaskUtil.maskEmail(email), e);
             throw new MailSendException("메일 전송 실패", e);
         }
     }
 
-    private String buildVerifyUrl(String token) {
+    private String buildVerifyUrl(String token, String attemptId) {
         String normalizedBaseUrl = baseUrl.endsWith("/") ? baseUrl.substring(0, baseUrl.length() - 1) : baseUrl;
         String encodedToken = URLEncoder.encode(token, StandardCharsets.UTF_8);
-        return normalizedBaseUrl + "/auth/email/verify?token=" + encodedToken;
+        String encodedAttempt = URLEncoder.encode(attemptId, StandardCharsets.UTF_8);
+
+        return normalizedBaseUrl + "/auth/email/verify?token=" + encodedToken + "&attempt=" + encodedAttempt;
+    }
+
+    private SignUpAttempt buildSignUpAttempt(String email, LocalDateTime now) {
+        return SignUpAttempt.builder()
+                .attemptId(UUID.randomUUID().toString())
+                .email(email)
+                .status(SignUpStatus.PENDING)
+                .createdAt(now)
+                .expiresAt(now.plusMinutes(attemptTtlMinutes))
+                .build();
+    }
+
+    private String insertTokenWithRetry(String email, String attemptId, LocalDateTime now) {
+        for (int retry = 1; retry <= MAX_RETRY; retry++) {
+            String token = UUID.randomUUID().toString();
+            String tokenHash = tokenHasher.hash(token);
+            EmailVerificationToken record = EmailVerificationToken.builder()
+                    .emailVerificationTokenId(UUID.randomUUID().toString())
+                    .email(email)
+                    .purpose(EmailVerificationPurpose.SIGNUP)
+                    .tokenHash(tokenHash)
+                    .expiresAt(now.plusMinutes(ttlMinutes))
+                    .createdAt(now)
+                    .attemptId(attemptId)
+                    .build();
+
+            try {
+                emailVerificationRepository.insertEmailVerificationToken(record);
+                return token;
+            } catch (DuplicateKeyException e) {
+                log.warn("[AUTH] duplicate token hash. retry={}", retry);
+                if (retry == MAX_RETRY) {
+                    throw e;
+                }
+            } catch (Exception e) {
+                log.error("[AUTH] failed to save email verification token. email={}",
+                        MaskUtil.maskEmail(email), e);
+                throw e;
+            }
+        }
+
+        throw new IllegalStateException("토큰 발급에 실패했습니다.");
     }
 }

--- a/src/main/java/com/flyway/auth/service/EmailVerificationServiceImpl.java
+++ b/src/main/java/com/flyway/auth/service/EmailVerificationServiceImpl.java
@@ -114,12 +114,18 @@ public class EmailVerificationServiceImpl implements EmailVerificationService {
     @Override
     public boolean isSignupVerified(String email, String attemptId) {
         validateEmail(email);
+
+        if (!StringUtils.hasText(attemptId)) {
+            throw new IllegalArgumentException(INVALID_LINK_MESSAGE);
+        }
+
         int count = emailVerificationRepository.existsUsedTokenByEmailAttempt(
                 email,
                 attemptId,
                 EmailVerificationPurpose.SIGNUP.name(),
                 LocalDateTime.now()
         );
+
         return count > 0;
     }
 

--- a/src/main/java/com/flyway/auth/service/EmailVerificationServiceImpl.java
+++ b/src/main/java/com/flyway/auth/service/EmailVerificationServiceImpl.java
@@ -98,14 +98,14 @@ public class EmailVerificationServiceImpl implements EmailVerificationService {
             throw new IllegalArgumentException(EXPIRED_LINK_MESSAGE);
         }
 
-        int tokenUpdated = emailVerificationRepository.markTokenUsed(stored.getEmailVerificationTokenId(), now);
-        if (tokenUpdated == 0) {
-            throw new IllegalArgumentException(USED_LINK_MESSAGE);
-        }
-
         int attemptUpdated = signUpAttemptRepository.markVerifiedIfPending(attemptId, now);
         if (attemptUpdated == 0) {
             throw new IllegalArgumentException("이미 처리된 인증 요청입니다.");
+        }
+
+        int tokenUpdated = emailVerificationRepository.markTokenUsed(stored.getEmailVerificationTokenId(), now);
+        if (tokenUpdated == 0) {
+            throw new IllegalArgumentException(USED_LINK_MESSAGE);
         }
 
         return stored.getEmail();

--- a/src/main/java/com/flyway/template/exception/ErrorCode.java
+++ b/src/main/java/com/flyway/template/exception/ErrorCode.java
@@ -28,6 +28,7 @@ public enum ErrorCode {
 	USER_BLOCKED(403, "U005", "차단된 계정입니다."),
 	USER_PASSWORD_ENCODE_ERROR(500, "U006", "비밀번호 처리 중 오류가 발생했습니다."),
 	USER_DB_ERROR(500, "U007", "회원 정보 저장 중 오류가 발생했습니다."),
+	USER_INVALID_SIGN_UP_ATTEMPT(400, "U008", "유효하지 않은 회원가입 요청입니다."),
 	USER_INTERNAL_ERROR(500, "U999", "회원 처리 중 알 수 없는 오류가 발생했습니다."),
 
 	// ==================== 관리자 (A) ====================

--- a/src/main/resources/mapper/EmailVerificationTokenMapper.xml
+++ b/src/main/resources/mapper/EmailVerificationTokenMapper.xml
@@ -13,7 +13,8 @@
             purpose,
             token_hash,
             expires_at,
-            created_at
+            created_at,
+            attempt_id
         )
         VALUES (
             #{emailVerificationTokenId},
@@ -21,7 +22,8 @@
             #{purpose},
             #{tokenHash},
             #{expiresAt},
-            #{createdAt}
+            #{createdAt},
+            #{attemptId}
         )
     </insert>
 
@@ -34,7 +36,8 @@
                token_hash,
                expires_at,
                used_at,
-               created_at
+               created_at,
+               attempt_id
         FROM email_verification_token
         WHERE token_hash = #{tokenHash}
     </select>
@@ -46,12 +49,13 @@
           AND used_at IS NULL
     </update>
 
-    <select id="countVerifiedByEmailPurpose"
+    <select id="existsUsedTokenByEmailAttempt"
             parameterType="map"
             resultType="int">
         SELECT COUNT(1)
         FROM email_verification_token
         WHERE email = #{email}
+          AND attempt_id = #{attemptId}
           AND purpose = #{purpose}
           AND used_at IS NOT NULL
           AND expires_at > #{now}

--- a/src/main/resources/mapper/auth/SignUpAttemptMapper.xml
+++ b/src/main/resources/mapper/auth/SignUpAttemptMapper.xml
@@ -22,14 +22,6 @@
                 #{consumedAt})
     </insert>
 
-    <update id="expirePendingAttemptsByEmail">
-        UPDATE signup_attempt
-        SET status = 'EXPIRED'
-        WHERE email = #{email}
-          AND status = 'PENDING'
-          AND expires_at &gt; #{now}
-    </update>
-
     <update id="markVerifiedIfPending">
         UPDATE signup_attempt
         SET status      = 'VERIFIED',

--- a/src/main/resources/mapper/auth/SignUpAttemptMapper.xml
+++ b/src/main/resources/mapper/auth/SignUpAttemptMapper.xml
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper
+        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="com.flyway.auth.mapper.SignUpAttemptMapper">
+
+    <insert id="insert" parameterType="com.flyway.auth.domain.SignUpAttempt">
+        INSERT INTO signup_attempt (attempt_id,
+                                    email,
+                                    status,
+                                    created_at,
+                                    expires_at,
+                                    verified_at,
+                                    consumed_at)
+        VALUES (#{attemptId},
+                #{email},
+                #{status},
+                #{createdAt},
+                #{expiresAt},
+                #{verifiedAt},
+                #{consumedAt})
+    </insert>
+
+    <update id="expirePendingAttemptsByEmail">
+        UPDATE signup_attempt
+        SET status = 'EXPIRED'
+        WHERE email = #{email}
+          AND status = 'PENDING'
+          AND expires_at &gt; #{now}
+    </update>
+
+    <update id="markVerifiedIfPending">
+        UPDATE signup_attempt
+        SET status      = 'VERIFIED',
+            verified_at = #{verifiedAt}
+        WHERE attempt_id = #{attemptId}
+          AND status = 'PENDING'
+          AND expires_at &gt; #{verifiedAt}
+    </update>
+
+    <update id="consumeIfVerified">
+        UPDATE signup_attempt
+        SET status      = 'CONSUMED',
+            consumed_at = #{consumedAt}
+        WHERE attempt_id = #{attemptId}
+          AND email = #{email}
+          AND status = 'VERIFIED'
+          AND expires_at &gt; #{consumedAt}
+    </update>
+
+    <select id="findStatusById" resultType="string">
+        SELECT status
+        FROM signup_attempt
+        WHERE attempt_id = #{attemptId}
+    </select>
+
+    <update id="expireIfPendingAndExpired">
+        UPDATE signup_attempt
+        SET status = 'EXPIRED'
+        WHERE attempt_id = #{attemptId}
+          AND status = 'PENDING'
+          AND expires_at &lt;= #{now}
+    </update>
+
+</mapper>

--- a/src/main/webapp/WEB-INF/views/signup.jsp
+++ b/src/main/webapp/WEB-INF/views/signup.jsp
@@ -22,6 +22,7 @@
     </c:if>
 
     <form id="signupForm" action="${pageContext.request.contextPath}/auth/signup" method="post">
+
         <div class="form-group">
             <label for="name">이름</label>
             <input type="text" id="name" name="name" placeholder="이름을 입력하세요" required>
@@ -32,28 +33,37 @@
             <label for="email">이메일</label>
 
             <div class="email-row">
-                <input type="email" id="email" name="email" placeholder="example@mail.com" required>
-                <button type="button" id="sendVerifyBtn">인증메일</button>
+                <input type="email" id="email" name="email" placeholder="example@mail.com" value="${signupEmail}"
+                ${oauthSignUp and signupEmail ? 'readonly="readonly"' : ''}
+                       required>
+
+                <c:if test="${not oauthSignUp}">
+                    <button type="button" id="sendVerifyBtn">인증메일</button>
+                </c:if>
             </div>
 
-            <div id="sendStatus" class="status-text"></div>
+            <c:if test="${not oauthSignUp}">
+                <div id="sendStatus" class="status-text"></div>
+            </c:if>
         </div>
 
-        <!-- 인증 확인 -->
-        <div class="form-group verify-box is-hidden" id="verifyBox">
-            <label>이메일 인증</label>
+        <c:if test="${not oauthSignUp}">
+            <!-- 인증 확인 -->
+            <div class="form-group verify-box is-hidden" id="verifyBox">
+                <label>이메일 인증</label>
 
-            <div class="verify-row">
-                <button type="button" id="verifyBtn" class="btn-submit btn-inline">
-                    인증 확인
-                </button>
+                <div class="verify-row">
+                    <button type="button" id="verifyBtn" class="btn-submit btn-inline">
+                        인증 확인
+                    </button>
+                </div>
+
+                <div id="verifyStatus" class="verify-status"></div>
+
+                <input type="hidden" id="emailVerified" name="emailVerified" value="false">
+                <input type="hidden" id="attemptId" name="attemptId" value="">
             </div>
-
-            <div id="verifyStatus" class="verify-status"></div>
-
-            <input type="hidden" id="emailVerified" name="emailVerified" value="false">
-            <input type="hidden" id="attemptId" name="attemptId" value="">
-        </div>
+        </c:if>
 
         <c:if test="${oauthSignUp}">
             <input type="hidden" name="oauthSignUp" value="true">

--- a/src/main/webapp/WEB-INF/views/signup.jsp
+++ b/src/main/webapp/WEB-INF/views/signup.jsp
@@ -1,4 +1,4 @@
-<%@ page language="java" contentType="text/html; charset=UTF-8" pageEncoding="UTF-8"%>
+<%@ page language="java" contentType="text/html; charset=UTF-8" pageEncoding="UTF-8" %>
 <%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
 
 <!DOCTYPE html>
@@ -17,7 +17,7 @@
     <!-- 에러 메시지 출력 -->
     <c:if test="${not empty error}">
         <div class="error">
-            <c:out value="${error}" />
+            <c:out value="${error}"/>
         </div>
     </c:if>
 
@@ -52,6 +52,7 @@
             <div id="verifyStatus" class="verify-status"></div>
 
             <input type="hidden" id="emailVerified" name="emailVerified" value="false">
+            <input type="hidden" id="attemptId" name="attemptId" value="">
         </div>
 
         <c:if test="${oauthSignUp}">

--- a/src/main/webapp/resources/auth/signup.js
+++ b/src/main/webapp/resources/auth/signup.js
@@ -9,6 +9,7 @@
     const verifyStatus = document.getElementById("verifyStatus");
 
     const emailVerifiedHidden = document.getElementById("emailVerified");
+    const attemptIdHidden = document.getElementById("attemptId");
     const signupForm = document.getElementById("signupForm");
 
     function setText(el, msg, ok) {
@@ -22,6 +23,7 @@
 
     emailInput.addEventListener("input", function () {
         emailVerifiedHidden.value = "false";
+        attemptIdHidden.value = "";
         verifyBox.classList.add("is-hidden");
         setText(sendStatus, "", true);
         setText(verifyStatus, "", true);
@@ -49,6 +51,7 @@
             let data = null;
             try {
                 data = await res.json();
+                attemptIdHidden.value = data.data.attemptId;
             } catch (e) {
                 data = null;
             }
@@ -81,12 +84,14 @@
         setText(verifyStatus, "인증 확인 중입니다...", true);
 
         try {
-            const res = await fetch(
-                base + "/api/auth/email/status?email=" + encodeURIComponent(email)
-            );
+            const query = new URLSearchParams({
+                email: email,
+                attemptId: attemptIdHidden.value
+            });
+            const res = await fetch(base + "/api/auth/email/status?" + query.toString());
 
             if (!res.ok) {
-                setText(verifyStatus, "인증 확인에 실패했습니다. 잠시 후 다시 시도해 주세요.", false);
+                setText(verifyStatus, "인증 확인에 실패했습니다.", false);
                 emailVerifiedHidden.value = "false";
                 return;
             }

--- a/src/test/java/com/flyway/auth/controller/AuthControllerTest.java
+++ b/src/test/java/com/flyway/auth/controller/AuthControllerTest.java
@@ -1,0 +1,109 @@
+package com.flyway.auth.controller;
+
+import com.flyway.auth.dto.EmailSignUpRequest;
+import com.flyway.auth.service.KakaoLoginService;
+import com.flyway.auth.service.SignUpService;
+import com.flyway.security.handler.LoginSuccessHandler;
+import com.flyway.security.service.EmailUserDetailsService;
+import com.flyway.security.service.UserIdUserDetailsService;
+import com.flyway.template.exception.BusinessException;
+import com.flyway.template.exception.ErrorCode;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.servlet.view.InternalResourceViewResolver;
+
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.model;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.redirectedUrl;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.view;
+
+class AuthControllerTest {
+
+    private MockMvc mockMvc;
+    private SignUpService signUpService;
+    private KakaoLoginService kakaoLoginService;
+    private EmailUserDetailsService emailUserDetailsService;
+    private UserIdUserDetailsService userIdUserDetailsService;
+    private LoginSuccessHandler loginSuccessHandler;
+
+    @BeforeEach
+    void setUp() {
+        signUpService = Mockito.mock(SignUpService.class);
+        kakaoLoginService = Mockito.mock(KakaoLoginService.class);
+        emailUserDetailsService = Mockito.mock(EmailUserDetailsService.class);
+        userIdUserDetailsService = Mockito.mock(UserIdUserDetailsService.class);
+        loginSuccessHandler = Mockito.mock(LoginSuccessHandler.class);
+
+        AuthController controller = new AuthController(
+                signUpService,
+                kakaoLoginService,
+                emailUserDetailsService,
+                userIdUserDetailsService,
+                loginSuccessHandler
+        );
+
+        InternalResourceViewResolver vr = new InternalResourceViewResolver();
+        vr.setPrefix("/WEB-INF/views/");
+        vr.setSuffix(".jsp");
+
+        mockMvc = MockMvcBuilders.standaloneSetup(controller)
+                .setViewResolvers(vr)
+                .build();
+    }
+
+    @Test
+    @DisplayName("회원가입 성공 시 홈으로 리다이렉트된다")
+    void signUp_success_redirectsHome() throws Exception {
+        UserDetails userDetails = new User(
+                "test@example.com",
+                "pw",
+                List.of(new SimpleGrantedAuthority("ROLE_USER"))
+        );
+        doNothing().when(signUpService).signUp(any(EmailSignUpRequest.class));
+        when(emailUserDetailsService.loadUserByUsername("test@example.com")).thenReturn(userDetails);
+
+        mockMvc.perform(post("/auth/signup")
+                        .param("name", "Tester")
+                        .param("email", "test@example.com")
+                        .param("rawPassword", "password")
+                        .param("attemptId", "attempt-1"))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(redirectedUrl("/"));
+
+        verify(signUpService).signUp(any(EmailSignUpRequest.class));
+        verify(loginSuccessHandler).issueAccessTokenCookie(any(), eq("test@example.com"));
+    }
+
+    @Test
+    @DisplayName("회원가입 실패 시 signup 뷰로 돌아간다")
+    void signUp_invalidAttempt_showsError() throws Exception {
+        doThrow(new BusinessException(ErrorCode.USER_INVALID_SIGN_UP_ATTEMPT))
+                .when(signUpService)
+                .signUp(any(EmailSignUpRequest.class));
+
+        mockMvc.perform(post("/auth/signup")
+                        .param("name", "Tester")
+                        .param("email", "test@example.com")
+                        .param("rawPassword", "password")
+                        .param("attemptId", "attempt-1"))
+                .andExpect(status().isOk())
+                .andExpect(view().name("signup"))
+                .andExpect(model().attribute("error", ErrorCode.USER_INVALID_SIGN_UP_ATTEMPT.getMessage()));
+    }
+}

--- a/src/test/java/com/flyway/auth/controller/EmailVerificationViewControllerTest.java
+++ b/src/test/java/com/flyway/auth/controller/EmailVerificationViewControllerTest.java
@@ -40,7 +40,7 @@ class EmailVerificationViewControllerTest {
     @Test
     @DisplayName("인증 링크 검증 성공 - 성공 메시지 출력")
     void verifySignupToken_success() throws Exception {
-        Mockito.when(emailVerificationService.verifySignupToken(anyString()))
+        Mockito.when(emailVerificationService.verifySignupToken(anyString(), anyString()))
                 .thenReturn("test@example.com");
 
         mockMvc.perform(get("/auth/email/verify")
@@ -58,7 +58,7 @@ class EmailVerificationViewControllerTest {
     void verifySignupToken_fail() throws Exception {
         doThrow(new IllegalArgumentException("유효하지 않은 인증 링크입니다."))
                 .when(emailVerificationService)
-                .verifySignupToken(anyString());
+                .verifySignupToken(anyString(), anyString());
 
         mockMvc.perform(get("/auth/email/verify")
                         .param("token", "invalid-token"))

--- a/src/test/java/com/flyway/auth/controller/EmailVerificationViewControllerTest.java
+++ b/src/test/java/com/flyway/auth/controller/EmailVerificationViewControllerTest.java
@@ -10,7 +10,6 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.servlet.view.InternalResourceViewResolver;
 
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.model;
@@ -44,7 +43,8 @@ class EmailVerificationViewControllerTest {
                 .thenReturn("test@example.com");
 
         mockMvc.perform(get("/auth/email/verify")
-                        .param("token", "valid-token"))
+                        .param("token", "valid-token")
+                        .param("attempt", "attempt-123"))
                 .andExpect(status().isOk())
                 .andExpect(view().name("email-verify"))
                 .andExpect(model().attribute("success", true))
@@ -61,7 +61,8 @@ class EmailVerificationViewControllerTest {
                 .verifySignupToken(anyString(), anyString());
 
         mockMvc.perform(get("/auth/email/verify")
-                        .param("token", "invalid-token"))
+                        .param("token", "invalid-token")
+                        .param("attempt", "attempt-456"))
                 .andExpect(status().isOk())
                 .andExpect(view().name("email-verify"))
                 .andExpect(model().attribute("success", false))

--- a/src/test/java/com/flyway/auth/integration/EmailVerificationMapperIT.java
+++ b/src/test/java/com/flyway/auth/integration/EmailVerificationMapperIT.java
@@ -1,0 +1,95 @@
+package com.flyway.auth.integration;
+
+import com.flyway.auth.domain.EmailVerificationPurpose;
+import com.flyway.auth.domain.EmailVerificationToken;
+import com.flyway.auth.mapper.EmailVerificationMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = MyBatisTestConfig.class)
+@Transactional
+class EmailVerificationMapperIT {
+
+    @Autowired
+    private EmailVerificationMapper mapper;
+
+    @Test
+    @DisplayName("토큰 저장 후 해시로 조회된다")
+    void insertAndFind() {
+        EmailVerificationToken token = EmailVerificationToken.builder()
+                .emailVerificationTokenId(UUID.randomUUID().toString())
+                .email("test@example.com")
+                .purpose(EmailVerificationPurpose.SIGNUP)
+                .tokenHash("hash-1")
+                .expiresAt(LocalDateTime.now().plusMinutes(10))
+                .createdAt(LocalDateTime.now())
+                .attemptId("attempt-1")
+                .build();
+
+        mapper.insertEmailVerificationToken(token);
+
+        EmailVerificationToken found = mapper.findByTokenHash("hash-1");
+        assertThat(found).isNotNull();
+        assertThat(found.getEmail()).isEqualTo("test@example.com");
+        assertThat(found.getAttemptId()).isEqualTo("attempt-1");
+    }
+
+    @Test
+    @DisplayName("토큰 used 업데이트는 한 번만 성공한다")
+    void markTokenUsed_once() {
+        String tokenId = UUID.randomUUID().toString();
+        EmailVerificationToken token = EmailVerificationToken.builder()
+                .emailVerificationTokenId(tokenId)
+                .email("test@example.com")
+                .purpose(EmailVerificationPurpose.SIGNUP)
+                .tokenHash("hash-2")
+                .expiresAt(LocalDateTime.now().plusMinutes(10))
+                .createdAt(LocalDateTime.now())
+                .attemptId("attempt-2")
+                .build();
+        mapper.insertEmailVerificationToken(token);
+
+        int updated = mapper.markTokenUsed(tokenId, LocalDateTime.now());
+        int updatedAgain = mapper.markTokenUsed(tokenId, LocalDateTime.now().plusMinutes(1));
+
+        assertThat(updated).isEqualTo(1);
+        assertThat(updatedAgain).isEqualTo(0);
+    }
+
+    @Test
+    @DisplayName("attempt + email + purpose 기준으로 verified 여부를 조회한다")
+    void existsUsedTokenByEmailAttempt() {
+        String tokenId = UUID.randomUUID().toString();
+        EmailVerificationToken token = EmailVerificationToken.builder()
+                .emailVerificationTokenId(tokenId)
+                .email("test@example.com")
+                .purpose(EmailVerificationPurpose.SIGNUP)
+                .tokenHash("hash-3")
+                .expiresAt(LocalDateTime.now().plusMinutes(10))
+                .createdAt(LocalDateTime.now())
+                .attemptId("attempt-3")
+                .build();
+        mapper.insertEmailVerificationToken(token);
+
+        mapper.markTokenUsed(tokenId, LocalDateTime.now());
+
+        int count = mapper.existsUsedTokenByEmailAttempt(
+                "test@example.com",
+                "attempt-3",
+                EmailVerificationPurpose.SIGNUP.name(),
+                LocalDateTime.now()
+        );
+        assertThat(count).isEqualTo(1);
+    }
+}

--- a/src/test/java/com/flyway/auth/integration/MyBatisTestConfig.java
+++ b/src/test/java/com/flyway/auth/integration/MyBatisTestConfig.java
@@ -1,0 +1,89 @@
+package com.flyway.auth.integration;
+
+import org.apache.ibatis.session.SqlSessionFactory;
+import org.mybatis.spring.SqlSessionFactoryBean;
+import org.mybatis.spring.annotation.MapperScan;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.io.support.PathMatchingResourcePatternResolver;
+import org.springframework.core.io.ByteArrayResource;
+import org.springframework.jdbc.datasource.DataSourceTransactionManager;
+import org.springframework.jdbc.datasource.DriverManagerDataSource;
+import org.springframework.jdbc.datasource.init.DataSourceInitializer;
+import org.springframework.jdbc.datasource.init.ResourceDatabasePopulator;
+import org.springframework.transaction.PlatformTransactionManager;
+
+import javax.sql.DataSource;
+
+@Configuration
+@MapperScan("com.flyway.auth.mapper")
+public class MyBatisTestConfig {
+
+    @Bean
+    public DataSource dataSource() {
+        DriverManagerDataSource ds = new DriverManagerDataSource();
+        ds.setDriverClassName("org.h2.Driver");
+        ds.setUrl("jdbc:h2:mem:flyway_test;MODE=MySQL;DB_CLOSE_DELAY=-1;DATABASE_TO_UPPER=false");
+        ds.setUsername("sa");
+        ds.setPassword("");
+        return ds;
+    }
+
+    @Bean
+    public SqlSessionFactory sqlSessionFactory(DataSource dataSource) throws Exception {
+        SqlSessionFactoryBean factory = new SqlSessionFactoryBean();
+        factory.setDataSource(dataSource);
+        factory.setMapperLocations(
+                new PathMatchingResourcePatternResolver().getResources("classpath*:mapper/**/*.xml")
+        );
+        org.apache.ibatis.session.Configuration mybatisConfiguration =
+                new org.apache.ibatis.session.Configuration();
+        mybatisConfiguration.setMapUnderscoreToCamelCase(true);
+        factory.setConfiguration(mybatisConfiguration);
+        return factory.getObject();
+    }
+
+    @Bean
+    public PlatformTransactionManager transactionManager(DataSource dataSource) {
+        return new DataSourceTransactionManager(dataSource);
+    }
+
+    @Bean
+    public DataSourceInitializer dataSourceInitializer(DataSource dataSource) {
+        ResourceDatabasePopulator populator = new ResourceDatabasePopulator();
+        populator.addScript(new ByteArrayResource(schemaSql().getBytes()));
+        DataSourceInitializer initializer = new DataSourceInitializer();
+        initializer.setDataSource(dataSource);
+        initializer.setDatabasePopulator(populator);
+        return initializer;
+    }
+
+    private String schemaSql() {
+        return ""
+                + "CREATE TABLE signup_attempt ("
+                + " attempt_id VARCHAR(36) PRIMARY KEY,"
+                + " email VARCHAR(255) NOT NULL,"
+                + " status VARCHAR(20) NOT NULL,"
+                + " created_at TIMESTAMP NOT NULL,"
+                + " expires_at TIMESTAMP NOT NULL,"
+                + " verified_at TIMESTAMP NULL,"
+                + " consumed_at TIMESTAMP NULL"
+                + ");"
+                + "CREATE TABLE email_verification_token ("
+                + " email_verification_token_id VARCHAR(36) PRIMARY KEY,"
+                + " email VARCHAR(255) NOT NULL,"
+                + " purpose VARCHAR(50) NOT NULL,"
+                + " token_hash VARCHAR(255) NOT NULL,"
+                + " expires_at TIMESTAMP NOT NULL,"
+                + " used_at TIMESTAMP NULL,"
+                + " created_at TIMESTAMP NOT NULL,"
+                + " attempt_id VARCHAR(36) NOT NULL"
+                + ");"
+                + "CREATE UNIQUE INDEX uq_email_verification_token_hash"
+                + " ON email_verification_token(token_hash);"
+                + "CREATE INDEX idx_email_verification_attempt"
+                + " ON email_verification_token(attempt_id);"
+                + "CREATE INDEX idx_signup_attempt_email"
+                + " ON signup_attempt(email);";
+    }
+}

--- a/src/test/java/com/flyway/auth/integration/SignUpAttemptMapperIT.java
+++ b/src/test/java/com/flyway/auth/integration/SignUpAttemptMapperIT.java
@@ -1,0 +1,64 @@
+package com.flyway.auth.integration;
+
+import com.flyway.auth.domain.SignUpAttempt;
+import com.flyway.auth.domain.SignUpStatus;
+import com.flyway.auth.mapper.SignUpAttemptMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = MyBatisTestConfig.class)
+@Transactional
+class SignUpAttemptMapperIT {
+
+    @Autowired
+    private SignUpAttemptMapper mapper;
+
+    @Test
+    @DisplayName("attempt 상태가 VERIFIED -> CONSUMED로 전이된다")
+    void verifyAndConsume() {
+        SignUpAttempt attempt = SignUpAttempt.builder()
+                .attemptId(UUID.randomUUID().toString())
+                .email("test@example.com")
+                .status(SignUpStatus.PENDING)
+                .createdAt(LocalDateTime.now())
+                .expiresAt(LocalDateTime.now().plusMinutes(10))
+                .build();
+        mapper.insert(attempt);
+
+        int verified = mapper.markVerifiedIfPending(attempt.getAttemptId(), LocalDateTime.now());
+        assertThat(verified).isEqualTo(1);
+        assertThat(mapper.findStatusById(attempt.getAttemptId())).isEqualTo("VERIFIED");
+
+        int consumed = mapper.consumeIfVerified(attempt.getAttemptId(), "test@example.com", LocalDateTime.now());
+        assertThat(consumed).isEqualTo(1);
+        assertThat(mapper.findStatusById(attempt.getAttemptId())).isEqualTo("CONSUMED");
+    }
+
+    @Test
+    @DisplayName("VERIFIED 상태가 아니면 consume이 실패한다")
+    void consumeFailsWhenNotVerified() {
+        SignUpAttempt attempt = SignUpAttempt.builder()
+                .attemptId(UUID.randomUUID().toString())
+                .email("test@example.com")
+                .status(SignUpStatus.PENDING)
+                .createdAt(LocalDateTime.now())
+                .expiresAt(LocalDateTime.now().plusMinutes(10))
+                .build();
+        mapper.insert(attempt);
+
+        int consumed = mapper.consumeIfVerified(attempt.getAttemptId(), "test@example.com", LocalDateTime.now());
+        assertThat(consumed).isEqualTo(0);
+        assertThat(mapper.findStatusById(attempt.getAttemptId())).isEqualTo("PENDING");
+    }
+}

--- a/src/test/java/com/flyway/auth/service/EmailVerificationServiceConcurrencyTest.java
+++ b/src/test/java/com/flyway/auth/service/EmailVerificationServiceConcurrencyTest.java
@@ -253,6 +253,9 @@ class EmailVerificationServiceConcurrencyTest {
                 if (token.getPurpose() == null || !purpose.equals(token.getPurpose().name())) {
                     continue;
                 }
+                if (attemptId != null && !attemptId.equals(token.getAttemptId())) {
+                    continue;
+                }
                 if (token.getUsedAt() == null) {
                     continue;
                 }

--- a/src/test/java/com/flyway/auth/service/EmailVerificationServiceConcurrencyTest.java
+++ b/src/test/java/com/flyway/auth/service/EmailVerificationServiceConcurrencyTest.java
@@ -3,6 +3,7 @@ package com.flyway.auth.service;
 import com.flyway.auth.domain.EmailVerificationPurpose;
 import com.flyway.auth.domain.EmailVerificationToken;
 import com.flyway.auth.repository.EmailVerificationRepository;
+import com.flyway.auth.repository.SignUpAttemptRepository;
 import com.flyway.auth.util.TokenHasher;
 import com.flyway.template.common.mail.MailSender;
 import com.flyway.user.mapper.UserMapper;
@@ -12,21 +13,18 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.springframework.dao.DuplicateKeyException;
 import org.springframework.test.util.ReflectionTestUtils;
+
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.UUID;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.Future;
-import java.util.concurrent.TimeUnit;
+import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
 
@@ -34,16 +32,20 @@ class EmailVerificationServiceConcurrencyTest {
 
     private EmailVerificationServiceImpl service;
     private InMemoryEmailVerificationRepository emailVerificationRepository;
+    private SignUpAttemptRepository signUpAttemptRepository;
 
     @BeforeEach
     void setUp() {
         emailVerificationRepository = new InMemoryEmailVerificationRepository();
+
         MailSender mailSender = Mockito.mock(MailSender.class);
         TokenHasher tokenHasher = Mockito.mock(TokenHasher.class);
         UserMapper userMapper = Mockito.mock(UserMapper.class);
+        signUpAttemptRepository = Mockito.mock(SignUpAttemptRepository.class);
 
         service = new EmailVerificationServiceImpl(
                 emailVerificationRepository,
+                signUpAttemptRepository,
                 mailSender,
                 tokenHasher,
                 userMapper
@@ -54,6 +56,8 @@ class EmailVerificationServiceConcurrencyTest {
         when(userMapper.findByEmailForLogin(anyString())).thenReturn(null);
         when(tokenHasher.hash(anyString()))
                 .thenAnswer(invocation -> invocation.getArgument(0, String.class));
+        when(signUpAttemptRepository.markVerifiedIfPending(anyString(), any(LocalDateTime.class)))
+                .thenReturn(1);
     }
 
     @Test
@@ -95,6 +99,7 @@ class EmailVerificationServiceConcurrencyTest {
         String email = "verify@example.com";
         String token = "token-123";
         String tokenHash = token;
+        String attemptId = "attempt-verify";
         LocalDateTime now = LocalDateTime.now();
 
         EmailVerificationToken record = EmailVerificationToken.builder()
@@ -104,6 +109,7 @@ class EmailVerificationServiceConcurrencyTest {
                 .tokenHash(tokenHash)
                 .expiresAt(now.plusMinutes(10))
                 .createdAt(now)
+                .attemptId(attemptId)
                 .build();
         emailVerificationRepository.insertEmailVerificationToken(record);
 
@@ -121,7 +127,7 @@ class EmailVerificationServiceConcurrencyTest {
                     ready.countDown();
                     start.await();
                     try {
-                        service.verifySignupToken(token);
+                        service.verifySignupToken(token, attemptId);
                         successCount.incrementAndGet();
                     } catch (IllegalArgumentException e) {
                         failCount.incrementAndGet();
@@ -152,6 +158,7 @@ class EmailVerificationServiceConcurrencyTest {
         String email = "race@example.com";
         String token = "race-token";
         String tokenHash = token;
+        String attemptId = "attempt-race";
         LocalDateTime now = LocalDateTime.now();
 
         EmailVerificationToken record = EmailVerificationToken.builder()
@@ -161,6 +168,7 @@ class EmailVerificationServiceConcurrencyTest {
                 .tokenHash(tokenHash)
                 .expiresAt(now.plusMinutes(10))
                 .createdAt(now)
+                .attemptId(attemptId)
                 .build();
         emailVerificationRepository.insertEmailVerificationToken(record);
 
@@ -172,7 +180,7 @@ class EmailVerificationServiceConcurrencyTest {
             Future<?> verifyFuture = executor.submit(() -> {
                 ready.countDown();
                 start.await();
-                service.verifySignupToken(token);
+                service.verifySignupToken(token, attemptId);
                 return null;
             });
 
@@ -227,6 +235,7 @@ class EmailVerificationServiceConcurrencyTest {
                         .expiresAt(current.getExpiresAt())
                         .usedAt(usedAt)
                         .createdAt(current.getCreatedAt())
+                        .attemptId(current.getAttemptId())
                         .build();
                 byId.put(emailVerificationTokenId, updated);
                 byHash.put(updated.getTokenHash(), updated);
@@ -235,7 +244,7 @@ class EmailVerificationServiceConcurrencyTest {
         }
 
         @Override
-        public int countVerifiedByEmailPurpose(String email, String purpose, LocalDateTime now) {
+        public int existsUsedTokenByEmailAttempt(String email, String attemptId, String purpose, LocalDateTime now) {
             int count = 0;
             for (EmailVerificationToken token : byId.values()) {
                 if (!email.equals(token.getEmail())) {

--- a/src/test/java/com/flyway/auth/service/EmailVerificationServiceImplTest.java
+++ b/src/test/java/com/flyway/auth/service/EmailVerificationServiceImplTest.java
@@ -3,6 +3,7 @@ package com.flyway.auth.service;
 import com.flyway.auth.domain.EmailVerificationPurpose;
 import com.flyway.auth.domain.EmailVerificationToken;
 import com.flyway.auth.repository.EmailVerificationRepository;
+import com.flyway.auth.repository.SignUpAttemptRepository;
 import com.flyway.auth.util.TokenHasher;
 import com.flyway.template.common.mail.MailSender;
 import org.junit.jupiter.api.BeforeEach;
@@ -24,6 +25,7 @@ import static org.mockito.Mockito.when;
 class EmailVerificationServiceImplTest {
 
     private EmailVerificationRepository tokenRepository;
+    private SignUpAttemptRepository signUpAttemptRepository;
     private MailSender mailSender;
     private TokenHasher tokenHasher;
     private com.flyway.user.mapper.UserMapper userMapper;
@@ -32,11 +34,18 @@ class EmailVerificationServiceImplTest {
     @BeforeEach
     void setUp() {
         tokenRepository = Mockito.mock(EmailVerificationRepository.class);
+        signUpAttemptRepository = Mockito.mock(SignUpAttemptRepository.class);
         mailSender = Mockito.mock(MailSender.class);
         tokenHasher = Mockito.mock(TokenHasher.class);
         userMapper = Mockito.mock(com.flyway.user.mapper.UserMapper.class);
 
-        service = new EmailVerificationServiceImpl(tokenRepository, mailSender, tokenHasher, userMapper);
+        service = new EmailVerificationServiceImpl(
+                tokenRepository,
+                signUpAttemptRepository,
+                mailSender,
+                tokenHasher,
+                userMapper
+        );
         ReflectionTestUtils.setField(service, "baseUrl", "http://localhost:8080");
         ReflectionTestUtils.setField(service, "ttlMinutes", 15L);
     }

--- a/src/test/java/com/flyway/auth/service/EmailVerificationServiceImplTest.java
+++ b/src/test/java/com/flyway/auth/service/EmailVerificationServiceImplTest.java
@@ -13,9 +13,12 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 import org.springframework.test.util.ReflectionTestUtils;
 
+import java.time.LocalDateTime;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.contains;
 import static org.mockito.Mockito.verify;
@@ -48,6 +51,7 @@ class EmailVerificationServiceImplTest {
         );
         ReflectionTestUtils.setField(service, "baseUrl", "http://localhost:8080");
         ReflectionTestUtils.setField(service, "ttlMinutes", 15L);
+        ReflectionTestUtils.setField(service, "attemptTtlMinutes", 10L);
     }
 
     @Test
@@ -72,6 +76,89 @@ class EmailVerificationServiceImplTest {
                 eq("[Flyway] 이메일 인증 안내"),
                 contains("/auth/email/verify?token=")
         );
+    }
+
+    @Test
+    @DisplayName("인증 링크 검증 성공 시 토큰과 시도가 처리된다")
+    void verifySignupToken_success_marksTokenAndAttempt() {
+        String attemptId = "attempt-1";
+        when(tokenHasher.hash(anyString())).thenReturn("token-hash");
+        when(tokenRepository.findByTokenHash("token-hash"))
+                .thenReturn(EmailVerificationToken.builder()
+                        .emailVerificationTokenId("token-id")
+                        .email("test@example.com")
+                        .purpose(EmailVerificationPurpose.SIGNUP)
+                        .tokenHash("token-hash")
+                        .attemptId(attemptId)
+                        .expiresAt(LocalDateTime.now().plusMinutes(10))
+                        .createdAt(LocalDateTime.now())
+                        .build());
+        when(tokenRepository.markTokenUsed(eq("token-id"), any(LocalDateTime.class))).thenReturn(1);
+        when(signUpAttemptRepository.markVerifiedIfPending(eq(attemptId), any(LocalDateTime.class))).thenReturn(1);
+
+        String email = service.verifySignupToken("raw-token", attemptId);
+
+        assertThat(email).isEqualTo("test@example.com");
+        verify(tokenRepository).markTokenUsed(eq("token-id"), any(LocalDateTime.class));
+        verify(signUpAttemptRepository).markVerifiedIfPending(eq(attemptId), any(LocalDateTime.class));
+    }
+
+    @Test
+    @DisplayName("인증 링크의 attemptId가 다르면 검증 실패")
+    void verifySignupToken_attemptMismatch_throws() {
+        when(tokenHasher.hash(anyString())).thenReturn("token-hash");
+        when(tokenRepository.findByTokenHash("token-hash"))
+                .thenReturn(EmailVerificationToken.builder()
+                        .emailVerificationTokenId("token-id")
+                        .email("test@example.com")
+                        .purpose(EmailVerificationPurpose.SIGNUP)
+                        .tokenHash("token-hash")
+                        .attemptId("attempt-a")
+                        .expiresAt(LocalDateTime.now().plusMinutes(10))
+                        .createdAt(LocalDateTime.now())
+                        .build());
+
+        assertThatThrownBy(() -> service.verifySignupToken("raw-token", "attempt-b"))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    @DisplayName("만료된 토큰은 검증에 실패한다")
+    void verifySignupToken_expired_throws() {
+        when(tokenHasher.hash(anyString())).thenReturn("token-hash");
+        when(tokenRepository.findByTokenHash("token-hash"))
+                .thenReturn(EmailVerificationToken.builder()
+                        .emailVerificationTokenId("token-id")
+                        .email("test@example.com")
+                        .purpose(EmailVerificationPurpose.SIGNUP)
+                        .tokenHash("token-hash")
+                        .attemptId("attempt-1")
+                        .expiresAt(LocalDateTime.now().minusMinutes(1))
+                        .createdAt(LocalDateTime.now())
+                        .build());
+
+        assertThatThrownBy(() -> service.verifySignupToken("raw-token", "attempt-1"))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    @DisplayName("이미 사용된 토큰은 검증에 실패한다")
+    void verifySignupToken_used_throws() {
+        when(tokenHasher.hash(anyString())).thenReturn("token-hash");
+        when(tokenRepository.findByTokenHash("token-hash"))
+                .thenReturn(EmailVerificationToken.builder()
+                        .emailVerificationTokenId("token-id")
+                        .email("test@example.com")
+                        .purpose(EmailVerificationPurpose.SIGNUP)
+                        .tokenHash("token-hash")
+                        .attemptId("attempt-1")
+                        .expiresAt(LocalDateTime.now().plusMinutes(5))
+                        .usedAt(LocalDateTime.now())
+                        .createdAt(LocalDateTime.now())
+                        .build());
+
+        assertThatThrownBy(() -> service.verifySignupToken("raw-token", "attempt-1"))
+                .isInstanceOf(IllegalArgumentException.class);
     }
 
     @Test

--- a/src/test/java/com/flyway/auth/service/EmailVerificationServiceIntegrationTest.java
+++ b/src/test/java/com/flyway/auth/service/EmailVerificationServiceIntegrationTest.java
@@ -48,6 +48,7 @@ class EmailVerificationServiceIntegrationTest {
         );
         ReflectionTestUtils.setField(service, "baseUrl", "http://localhost:8080");
         ReflectionTestUtils.setField(service, "ttlMinutes", 15L);
+        ReflectionTestUtils.setField(service, "attemptTtlMinutes", 10L);
     }
 
     @Test
@@ -81,7 +82,7 @@ class EmailVerificationServiceIntegrationTest {
         assertThatThrownBy(() -> service.verifySignupToken(token, attemptId))
                 .isInstanceOf(IllegalArgumentException.class);
 
-        assertThat(service.isSignupVerified(email, anyString())).isFalse();
+        assertThat(service.isSignupVerified(email, attemptId)).isFalse();
         verify(emailVerificationRepository, never())
                 .markTokenUsed(anyString(), any(LocalDateTime.class));
     }

--- a/src/test/java/com/flyway/auth/service/EmailVerificationServiceIntegrationTest.java
+++ b/src/test/java/com/flyway/auth/service/EmailVerificationServiceIntegrationTest.java
@@ -3,6 +3,7 @@ package com.flyway.auth.service;
 import com.flyway.auth.domain.EmailVerificationPurpose;
 import com.flyway.auth.domain.EmailVerificationToken;
 import com.flyway.auth.repository.EmailVerificationRepository;
+import com.flyway.auth.repository.SignUpAttemptRepository;
 import com.flyway.auth.util.TokenHasher;
 import com.flyway.template.common.mail.MailSender;
 import com.flyway.user.mapper.UserMapper;
@@ -27,6 +28,7 @@ class EmailVerificationServiceIntegrationTest {
 
     private EmailVerificationRepository emailVerificationRepository;
     private TokenHasher tokenHasher;
+    private SignUpAttemptRepository signUpAttemptRepository;
     private EmailVerificationServiceImpl service;
 
     @BeforeEach
@@ -35,9 +37,11 @@ class EmailVerificationServiceIntegrationTest {
         MailSender mailSender = Mockito.mock(MailSender.class);
         tokenHasher = Mockito.mock(TokenHasher.class);
         UserMapper userMapper = Mockito.mock(UserMapper.class);
+        signUpAttemptRepository = Mockito.mock(SignUpAttemptRepository.class);
 
         service = new EmailVerificationServiceImpl(
                 emailVerificationRepository,
+                signUpAttemptRepository,
                 mailSender,
                 tokenHasher,
                 userMapper
@@ -52,6 +56,7 @@ class EmailVerificationServiceIntegrationTest {
         String email = "expired@example.com";
         String token = "expired-token";
         String tokenHash = "hash-expired";
+        String attemptId = "attempt-123";
         LocalDateTime now = LocalDateTime.now();
 
         EmailVerificationToken record = EmailVerificationToken.builder()
@@ -61,20 +66,22 @@ class EmailVerificationServiceIntegrationTest {
                 .tokenHash(tokenHash)
                 .expiresAt(now.minusMinutes(1))
                 .createdAt(now.minusMinutes(2))
+                .attemptId(attemptId)
                 .build();
 
         when(tokenHasher.hash(token)).thenReturn(tokenHash);
         when(emailVerificationRepository.findByTokenHash(tokenHash)).thenReturn(record);
-        when(emailVerificationRepository.countVerifiedByEmailPurpose(
+        when(emailVerificationRepository.existsUsedTokenByEmailAttempt(
                 eq(email),
+                eq(attemptId),
                 eq(EmailVerificationPurpose.SIGNUP.name()),
                 any(LocalDateTime.class)
         )).thenReturn(0);
 
-        assertThatThrownBy(() -> service.verifySignupToken(token))
+        assertThatThrownBy(() -> service.verifySignupToken(token, attemptId))
                 .isInstanceOf(IllegalArgumentException.class);
 
-        assertThat(service.isSignupVerified(email)).isFalse();
+        assertThat(service.isSignupVerified(email, anyString())).isFalse();
         verify(emailVerificationRepository, never())
                 .markTokenUsed(anyString(), any(LocalDateTime.class));
     }

--- a/src/test/java/com/flyway/auth/service/SignUpServiceImplTest.java
+++ b/src/test/java/com/flyway/auth/service/SignUpServiceImplTest.java
@@ -1,0 +1,154 @@
+package com.flyway.auth.service;
+
+import com.flyway.auth.domain.AuthProvider;
+import com.flyway.auth.domain.AuthStatus;
+import com.flyway.auth.dto.EmailSignUpRequest;
+import com.flyway.auth.repository.SignUpAttemptRepository;
+import com.flyway.template.exception.BusinessException;
+import com.flyway.template.exception.ErrorCode;
+import com.flyway.user.domain.User;
+import com.flyway.user.domain.UserIdentity;
+import com.flyway.user.domain.UserProfile;
+import com.flyway.user.repository.UserIdentityRepository;
+import com.flyway.user.repository.UserProfileRepository;
+import com.flyway.user.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+class SignUpServiceImplTest {
+
+    private UserRepository userRepository;
+    private UserIdentityRepository userIdentityRepository;
+    private UserProfileRepository userProfileRepository;
+    private SignUpAttemptRepository signUpAttemptRepository;
+    private PasswordEncoder passwordEncoder;
+    private SignUpServiceImpl signUpService;
+
+    @BeforeEach
+    void setUp() {
+        userRepository = Mockito.mock(UserRepository.class);
+        userIdentityRepository = Mockito.mock(UserIdentityRepository.class);
+        userProfileRepository = Mockito.mock(UserProfileRepository.class);
+        signUpAttemptRepository = Mockito.mock(SignUpAttemptRepository.class);
+        passwordEncoder = Mockito.mock(PasswordEncoder.class);
+
+        signUpService = new SignUpServiceImpl(
+                userRepository,
+                userIdentityRepository,
+                userProfileRepository,
+                signUpAttemptRepository,
+                passwordEncoder
+        );
+    }
+
+    @Test
+    @DisplayName("회원가입 성공 시 사용자/아이덴티티/프로필이 생성된다")
+    void signUp_success_createsUserAndIdentity() {
+        EmailSignUpRequest request = EmailSignUpRequest.builder()
+                .name("Tester")
+                .email("test@example.com")
+                .rawPassword("password")
+                .attemptId("attempt-1")
+                .build();
+
+        when(signUpAttemptRepository.consumeIfVerified(eq("attempt-1"), eq("test@example.com"), any()))
+                .thenReturn(1);
+        when(userIdentityRepository.existsEmailIdentity("test@example.com")).thenReturn(false);
+        when(passwordEncoder.encode("password")).thenReturn("encoded");
+
+        signUpService.signUp(request);
+
+        ArgumentCaptor<User> userCaptor = ArgumentCaptor.forClass(User.class);
+        verify(userRepository).save(userCaptor.capture());
+        User savedUser = userCaptor.getValue();
+        assertThat(savedUser.getEmail()).isEqualTo("test@example.com");
+        assertThat(savedUser.getPasswordHash()).isEqualTo("encoded");
+        assertThat(savedUser.getStatus()).isEqualTo(AuthStatus.ACTIVE);
+
+        ArgumentCaptor<UserIdentity> identityCaptor = ArgumentCaptor.forClass(UserIdentity.class);
+        verify(userIdentityRepository).save(identityCaptor.capture());
+        UserIdentity savedIdentity = identityCaptor.getValue();
+        assertThat(savedIdentity.getProvider()).isEqualTo(AuthProvider.EMAIL);
+        assertThat(savedIdentity.getProviderUserId()).isEqualTo("test@example.com");
+
+        ArgumentCaptor<UserProfile> profileCaptor = ArgumentCaptor.forClass(UserProfile.class);
+        verify(userProfileRepository).createProfile(profileCaptor.capture());
+        assertThat(profileCaptor.getValue().getName()).isEqualTo("Tester");
+    }
+
+    @Test
+    @DisplayName("인증 시도 정보가 유효하지 않으면 회원가입이 실패한다")
+    void signUp_invalidAttempt_throws() {
+        EmailSignUpRequest request = EmailSignUpRequest.builder()
+                .name("Tester")
+                .email("test@example.com")
+                .rawPassword("password")
+                .attemptId("attempt-1")
+                .build();
+
+        when(signUpAttemptRepository.consumeIfVerified(anyString(), anyString(), any()))
+                .thenReturn(0);
+
+        assertThatThrownBy(() -> signUpService.signUp(request))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage(ErrorCode.USER_INVALID_SIGN_UP_ATTEMPT.getMessage());
+
+        verifyNoInteractions(userRepository, userIdentityRepository, userProfileRepository);
+    }
+
+    @Test
+    @DisplayName("이메일이 이미 존재하면 회원가입이 실패한다")
+    void signUp_duplicateEmail_throws() {
+        EmailSignUpRequest request = EmailSignUpRequest.builder()
+                .name("Tester")
+                .email("test@example.com")
+                .rawPassword("password")
+                .attemptId("attempt-1")
+                .build();
+
+        when(signUpAttemptRepository.consumeIfVerified(eq("attempt-1"), eq("test@example.com"), any()))
+                .thenReturn(1);
+        when(userIdentityRepository.existsEmailIdentity("test@example.com")).thenReturn(true);
+
+        assertThatThrownBy(() -> signUpService.signUp(request))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage(ErrorCode.USER_EMAIL_ALREADY_EXISTS.getMessage());
+
+        verifyNoInteractions(userRepository, userProfileRepository);
+    }
+
+    @Test
+    @DisplayName("비밀번호 인코딩 실패 시 회원가입이 실패한다")
+    void signUp_passwordEncodeFails_throws() {
+        EmailSignUpRequest request = EmailSignUpRequest.builder()
+                .name("Tester")
+                .email("test@example.com")
+                .rawPassword("password")
+                .attemptId("attempt-1")
+                .build();
+
+        when(signUpAttemptRepository.consumeIfVerified(eq("attempt-1"), eq("test@example.com"), any()))
+                .thenReturn(1);
+        when(userIdentityRepository.existsEmailIdentity("test@example.com")).thenReturn(false);
+        when(passwordEncoder.encode("password")).thenThrow(new RuntimeException("fail"));
+
+        assertThatThrownBy(() -> signUpService.signUp(request))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage(ErrorCode.USER_PASSWORD_ENCODE_ERROR.getMessage());
+
+        verifyNoInteractions(userRepository, userProfileRepository);
+    }
+}


### PR DESCRIPTION
## 📌 PR 설명
- 회원가입 이메일 인증 흐름을 attempt 기반으로 개선했습니다.  
- 인증 발급 시 `attemptId`를 생성/반환하고, 인증 링크 검증 및 인증 상태 조회/회원가입까지 전 과정에서 `attemptId`를 함께 검증하도록 변경했습니다.  
- 이를 통해 동일 이메일로 여러 번 인증을 요청하거나 동시 시도가 발생해도 인증 상태가 섞이지 않도록 방어합니다.

<br>

## ✅ 완료한 기능 명세

- [x] 이메일 인증 발급 API가 `attemptId`를 생성하고 응답에 포함하도록 변경  
- [x] 이메일 인증 상태 조회 API가 `attemptId` 파라미터를 필수로 받아 attempt 단위로 검증하도록 변경  
- [x] 인증 링크 검증(View) 시 `attempt` 파라미터를 추가하고, 토큰-시도 매칭 검증 로직 적용  
- [x] `SignUpAttempt / SignUpStatus` 도메인 및 MyBatis Mapper/Repository 추가  
  - 상태 전이: `PENDING → VERIFIED → CONSUMED` (만료: `EXPIRED`)
- [x] 회원가입 요청에 `attemptId` 필수값 추가 및 가입 시점에 attempt 유효성 검증 추가  
  - `consumeIfVerified(attemptId, email, now)` 성공(1)일 때만 유저 생성
- [x] 이메일 인증 토큰 테이블에 `attempt_id` 컬럼 연동 및 조회 쿼리 개선  
  - `existsUsedTokenByEmailAttempt(email, attemptId, purpose, now)`
- [x] 메일 발송 시점 안정화를 위해 트랜잭션 커밋 이후(afterCommit) 발송하도록 개선
- [x] JSP/JS에서 attemptId를 hidden input으로 관리하도록 변경  
  - 인증메일 발급 응답의 `attemptId`를 저장  
  - 인증 확인 요청 시 `email + attemptId` 함께 전송
- [x] 테스트 추가/수정  
  - Controller 단위 테스트 추가/보완  
  - Service 단위 테스트 보강(토큰/attempt 매칭, 만료/사용됨 케이스)  
  - MyBatis 통합 테스트(MapperIT) 및 H2 기반 테스트 설정 추가  
  - 회원가입 서비스 테스트에서 attempt 검증 케이스 추가


<br>

## 💭 고민과 해결과정

### attemptId의 필요성
기존에는 이메일 기준으로만 인증 완료 여부를 확인하는 구조라, 동일 이메일로 인증을 여러 번 요청했을 때 인증 상태가 섞일 여지가 있었습니다.

### 방어 방법
- 발급 시점에 `signup_attempt(attemptId, email, status, expiresAt...)`을 생성하고,
- 이메일 인증 토큰에도 `attempt_id`를 저장하여 링크 검증 시 `token ↔ attemptId`를 매칭합니다.
- 인증 상태 조회 및 회원가입에서도 `email + attemptId`를 함께 검증해 attempt 단위로만 인증을 검증합니다.
- 회원가입은 `consumeIfVerified` 업데이트 결과가 1일 때만 진행하여, **1회성/재사용 방지**를 보장합니다.

### 트랜잭션/메일 발송 처리
DB insert 이후 메일 발송 실패로 인해 상태가 모호해지는 문제를 해결하기 위해,= 메일 발송을 `afterCommit`에서 수행하도록 변경했습니다.

<br>

### 🔗 관련 이슈
Closes #97 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Email verification now issues and surfaces an attemptId across API, UI, verification URLs, and backend flows.
  * New signup-attempt lifecycle (PENDING → VERIFIED → CONSUMED/EXPIRED) to manage retries and state.

* **Bug Fixes**
  * Stronger validation and clearer messages for invalid, expired, already-used, or mismatched verification attempts.
  * Prevents token reuse across different signup attempts.

* **Tests**
  * Added/updated unit and integration tests for attempt tracking, concurrency, and end-to-end verification flows.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->