### PR TITLE
[FLYW-57] 회원 탈퇴 시 개인정보 익명화 처리 구현

### DIFF
--- a/src/main/java/com/flyway/template/exception/ErrorCode.java
+++ b/src/main/java/com/flyway/template/exception/ErrorCode.java
@@ -30,6 +30,7 @@ public enum ErrorCode {
 	USER_DB_ERROR(500, "U007", "회원 정보 저장 중 오류가 발생했습니다."),
 	USER_INVALID_SIGN_UP_ATTEMPT(400, "U008", "유효하지 않은 회원가입 요청입니다."),
 	USER_ALREADY_WITHDRAWN(409, "U009", "이미 탈퇴 처리된 사용자입니다."),
+	USER_NOT_WITHDRAWN(409, "U010","탈퇴 처리된 사용자만 익명화할 수 있습니다."),
 	USER_INTERNAL_ERROR(500, "U999", "회원 처리 중 알 수 없는 오류가 발생했습니다."),
 
 	// ==================== 인증 (AU) ====================

--- a/src/main/java/com/flyway/user/mapper/UserIdentityMapper.java
+++ b/src/main/java/com/flyway/user/mapper/UserIdentityMapper.java
@@ -24,4 +24,10 @@ public interface UserIdentityMapper {
             @Param("provider") AuthProvider provider,
             @Param("providerUserId") String providerUserId
     );
+
+    /**
+     * EMAIL 가입자의 provider_user_id(이메일) 익명화
+     */
+    int anonymizeEmailProviderUserIdIfWithdrawn(@Param("userId") String userId,
+                                                @Param("anonymizedEmail") String anonymizedEmail);
 }

--- a/src/main/java/com/flyway/user/mapper/UserMapper.java
+++ b/src/main/java/com/flyway/user/mapper/UserMapper.java
@@ -45,4 +45,10 @@ public interface UserMapper {
      */
     int markWithdrawn(@Param("userId") String userId,
                       @Param("now") LocalDateTime now);
+
+    /**
+     * users.email 이메일 익명화
+     */
+    int anonymizeEmailIfWithdrawn(@Param("userId") String userId,
+                                  @Param("anonymizedEmail") String anonymizedEmail);
 }

--- a/src/main/java/com/flyway/user/mapper/UserProfileMapper.java
+++ b/src/main/java/com/flyway/user/mapper/UserProfileMapper.java
@@ -26,5 +26,5 @@ public interface UserProfileMapper {
     /**
      * user_profile 개인정보 NULL 처리
      */
-    int nullifyProfileIfWithdrawn(@Param("userId") String userId);
+    int nullifyProfileIfWithdrawn(@Param("userId") String userId, @Param("maskedName") String maskedName);
 }

--- a/src/main/java/com/flyway/user/mapper/UserProfileMapper.java
+++ b/src/main/java/com/flyway/user/mapper/UserProfileMapper.java
@@ -22,4 +22,9 @@ public interface UserProfileMapper {
      * 프로필 업데이트 (동적 SQL, null이 아닌 필드만 업데이트)
      */
     void updateProfile(UserProfile profile);
+
+    /**
+     * user_profile 개인정보 NULL 처리
+     */
+    int nullifyProfileIfWithdrawn(@Param("userId") String userId);
 }

--- a/src/main/java/com/flyway/user/repository/UserIdentityRepository.java
+++ b/src/main/java/com/flyway/user/repository/UserIdentityRepository.java
@@ -2,6 +2,7 @@ package com.flyway.user.repository;
 
 import com.flyway.auth.domain.AuthProvider;
 import com.flyway.user.domain.UserIdentity;
