### PR TITLE
[FLWY-148] 여정상세 패널 만들기

### DIFF
--- a/src/main/java/com/flyway/search/controller/FlightApiController.java
+++ b/src/main/java/com/flyway/search/controller/FlightApiController.java
@@ -1,14 +1,12 @@
 package com.flyway.search.controller;
 
 import com.flyway.search.domain.*;
+import com.flyway.search.dto.FlightDetailDto;
 import com.flyway.search.dto.FlightSearchRequest;
 import com.flyway.search.dto.SearchResultDto;
 import com.flyway.search.service.FlightService;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
@@ -38,6 +36,12 @@ public class FlightApiController {
     @PostMapping("/api/public/flights/search")
     public SearchResultDto search(@RequestBody FlightSearchRequest dto) {
         return service.search(dto);
+    }
+
+    // 여정상세
+    @GetMapping("/api/public/flights/details")
+    public FlightDetailDto details(@RequestParam String cabinClass, @RequestParam String routeType) {
+        return service.details(cabinClass, routeType);
     }
 
 }

--- a/src/main/java/com/flyway/search/controller/FlightController.java
+++ b/src/main/java/com/flyway/search/controller/FlightController.java
@@ -8,11 +8,9 @@ import org.springframework.web.bind.annotation.GetMapping;
 
 @Controller
 public class FlightController {
-    @Autowired
-    FlightService service;
 
     @GetMapping("/search")
     public String list() {
-        return "search";
+        return "search/search";
     }
 }

--- a/src/main/java/com/flyway/search/dto/FlightDetailDto.java
+++ b/src/main/java/com/flyway/search/dto/FlightDetailDto.java
@@ -1,0 +1,11 @@
+package com.flyway.search.dto;
+
+import lombok.Data;
+
+@Data
+public class FlightDetailDto {
+    private Integer freeCheckedBags;
+    private Integer freeCheckedWeights;
+
+    // 추가 여정 상세 정보
+}

--- a/src/main/java/com/flyway/search/dto/FlightSearchResponse.java
+++ b/src/main/java/com/flyway/search/dto/FlightSearchResponse.java
@@ -16,5 +16,7 @@ public class FlightSearchResponse {
     private String flightNumber;
     private Integer seatCount;
     private Integer durationMinutes;
-    //private int currentPrice;
+    private String terminalNo;
+    private String routeType;
+//    private Integer currentPrice;
 }

--- a/src/main/java/com/flyway/search/mapper/FlightMapper.java
+++ b/src/main/java/com/flyway/search/mapper/FlightMapper.java
@@ -1,9 +1,11 @@
 package com.flyway.search.mapper;
 
 import com.flyway.search.domain.*;
+import com.flyway.search.dto.FlightDetailDto;
 import com.flyway.search.dto.FlightSearchRequest;
 import com.flyway.search.dto.FlightSearchResponse;
 import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
 
 import java.util.List;
 
@@ -14,4 +16,5 @@ public interface FlightMapper {
     List<Airline> airline(Airline vo);
     List<FlightSearchResponse> outbound(FlightSearchRequest dto);
     List<FlightSearchResponse> inbound(FlightSearchRequest dto);
+    FlightDetailDto details(@Param("cabinClass") String cabinClass, @Param("routeType") String routeType);
 }

--- a/src/main/java/com/flyway/search/repository/FlightRepository.java
+++ b/src/main/java/com/flyway/search/repository/FlightRepository.java
@@ -3,6 +3,7 @@ package com.flyway.search.repository;
 import com.flyway.search.domain.Airline;
 import com.flyway.search.domain.Airport;
 import com.flyway.search.domain.Flight;
+import com.flyway.search.dto.FlightDetailDto;
 import com.flyway.search.dto.FlightSearchRequest;
 import com.flyway.search.dto.FlightSearchResponse;
 import com.flyway.search.mapper.FlightMapper;
@@ -19,4 +20,6 @@ public interface FlightRepository {
     List<FlightSearchResponse> findOutboundFlights(FlightSearchRequest dto);
 
     List<FlightSearchResponse> findInboundFlights(FlightSearchRequest dto);
+
+    FlightDetailDto findDetails(String cabinClass, String routeType);
 }

--- a/src/main/java/com/flyway/search/repository/FlightRepositoryImpl.java
+++ b/src/main/java/com/flyway/search/repository/FlightRepositoryImpl.java
@@ -3,6 +3,7 @@ package com.flyway.search.repository;
 import com.flyway.search.domain.Airline;
 import com.flyway.search.domain.Airport;
 import com.flyway.search.domain.Flight;
+import com.flyway.search.dto.FlightDetailDto;
 import com.flyway.search.dto.FlightSearchRequest;
 import com.flyway.search.dto.FlightSearchResponse;
 import com.flyway.search.mapper.FlightMapper;
@@ -20,9 +21,7 @@ public class FlightRepositoryImpl implements FlightRepository {
         return mapper.list(vo);
     }
 
-    public List<Airport> findAirports(Airport vo) {
-        return mapper.airport(vo);
-    }
+    public List<Airport> findAirports(Airport vo) { return mapper.airport(vo); }
 
     public List<Airline> findAirlines(Airline vo) { return mapper.airline(vo); }
 
@@ -33,4 +32,6 @@ public class FlightRepositoryImpl implements FlightRepository {
     public List<FlightSearchResponse> findInboundFlights(FlightSearchRequest dto) {
         return mapper.inbound(dto);
     }
+
+    public FlightDetailDto findDetails(String cabinClass, String routeType) { return mapper.details(cabinClass, routeType); }
 }

--- a/src/main/java/com/flyway/search/service/FlightService.java
+++ b/src/main/java/com/flyway/search/service/FlightService.java
@@ -1,6 +1,7 @@
 package com.flyway.search.service;
 
 import com.flyway.search.domain.*;
+import com.flyway.search.dto.FlightDetailDto;
 import com.flyway.search.dto.FlightSearchRequest;
 import com.flyway.search.dto.SearchResultDto;
 
@@ -11,4 +12,5 @@ public interface FlightService {
     List<Airport> airport(Airport vo);
     List<Airline> airline(Airline vo);
     SearchResultDto search(FlightSearchRequest dto);
+    FlightDetailDto details(String cabinClass, String routeType);
 }

--- a/src/main/java/com/flyway/search/service/FlightServiceImpl.java
+++ b/src/main/java/com/flyway/search/service/FlightServiceImpl.java
@@ -36,6 +36,11 @@ public class FlightServiceImpl implements FlightService{
         return flightRepository.findAirlines(vo);
     }
 
+    @Override
+    public FlightDetailDto details(String cabinClass, String routeType) {
+        return flightRepository.findDetails(cabinClass, routeType);
+    }
+
     // 검색 결과
     @Override
     public SearchResultDto search(FlightSearchRequest dto) {
@@ -54,7 +59,7 @@ public class FlightServiceImpl implements FlightService{
 //                opt.setTotalPrice(o.getCurrentPrice);                // 아직 운임 없으면 null
                 options.add(opt);
             }
-            result. setOptions(options);
+            result.setOptions(options);
             return result;
         }
 

--- a/src/main/java/com/flyway/security/config/SecurityConfigWeb.java
+++ b/src/main/java/com/flyway/security/config/SecurityConfigWeb.java
@@ -31,7 +31,7 @@ public class SecurityConfigWeb extends WebSecurityConfigurerAdapter {
     };
 
     private static final String[] PUBLIC_ENDPOINTS = {
-            "/", "/login", "/loginProc", "/signup", "/admin", "/admin/**", "/auth/**", "/search"
+            "/", "/login", "/loginProc", "/signup", "/admin", "/admin/**", "/auth/**", "/search/**"
     };
 
     private final JwtProvider jwtProvider;

--- a/src/main/resources/mapper/flights/FlightsMapper.xml
+++ b/src/main/resources/mapper/flights/FlightsMapper.xml
@@ -111,7 +111,7 @@
         LIMIT 20;
     </select>
 
-    <select id="details" resultType="FlightDetailDto">
+    <select id="details" resultType="com.flyway.search.dto.FlightDetailDto">
         SELECT
             free_checked_bags AS freeCheckedBags,
             free_checked_weight_kg AS freeCheckedWeights

--- a/src/main/resources/mapper/flights/FlightsMapper.xml
+++ b/src/main/resources/mapper/flights/FlightsMapper.xml
@@ -32,8 +32,10 @@
         f.arrival_airport   AS arrivalAirport,
         f.departure_time    AS departureTime,
         f.arrival_time      AS arrivalTime,
+        f.terminal_no       AS terminalNo,
         f.flight_number     AS flightNumber,
         f.duration_minutes  AS durationMinutes,
+        f.route_type        AS routeType,
         da.city             AS departureCity,
         aa.city             AS arrivalCity,
         <choose>
@@ -73,8 +75,10 @@
         f.arrival_airport   AS arrivalAirport,
         f.departure_time    AS departureTime,
         f.arrival_time      AS arrivalTime,