+import org.apache.ibatis.annotations.Param;
 
 public interface UserIdentityRepository {
 
@@ -23,4 +24,9 @@ public interface UserIdentityRepository {
      * provider가 EMAIL인 사용자 중 이메일 중복 여부 확인
      */
     boolean existsEmailIdentity(String email);
+
+    /**
+     * EMAIL 가입자의 provider_user_id(이메일) 익명화
+     */
+    int anonymizeEmailProviderUserIdIfWithdrawn(String userId, String anonymizedEmail);
 }

--- a/src/main/java/com/flyway/user/repository/UserIdentityRepositoryImpl.java
+++ b/src/main/java/com/flyway/user/repository/UserIdentityRepositoryImpl.java
@@ -26,4 +26,9 @@ public class UserIdentityRepositoryImpl implements UserIdentityRepository {
     public boolean existsEmailIdentity(String email) {
         return userIdentityMapper.existsEmailIdentity(email);
     }
+
+    @Override
+    public int anonymizeEmailProviderUserIdIfWithdrawn(String userId, String anonymizedEmail) {
+        return userIdentityMapper.anonymizeEmailProviderUserIdIfWithdrawn(userId, anonymizedEmail);
+    }
 }

--- a/src/main/java/com/flyway/user/repository/UserProfileRepository.java
+++ b/src/main/java/com/flyway/user/repository/UserProfileRepository.java
@@ -1,6 +1,7 @@
 package com.flyway.user.repository;
 
 import com.flyway.user.domain.UserProfile;
+import org.apache.ibatis.annotations.Param;
 
 public interface UserProfileRepository {
 
@@ -19,4 +20,9 @@ public interface UserProfileRepository {
      * - null이 아닌 필드만 업데이트
      */
     void updateProfile(UserProfile profile);
+
+    /**
+     * user_profile 개인정보 NULL 처리
+     */
+    int nullifyProfileIfWithdrawn(String userId);
 }

--- a/src/main/java/com/flyway/user/repository/UserProfileRepository.java
+++ b/src/main/java/com/flyway/user/repository/UserProfileRepository.java
@@ -1,7 +1,6 @@
 package com.flyway.user.repository;
 
 import com.flyway.user.domain.UserProfile;
-import org.apache.ibatis.annotations.Param;
 
 public interface UserProfileRepository {
 
@@ -24,5 +23,5 @@ public interface UserProfileRepository {
     /**
      * user_profile 개인정보 NULL 처리
      */
-    int nullifyProfileIfWithdrawn(String userId);
+    int nullifyProfileIfWithdrawn(String userId, String maskedName);
 }

--- a/src/main/java/com/flyway/user/repository/UserProfileRepositoryImpl.java
+++ b/src/main/java/com/flyway/user/repository/UserProfileRepositoryImpl.java
@@ -27,7 +27,7 @@ public class UserProfileRepositoryImpl implements UserProfileRepository {
     }
 
     @Override
-    public int nullifyProfileIfWithdrawn(String userId) {
-        return userProfileMapper.nullifyProfileIfWithdrawn(userId);
+    public int nullifyProfileIfWithdrawn(String userId, String maskedName) {
+        return userProfileMapper.nullifyProfileIfWithdrawn(userId, maskedName);
     }
 }

--- a/src/main/java/com/flyway/user/repository/UserProfileRepositoryImpl.java
+++ b/src/main/java/com/flyway/user/repository/UserProfileRepositoryImpl.java
@@ -25,4 +25,9 @@ public class UserProfileRepositoryImpl implements UserProfileRepository {
     public void updateProfile(UserProfile profile) {
         userProfileMapper.updateProfile(profile);
     }
+
+    @Override
+    public int nullifyProfileIfWithdrawn(String userId) {
+        return userProfileMapper.nullifyProfileIfWithdrawn(userId);
+    }
 }

--- a/src/main/java/com/flyway/user/repository/UserRepository.java
+++ b/src/main/java/com/flyway/user/repository/UserRepository.java
@@ -2,6 +2,7 @@ package com.flyway.user.repository;
 
 import com.flyway.auth.domain.AuthStatus;
 import com.flyway.user.domain.User;
+import org.apache.ibatis.annotations.Param;
 
 import java.time.LocalDateTime;
 
@@ -36,4 +37,10 @@ public interface UserRepository {
      * 사용자 탈퇴 처리
      */
     int markWithdrawn(String userId, LocalDateTime now);
+
+    /**
+     * users.email 익명화
+     */
+    int anonymizeEmailIfWithdrawn(@Param("userId") String userId,
+                                  @Param("anonymizedEmail") String anonymizedEmail);
 }

--- a/src/main/java/com/flyway/user/repository/UserRepositoryImpl.java
+++ b/src/main/java/com/flyway/user/repository/UserRepositoryImpl.java
@@ -39,4 +39,9 @@ public class UserRepositoryImpl implements UserRepository {
 
     @Override
     public int markWithdrawn(String userId, LocalDateTime now) { return userMapper.markWithdrawn(userId, now); }
+
+    @Override
+    public int anonymizeEmailIfWithdrawn(String userId, String anonymizedEmail) {
+        return userMapper.anonymizeEmailIfWithdrawn(userId, anonymizedEmail);
+    }
 }

--- a/src/main/java/com/flyway/user/service/UserWithdrawalService.java
+++ b/src/main/java/com/flyway/user/service/UserWithdrawalService.java
@@ -11,4 +11,8 @@ public interface UserWithdrawalService {
      */
     void withdraw(String userId, LocalDateTime now, HttpServletRequest request, HttpServletResponse response);
 
+    /**
+     * 회원 정보 익명화
+     */
+    void anonymizeWithdrawnUser(String userId);
 }

--- a/src/main/java/com/flyway/user/service/UserWithdrawalServiceImpl.java
+++ b/src/main/java/com/flyway/user/service/UserWithdrawalServiceImpl.java
@@ -3,6 +3,8 @@ package com.flyway.user.service;
 import com.flyway.auth.service.AuthTokenService;
 import com.flyway.template.exception.BusinessException;
 import com.flyway.template.exception.ErrorCode;
+import com.flyway.user.repository.UserIdentityRepository;
+import com.flyway.user.repository.UserProfileRepository;
 import com.flyway.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -19,7 +21,11 @@ import java.time.LocalDateTime;
 public class UserWithdrawalServiceImpl implements UserWithdrawalService {
 
     private final UserRepository userRepository;
+    private final UserIdentityRepository userIdentityRepository;
+    private final UserProfileRepository userProfileRepository;
     private final AuthTokenService authTokenService;
+
+    private static final String DELETED_EMAIL_DOMAIN = "@deleted.local";
 
     @Override
     @Transactional
@@ -34,6 +40,31 @@ public class UserWithdrawalServiceImpl implements UserWithdrawalService {
         SecurityContextHolder.clearContext();
 
         authTokenService.revokeAllRefreshTokens(userId, now);
+
+        anonymizeWithdrawnUser(userId);
         authTokenService.logout(request, response);
+    }
+
+    @Override
+    @Transactional
+    public void anonymizeWithdrawnUser(String userId) {
+        String anonymizedEmail = "withdrawn_" + userId + DELETED_EMAIL_DOMAIN;
+
+        int usersUpdated = userRepository.anonymizeEmailIfWithdrawn(userId, anonymizedEmail);
+
+        if (usersUpdated == 0) {
+            throw new BusinessException(ErrorCode.USER_NOT_WITHDRAWN);
+        }
+
+        String userName = userProfileRepository.findByUserId(userId).getName();
+        userIdentityRepository.anonymizeEmailProviderUserIdIfWithdrawn(userId, anonymizedEmail);
+        userProfileRepository.nullifyProfileIfWithdrawn(userId, maskName(userName));
+    }
+
+    private String maskName(String name) {
+        if (name == null || name.isBlank()) return null;
+        if (name.length() == 1) return "*";
+        if (name.length() == 2) return name.charAt(0) + "*";
+        return "" + name.charAt(0) + "*".repeat(name.length() - 2) + name.charAt(name.length() - 1);
     }
 }

--- a/src/main/resources/mapper/user/UserIdentityMapper.xml
+++ b/src/main/resources/mapper/user/UserIdentityMapper.xml
@@ -39,4 +39,15 @@
           AND provider_user_id = #{providerUserId}
     </select>
 
+    <!-- EMAIL 가입자의 provider_user_id(이메일) 익명화 -->
+    <update id="anonymizeEmailProviderUserIdIfWithdrawn">
+        UPDATE user_identity ui
+            JOIN users u ON u.user_id = ui.user_id
+        SET ui.provider_user_id = #{anonymizedEmail}
+        WHERE ui.user_id = #{userId}
+          AND ui.provider = 'EMAIL'
+          AND u.status = 'WITHDRAWN'
+    </update>
+
+
 </mapper>

--- a/src/main/resources/mapper/user/UserMapper.xml
+++ b/src/main/resources/mapper/user/UserMapper.xml
@@ -49,26 +49,34 @@
 
 
     <!-- 이메일 업데이트 (OAuth 온보딩에서 이메일 입력 완료 시) -->
-    <update id="updateEmail" parameterType="map">
+    <update id="updateEmail">
         UPDATE users
         SET email = #{email}
         WHERE user_id = #{userId}
     </update>
 
     <!-- 상태 변경 -->
-    <update id="updateStatus" parameterType="map">
+    <update id="updateStatus">
         UPDATE users
         SET status = #{status}
         WHERE user_id = #{userId}
     </update>
 
     <!-- 사용자 탈퇴 처리 -->
-    <update id="markWithdrawn" parameterType="map">
+    <update id="markWithdrawn">
         UPDATE users
         SET status = 'WITHDRAWN',
         withdrawn_at = #{now}
         WHERE user_id = #{userId}
         AND status != 'WITHDRAWN'
+    </update>
+
+    <!-- users.email 익명화 -->
+    <update id="anonymizeEmailIfWithdrawn">
+        UPDATE users
+        SET email = #{anonymizedEmail}
+        WHERE user_id = #{userId}
+          AND status = 'WITHDRAWN'
     </update>
 
 </mapper>

--- a/src/main/resources/mapper/user/UserProfileMapper.xml
+++ b/src/main/resources/mapper/user/UserProfileMapper.xml
@@ -43,4 +43,17 @@
         WHERE user_id = #{userId}
     </update>
 
+    <!-- user_profile 개인정보 NULL 처리 -->
+    <update id="nullifyProfileIfWithdrawn">
+        UPDATE user_profile up
+            JOIN users u ON u.user_id = up.user_id
+        SET
+            up.passport_no = NULL,
+            up.first_name  = NULL,
+            up.last_name   = NULL,
+            up.name        = NULL
+        WHERE up.user_id = #{userId}
+          AND u.status = 'WITHDRAWN'
+    </update>
+
 </mapper>

--- a/src/main/resources/mapper/user/UserProfileMapper.xml
+++ b/src/main/resources/mapper/user/UserProfileMapper.xml
@@ -51,7 +51,7 @@
             up.passport_no = NULL,
             up.first_name  = NULL,
             up.last_name   = NULL,
-            up.name        = NULL
+            up.name        = #{maskedName}
         WHERE up.user_id = #{userId}
           AND u.status = 'WITHDRAWN'
     </update>

--- a/src/main/webapp/WEB-INF/views/mypage.jsp
+++ b/src/main/webapp/WEB-INF/views/mypage.jsp
@@ -5,10 +5,13 @@
 <head>
     <meta charset="UTF-8">
     <title>마이페이지</title>
+    <link rel="stylesheet" href="${pageContext.request.contextPath}/resources/common/css/base.css">
     <link rel="stylesheet"
           href="${pageContext.request.contextPath}/resources/user/mypage.css">
 </head>
 <body>
+
+<%@ include file="/WEB-INF/views/common/header.jsp" %>
 
 <div class="mypage-container">
     <h2>내 프로필</h2>

--- a/src/main/webapp/resources/user/mypage.css
+++ b/src/main/webapp/resources/user/mypage.css
@@ -1,5 +1,5 @@
-body { font-family: 'Malgun Gothic', sans-serif; background-color: #f0f2f5; display: flex; justify-content: center; align-items: center; min-height: 100vh; margin: 0; }
-.mypage-container { background: white; padding: 40px; border-radius: 12px; shadow: 0 8px 20px rgba(0,0,0,0.1); width: 450px; box-shadow: 0 4px 15px rgba(0,0,0,0.1); }
+body { font-family: 'Malgun Gothic', sans-serif; display: flex; flex-direction: column; align-items: stretch; min-height: 100vh; background-color: #f0f2f5; margin: 0; }
+.mypage-container {  margin: 40px auto 80px; background: white; padding: 40px; border-radius: 12px; shadow: 0 8px 20px rgba(0,0,0,0.1); width: 450px; box-shadow: 0 4px 15px rgba(0,0,0,0.1); }
 h2 { text-align: center; color: #333; margin-bottom: 30px; border-bottom: 2px solid #007bff; padding-bottom: 10px; }
 
 .info-row { display: flex; justify-content: space-between; padding: 15px 0; border-bottom: 1px solid #eee; }

--- a/src/main/webapp/resources/user/mypage.css
+++ b/src/main/webapp/resources/user/mypage.css
@@ -1,5 +1,5 @@
 body { font-family: 'Malgun Gothic', sans-serif; display: flex; flex-direction: column; align-items: stretch; min-height: 100vh; background-color: #f0f2f5; margin: 0; }
-.mypage-container {  margin: 40px auto 80px; background: white; padding: 40px; border-radius: 12px; shadow: 0 8px 20px rgba(0,0,0,0.1); width: 450px; box-shadow: 0 4px 15px rgba(0,0,0,0.1); }
+.mypage-container {  margin: 40px auto 80px; background: white; padding: 40px; border-radius: 12px; width: 450px; box-shadow: 0 4px 15px rgba(0,0,0,0.1); }
 h2 { text-align: center; color: #333; margin-bottom: 30px; border-bottom: 2px solid #007bff; padding-bottom: 10px; }
 
 .info-row { display: flex; justify-content: space-between; padding: 15px 0; border-bottom: 1px solid #eee; }


### PR DESCRIPTION
## 📌 PR 설명
회원 탈퇴 시 개인 정보를 익명화 처리하는 로직을 추가하였습니다.
### 개인정보 익명화 정책
- **users**
  - `email` → `withdrawn_{userId}@deleted.local`
- **user_identity**
  - `provider_user_id` → `withdrawn_{userId}@deleted.local`
- **user_profile**
  - `name` → 마스킹 처리
  - `first_name`, `last_name`, `passport_no` → `NULL` 처리

<br>

## ✅ 완료한 기능 명세
- [x] 탈퇴 회원 `users.email` 익명화 처리
- [x] EMAIL 가입자의 `user_identity.provider_user_id` 익명화 처리
- [x] `user_profile` 개인정보 마스킹/NULL 처리

<br>

## 📸 스크린샷
- 이름 마스킹 처리, 개인정보 NULL 처리
    <img width="693" height="31" alt="image" src="https://github.com/user-attachments/assets/2de03b0b-8b68-452a-99a3-9833e8692240" />
- 이메일, provider_id 값 변경 (withdrawn_{userId}@deleted.local)
    <img width="618" height="53" alt="image" src="https://github.com/user-attachments/assets/9eccf63b-ce0d-4ae0-8988-ff8b672ae642" />
    <img width="332" height="63" alt="image" src="https://github.com/user-attachments/assets/b110e50c-6151-4b59-a4be-b416e16c855d" />


<br>



### 🔗 관련 이슈
Closes #23

<br>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic anonymization for withdrawn accounts: emails anonymized and sensitive profile fields masked; new public anonymization flow added.
* **Behavior**
  * Clearer error when trying to anonymize a non-withdrawn account.
* **UI Updates**
  * My Page layout and styling refreshed; common header and base stylesheet included for consistent presentation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->