+        f.terminal_no       AS terminalNo,
         f.flight_number     AS flightNumber,
         f.duration_minutes  AS durationMinutes,
+        f.route_type        AS routeType,
         da.city             AS departureCity,
         aa.city             AS arrivalCity,
         <choose>
@@ -105,6 +109,14 @@
             </choose>
         </if>
         LIMIT 20;
+    </select>
+
+    <select id="details" resultType="FlightDetailDto">
+        SELECT
+            free_checked_bags AS freeCheckedBags,
+            free_checked_weight_kg AS freeCheckedWeights
+        FROM baggage_policy
+        WHERE route_type = #{routeType} AND cabin_class_code = #{cabinClass}
     </select>
 
 </mapper>

--- a/src/main/webapp/WEB-INF/views/search/include/flight-detail.jsp
+++ b/src/main/webapp/WEB-INF/views/search/include/flight-detail.jsp
@@ -1,0 +1,26 @@
+<%@ page contentType="text/html;charset=UTF-8" language="java" %>
+
+<div id="flightDetailModal" class="modal-overlay" hidden>
+
+    <div class="modal-content itinerary-modal-style">
+
+        <div class="modal-header">
+            <h2 class="itinerary-title">여정 상세</h2>
+            <button type="button" class="close-btn" onclick="closeDetailPage()">×</button>
+        </div>
+
+        <div class="itinerary-content">
+
+            <div class="flights-row">
+
+            </div>
+
+            <div class="content-separator"></div>
+
+            <div class="policy-section">
+                <div class="policy-title">취소 및 변경</div>
+                <div class="policy-details">취소 수수료: 무료 (24시간 이내)<br>변경 수수료: ₩235,000 ~</div>
+            </div>
+        </div>
+    </div>
+</div>

--- a/src/main/webapp/WEB-INF/views/search/search.jsp
+++ b/src/main/webapp/WEB-INF/views/search/search.jsp
@@ -13,6 +13,7 @@
     <link rel="stylesheet" href="${pageContext.request.contextPath}/resources/search/css/global.css">
     <link rel="stylesheet" href="${pageContext.request.contextPath}/resources/search/css/header.css">
     <link rel="stylesheet" href="${pageContext.request.contextPath}/resources/search/css/search.css?v=<%= System.currentTimeMillis() %>">
+    <link rel="stylesheet" href="${pageContext.request.contextPath}/resources/search/css/details.css?v=<%= System.currentTimeMillis() %>">
     <link rel="stylesheet" href="${pageContext.request.contextPath}/resources/search/css/flights.css?v=<%= System.currentTimeMillis() %>">
 </head>
 
@@ -293,11 +294,14 @@
 <script>
     const CONTEXT_PATH = "${pageContext.request.contextPath}";
 </script>
+
+<jsp:include page="include/flight-detail.jsp" />
+
 <script src="${pageContext.request.contextPath}/resources/search/js/search.js?v=<%= System.currentTimeMillis() %>"></script>
 <script src="${pageContext.request.contextPath}/resources/search/js/filtering.js?v=<%= System.currentTimeMillis() %>"></script>
 <script src="${pageContext.request.contextPath}/resources/search/js/sort.js?v=<%= System.currentTimeMillis() %>"></script>
 <script src="${pageContext.request.contextPath}/resources/search/js/flight.js?v=<%= System.currentTimeMillis() %>"></script>
-
+<script src="${pageContext.request.contextPath}/resources/search/js/details.js?v=<%= System.currentTimeMillis() %>"></script>
 <script>
     // 1. 기본값은 비로그인(false)으로 설정
     let isUserLoggedIn = false;

--- a/src/main/webapp/resources/search/css/details.css
+++ b/src/main/webapp/resources/search/css/details.css
@@ -139,7 +139,15 @@
 .itinerary-modal-style .flight-point {
     display: flex;
     flex-direction: column;
-    gap: 2px;
+    align-items: center;
+    gap: 6px;
+    margin-bottom: 10px;
+}
+
+.itinerary-modal-style .date-highlight {
+    font-size: 16px;
+    font-weight: 700; /* 굵게 */
+    color: #222;      /* 진한 검정 */
 }
 
 /* 시간 (크고 진하게) */

--- a/src/main/webapp/resources/search/css/details.css
+++ b/src/main/webapp/resources/search/css/details.css
@@ -1,0 +1,270 @@
+@charset "UTF-8";
+
+.modal-overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background-color: rgba(0, 0, 0, 0.6); /* 배경을 좀 더 진하게 */
+    z-index: 9999; /* 최상위 레벨 */
+
+    /* 플렉스로 내용물 정중앙 정렬 */
+    display: flex;
+    justify-content: center;
+    align-items: center;
+
+    /* 트랜지션 효과 (선택사항) */
+    opacity: 1;
+    transition: opacity 0.3s ease;
+    backdrop-filter: blur(3px); /* 배경 블러 효과 */
+}
+
+/* hidden 속성이 있으면 숨김 */
+.modal-overlay[hidden] {
+    display: none !important;
+    opacity: 0;
+}
+
+/* 모달 하얀색 박스 */
+.modal-content {
+    background: #ffffff;
+    width: 95%;
+    max-width: 850px;
+    max-height: 90vh;
+    border-radius: 16px;
+    box-shadow: 0 10px 40px rgba(0, 0, 0, 0.2);
+    overflow-y: auto; /* 내용 길면 스크롤 */
+    position: relative;
+    padding: 0; /* 내부 여백은 아래 요소에서 처리 */
+}
+
+/* 모달 헤더 */
+.modal-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 20px 30px;
+    border-bottom: 1px solid #eee;
+    background: #fff;
+    position: sticky;
+    top: 0;
+    z-index: 10;
+}
+
+.modal-header .itinerary-title {
+    font-size: 20px;
+    font-weight: 700;
+    color: #333;
+    margin: 0;
+}
+
+.close-btn {
+    background: none;
+    border: none;
+    font-size: 28px;
+    color: #999;
+    cursor: pointer;
+    padding: 0;
+    line-height: 1;
+}
+.close-btn:hover { color: #333; }
+
+/* 모달 바디 */
+.itinerary-content {
+    padding: 30px;
+    background-color: #f8f9fa;
+}
+
+/* 카드들을 감싸는 영역 */
+.itinerary-modal-style .flights-row {
+    display: flex;
+    gap: 20px;
+    justify-content: center;
+}
+
+/* [개별 카드 디자인] */
+.itinerary-modal-style .flight-card {
+    flex: 1;
+    background: #ffffff;
+    border: 1px solid #e0e0e0;
+    border-radius: 12px;
+    padding: 25px 20px;
+
+    /* 내용물 가운데 정렬 */
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    text-align: center;
+
+    box-shadow: 0 4px 12px rgba(0,0,0,0.05);
+}
+
+/* 가는편/오는편 라벨 */
+.itinerary-modal-style .badge-label {
+    background-color: #f0f4ff;
+    color: #2563eb;
+    font-size: 13px;
+    font-weight: 700;
+    padding: 4px 12px;
+    border-radius: 20px;
+    margin-bottom: 15px;
+    display: inline-block;
+}
+
+/* 항공사 정보 (로고 + 이름) */
+.itinerary-modal-style .flight-airline {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    font-size: 16px;
+    font-weight: 600;
+    color: #333;
+    margin-bottom: 20px;
+}
+.itinerary-modal-style .airline-logo {
+    width: 24px;
+    height: 24px;
+}
+
+.itinerary-modal-style .flight-route {
+    display: flex;
+    flex-direction: column;
+    gap: 15px;
+    width: 100%;
+    margin-bottom: 20px;
+}
+
+/* 출발/도착 지점 그룹 */
+.itinerary-modal-style .flight-point {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+}
+
+/* 시간 (크고 진하게) */
+.itinerary-modal-style .time-highlight {
+    font-size: 28px; /* 시간 폰트 확대 */
+    font-weight: 800;
+    color: #111;
+    line-height: 1.2;
+}
+
+/* 날짜 */
+.itinerary-modal-style #modal-out-start-date,
+.itinerary-modal-style #modal-out-end-date {
+    font-size: 14px;
+    color: #666;
+    margin-bottom: 2px;
+}
+
+/* 공항 이름 */
+.itinerary-modal-style .flight-airport {
+    font-size: 15px;
+    color: #555;
+    font-weight: 500;
+}
+
+/* [중간 소요시간 영역] */
+.itinerary-modal-style .flight-duration {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 5px;
+
+    /* 위아래 점선으로 구분감 주기 */
+    border-top: 1px dashed #ddd;
+    border-bottom: 1px dashed #ddd;
+    padding: 10px 0;
+    margin: 5px 0;
+    width: 100%;
+}
+
+.itinerary-modal-style .flight-direct-badge {
+    font-size: 12px;
+    color: #2563eb;
+    background-color: transparent;
+    font-weight: 600;
+}
+
+.itinerary-modal-style .flight-duration-text {
+    font-size: 13px;
+    color: #888;
+}
+
+/* 구분선 (필요 없으면 숨김) */
+.itinerary-modal-style .flight-separator {
+    display: none;
+}
+
+/* [수하물 정보 박스] */
+.itinerary-modal-style .flight-baggage {
+    width: 100%;
+    background-color: #f5f7fa;
+    border-radius: 8px;
+    padding: 15px;
+    margin-top: auto; /* 카드 맨 아래로 */
+    text-align: left; /* 텍스트는 왼쪽 정렬 */
+}
+
+.itinerary-modal-style .baggage-title {
+    font-size: 14px;
+    font-weight: 700;
+    color: #333;
+    margin-bottom: 5px;
+    display: flex;
+    align-items: center;
+    gap: 5px;
+}
+
+/* 수하물 아이콘 효과 (선택) */
+.itinerary-modal-style .baggage-title::before {
+    content: '🧳';
+    font-size: 14px;
+}
+
+.itinerary-modal-style .baggage-details {
+    font-size: 13px;
+    color: #666;
+    line-height: 1.5;
+}
+
+/* 구분선 (모달 하단) */
+.content-separator {
+    height: 1px;
+    background-color: #eee;
+    margin: 20px 0;
+}
+
+/* 취소 규정 섹션 */
+.policy-section {
+    padding: 0 10px;
+}
+.policy-title {
+    font-size: 16px;
+    font-weight: 700;
+    margin-bottom: 8px;
+    color: #333;
+}
+.policy-details {
+    font-size: 14px;
+    color: #666;
+}
+
+@media (max-width: 768px) {
+    .itinerary-modal-style .flights-row {
+        flex-direction: column; /* 카드를 세로로 쌓기 */
+    }
+
+    .modal-content {
+        width: 100%;
+        height: 100%;
+        max-height: 100%;
+        border-radius: 0;
+    }
+
+    .itinerary-modal-style .flight-card {
+        min-width: auto;
+    }
+}

--- a/src/main/webapp/resources/search/js/details.js
+++ b/src/main/webapp/resources/search/js/details.js
@@ -1,0 +1,136 @@
+async function openDetailPage(index) {
+    const flight = displayedOptions[index];
+
+    if (!flight) {
+        console.error("비행편 정보를 찾을 수 없습니다 index:", index);
+        return;
+    }
+
+    const modal = document.getElementById('flightDetailModal');
+
+    const flightsRow = modal.querySelector('.flights-row');
+
+    // 수하물 정보 없이 기본 카드만 먼저
+    let cardsHtml = "";
+    cardsHtml += createDetail(flight.outbound, {}, "가는 편");
+    if (flight.inbound) {
+        cardsHtml += createDetail(flight.inbound, {}, "오는 편");
+    }
+    flightsRow.innerHTML = cardsHtml;
+
+    modal.hidden = false;
+
+    const routeType = flight.outbound.routeType;
+    const cabinClass = state.cabin;
+
+    try {
+        const res = await fetch(`${CONTEXT_PATH}/api/public/flights/details?cabinClass=${cabinClass}&routeType=${routeType}`);
+
+        if (res.ok) {
+            const details = await res.json();
+
+            let updatedHtml = "";
+            updatedHtml += createDetail(flight.outbound, details, "가는 편");
+            if (flight.inbound) {
+                updatedHtml += createDetail(flight.inbound, details, "오는 편");
+            }
+            flightsRow.innerHTML = updatedHtml;
+        }
+    } catch (err) {
+        console.error("규정 조회 실패:", err);
+    }
+}
+
+function closeDetailPage() {
+    document.getElementById('flightDetailModal').hidden = true;
+}
+
+function createDetail(f, details, type) {
+    const flightNumber = f.flightNumber ?? "-";
+    const depAirport = f.departureAirport ?? "-";
+    const arrAirport = f.arrivalAirport ?? "-";
+    const depCity = f.departureCity ?? "-";
+    const arrCity = f.arrivalCity ?? "-";
+    const terminalNo = f.terminalNo ?? "-";
+    const depTime = formatTimeArray(f.departureTime);
+    const arrTime = formatTimeArray(f.arrivalTime);
+    const depDate = formatDateArray(f.departureTime);
+    const arrDate = formatDateArray(f.arrivalTime);
+    const durationMinutes = Number.isFinite(f.durationMinutes) ? f.durationMinutes : null;
+
+    const freeCheckedBags = details.freeCheckedBags ?? "-";
+    const freeCheckedWeights = details.freeCheckedWeights ?? "-";
+
+    // 시간 표시
+    let time = "-";
+    if (durationMinutes !== null) {
+        const hours = Math.floor(durationMinutes / 60);
+        const minutes = durationMinutes % 60;
+        time = hours === 0 ? `${minutes}분` : `${hours}시간 ${minutes}분`;
+    }
+
+    // 항공사, 아이콘 표시
+    let airlineName = "항공사";
+    let airlineLogoHtml = "";
+
+    const prefix = flightNumber.substring(0, 2).toUpperCase();
+
+    if (prefix === 'OZ') {
+        airlineName = '아시아나항공';
+        airlineLogoHtml = '<img src="/resources/search/img/asiana-logo.svg" alt="Asiana" class="airline-logo">';
+    } else if (prefix === 'KE') {
+        airlineName = '대한항공';
+        airlineLogoHtml = '<img src="/resources/search/img/korean-logo.svg" alt="Korean" class="airline-logo">';
+    }
+
+    return `
+        <div class="flight-card" id="dynamic-outbound">
+            <div class="badge-label">${type}</div>
+            <div class="flight-airline" id="modal-out-airline">${airlineLogoHtml}${airlineName} ${flightNumber}</div> 
+            <div class="flight-route">
+                <div class="flight-point">
+                    <div class="flight-time">
+                        <span id="modal-out-start-date">${depDate}</span><br>
+                        <span id="modal-out-start-time" class="time-highlight">${depTime}</span>
+                    </div>
+                    <div class="flight-airport" id="modal-out-start-airport">${depCity}(${depAirport}) ${terminalNo}</div>
+                </div>
+    
+                <div class="flight-duration">
+                    <span class="flight-direct-badge">직항</span>
+                    <div class="flight-duration-text" id="modal-out-duration">${time}</div>
+                </div>
+    
+                <div class="flight-point">
+                    <div class="flight-time">
+                        <span id="modal-out-end-date">${arrDate}</span><br>
+                        <span id="modal-out-end-time" class="time-highlight">${arrTime}</span>
+                    </div>
+                    <div class="flight-airport" id="modal-out-end-airport">${arrCity}(${arrAirport})</div>
+                </div>
+            </div>
+
+            <div class="flight-separator"></div>
+
+            <div class="flight-baggage">
+                <div class="baggage-title">수하물</div>
+                <div class="baggage-details">무료 위탁수하물 개수: ${freeCheckedBags}개<br>무료 위탁수하물 무게: ${freeCheckedWeights}kg</div>
+            </div>
+        </div>
+    `
+}
+
+function formatTimeArray(arr) {
+    if (!Array.isArray(arr) || arr.length < 5) return "-";
+    const hh = String(arr[3]).padStart(2, "0");
+    const mm = String(arr[4]).padStart(2, "0");
+    return `${hh}:${mm}`;
+}
+
+function formatDateArray(arr) {
+    if (!Array.isArray(arr) || arr.length < 5) return "-";
+    const year = String(arr[0]);
+    const month = String(arr[1] - 1).padStart(2, "0");
+    const day = String(arr[2]).padStart(2,"0");
+    return `${year}-${month}-${day}`;
+}

--- a/src/main/webapp/resources/search/js/details.js
+++ b/src/main/webapp/resources/search/js/details.js
@@ -1,3 +1,5 @@
+let detailRequestSeq = 0;
+
 async function openDetailPage(index) {
     const flight = displayedOptions[index];
 
@@ -23,11 +25,13 @@ async function openDetailPage(index) {
     const routeType = flight.outbound.routeType;
     const cabinClass = state.cabin;
 
+    const requestSeq = ++detailRequestSeq;
     try {
         const res = await fetch(`${CONTEXT_PATH}/api/public/flights/details?cabinClass=${cabinClass}&routeType=${routeType}`);
 
         if (res.ok) {
             const details = await res.json();
+            if (requestSeq !== detailRequestSeq) return; // stale response
 
             let updatedHtml = "";
             updatedHtml += createDetail(flight.outbound, details, "가는 편");

--- a/src/main/webapp/resources/search/js/details.js
+++ b/src/main/webapp/resources/search/js/details.js
@@ -95,7 +95,7 @@ function createDetail(f, details, type) {
             <div class="flight-route">
                 <div class="flight-point">
                     <div class="flight-time">
-                        <span id="modal-${segmentKey}-start-date">${depDate}</span><br>
+                        <span id="modal-${segmentKey}-start-date" class="date-highlight">${depDate}</span>
                         <span id="modal-${segmentKey}-start-time" class="time-highlight">${depTime}</span>
                     </div>
                     <div class="flight-airport" id="modal-${segmentKey}-start-airport">${depCity}(${depAirport}) ${terminalNo}</div>
@@ -108,7 +108,7 @@ function createDetail(f, details, type) {
     
                 <div class="flight-point">
                     <div class="flight-time">
-                        <span id="modal-${segmentKey}-end-date">${arrDate}</span><br>
+                        <span id="modal-${segmentKey}-end-date" class="date-highlight">${arrDate}</span>
                         <span id="modal-${segmentKey}-end-time" class="time-highlight">${arrTime}</span>
                     </div>
                     <div class="flight-airport" id="modal-${segmentKey}-end-airport">${arrCity}(${arrAirport})</div>

--- a/src/main/webapp/resources/search/js/details.js
+++ b/src/main/webapp/resources/search/js/details.js
@@ -46,6 +46,7 @@ function closeDetailPage() {
 }
 
 function createDetail(f, details, type) {
+    const segmentKey = type === "가는 편" ? "outbound" : "inbound";
     const flightNumber = f.flightNumber ?? "-";
     const depAirport = f.departureAirport ?? "-";
     const arrAirport = f.arrivalAirport ?? "-";
@@ -84,29 +85,29 @@ function createDetail(f, details, type) {
     }
 
     return `
-        <div class="flight-card" id="dynamic-outbound">
+        <div class="flight-card" id="dynamic-${segmentKey}">
             <div class="badge-label">${type}</div>
-            <div class="flight-airline" id="modal-out-airline">${airlineLogoHtml}${airlineName} ${flightNumber}</div> 
+            <div class="flight-airline" id="modal-${segmentKey}-airline">${airlineLogoHtml}${airlineName} ${flightNumber}</div> 
             <div class="flight-route">
                 <div class="flight-point">
                     <div class="flight-time">
-                        <span id="modal-out-start-date">${depDate}</span><br>
-                        <span id="modal-out-start-time" class="time-highlight">${depTime}</span>
+                        <span id="modal-${segmentKey}-start-date">${depDate}</span><br>
+                        <span id="modal-${segmentKey}-start-time" class="time-highlight">${depTime}</span>
                     </div>
-                    <div class="flight-airport" id="modal-out-start-airport">${depCity}(${depAirport}) ${terminalNo}</div>
+                    <div class="flight-airport" id="modal-${segmentKey}-start-airport">${depCity}(${depAirport}) ${terminalNo}</div>
                 </div>
     
                 <div class="flight-duration">
                     <span class="flight-direct-badge">직항</span>
-                    <div class="flight-duration-text" id="modal-out-duration">${time}</div>
+                    <div class="flight-duration-text" id="modal-${segmentKey}-duration">${time}</div>
                 </div>
     
                 <div class="flight-point">
                     <div class="flight-time">
-                        <span id="modal-out-end-date">${arrDate}</span><br>
-                        <span id="modal-out-end-time" class="time-highlight">${arrTime}</span>
+                        <span id="modal-${segmentKey}-end-date">${arrDate}</span><br>
+                        <span id="modal-${segmentKey}-end-time" class="time-highlight">${arrTime}</span>
                     </div>
-                    <div class="flight-airport" id="modal-out-end-airport">${arrCity}(${arrAirport})</div>
+                    <div class="flight-airport" id="modal-${segmentKey}-end-airport">${arrCity}(${arrAirport})</div>
                 </div>
             </div>
 
@@ -130,7 +131,7 @@ function formatTimeArray(arr) {
 function formatDateArray(arr) {
     if (!Array.isArray(arr) || arr.length < 5) return "-";
     const year = String(arr[0]);
-    const month = String(arr[1] - 1).padStart(2, "0");
+    const month = String(arr[1]).padStart(2, "0");
     const day = String(arr[2]).padStart(2,"0");
     return `${year}-${month}-${day}`;
 }

--- a/src/main/webapp/resources/search/js/flight.js
+++ b/src/main/webapp/resources/search/js/flight.js
@@ -96,13 +96,13 @@ function renderSegment(f) {
       </div>
     `;
 }
-function renderFooter(option) {
+function renderFooter(option, index) {
     const seatCount = option.totalSeats ?? "-";
     return `
       <div class="flight-footer">
         <div class="flight-actions">
           <button class="action-button">가격 변동 그래프</button>
-          <button class="action-button">여정 상세</button>
+          <button class="action-button" onclick="openDetailPage(${index})">여정 상세</button>
         </div>
         <div class="seats-remaining">${seatCount}석 남음</div>
         <div class="flight-price" tabindex="0">
@@ -113,18 +113,18 @@ function renderFooter(option) {
     `;
 }
 
-function createOneWayCard(option) {
+function createOneWayCard(option, index) {
     const f = option.outbound;
 
     return `
     <article class="flight-card" data-out-id="${option.outbound.flightId}">
       ${renderSegment(f)}
-      ${renderFooter(option)}
+      ${renderFooter(option, index)}
     </article>
   `;
 }
 
-function createRoundTripCard(option) {
+function createRoundTripCard(option, index) {
     const o = option.outbound;
     const i = option.inbound;
 
@@ -135,7 +135,7 @@ function createRoundTripCard(option) {
     >
       ${renderSegment(o)}
       ${renderSegment(i)}
-      ${renderFooter(option)}
+      ${renderFooter(option, index)}
     </article>
   `;
 }
@@ -152,7 +152,7 @@ function renderOneWay(options) {
     displayedOptions = options;
 
     el.innerHTML = options
-        .map(option => createOneWayCard(option))
+        .map((option, index) => createOneWayCard(option, index))
         .join("");
 }
 
@@ -168,7 +168,7 @@ function renderRoundTrip(options) {
     displayedOptions = options;
 
     el.innerHTML = options
-        .map(option => createRoundTripCard(option))
+        .map((option, index) => createRoundTripCard(option, index))
         .join("");
 }
 

--- a/src/main/webapp/resources/search/js/search.js
+++ b/src/main/webapp/resources/search/js/search.js
@@ -1,6 +1,7 @@
 let AIRPORTS = [];
 let allOptions = [];
 let displayedOptions = [];
+let details = {};
 
 async function loadAirports() {
     const res = await fetch(`${CONTEXT_PATH}/api/public/airports`);
@@ -101,7 +102,6 @@ function initTripTabs() {
 function syncTripUI() {
     const rtOnly = document.querySelectorAll("[data-rt-only]");
     rtOnly.forEach(el => {
-        // hidden 속성 쓰면 간단
         el.hidden = (state.tripType !== "RT");
     });
 
@@ -425,6 +425,7 @@ function initSearchButton() {
 
 function handleSearchResult(data){
     allOptions = data.options ?? [];
+    details = data.details;
     displayedOptions = [...allOptions];
 
     if(allOptions.length > 0) {


### PR DESCRIPTION
## 📌 PR 설명
- 항공권 검색 결과 리스트에서 선택한 항공편의 상세 정보를 보여주는 여정 상세 패널 구현

- 여정상세 데이터(수하물 규정)를 조회하는 전용 API를 추가하고 연동
<br>

## ✅ 완료한 기능 명세

- [x] 수하물 규정 조회 API 구현 (/api/public/flights/details)

- [x] 여정 상세 UI

<br>

## 💭 고민과 해결과정
[수하물 데이터 로딩 시점에 대한 고민]

여정 상세 정보에 포함될 '수하물 규정'은 좌석 등급(cabinClass)과 노선 타입(routeType, 국내/국제)에 따라 달라지는 데이터
이 데이터를 언제 가져올지에 대해 고민

방법 1: 메인 검색 쿼리에 포함하기 (Join)

flights 테이블과 baggage_policy 테이블을 처음부터 조인해서 모든 검색 결과에 수하물 정보를 붙여서 가져오는 방식.

문제점: 검색 쿼리가 이미 복잡한 상황에서, 상세 정보 데이터 추가시 더 어려워짐

(선택) 방법 2: 상세 보기 클릭 시 조회하기 (API 분리)

사용자가 '상세 보기'를 클릭했을 때, 해당 항공편의 정보로 별도 API를 호출하는 방식.

사용자가 모든 항공편의 상세 정보를 열어보지는 않으므로 클릭한것만 조회, 여정 상세 데이터 추가시 용이
<br>

### 🔗 관련 이슈
Closes #118 

<br>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Flight detail modal with journey view, baggage allowances, and policy (cancellation/change) display.
  * Public API endpoint to fetch flight details by cabin class and route type.

* **Improvements**
  * Search results now include terminal number and route type.
  * Client UI: per-result detail opening, async detail loading, responsive modal styling, and new assets.
  * Public search access broadened to include subpaths.

* **Bug Fixes**
  * Minor formatting cleanup in search logic.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->