### PR TITLE
FLYW-83 fix: 좌석 잔여석 차감, 동시성제어 

### DIFF
--- a/src/main/java/com/flyway/reservation/dto/FlightInfoView.java
+++ b/src/main/java/com/flyway/reservation/dto/FlightInfoView.java
@@ -1,0 +1,17 @@
+package com.flyway.reservation.dto;
+
+import lombok.*;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class FlightInfoView {
+
+    private String flightInfoId;
+    private String flightId;
+    private Integer firstClassSeat;
+    private Integer businessClassSeat;
+    private Integer economyClassSeat;
+}

--- a/src/main/java/com/flyway/reservation/mapper/ReservationDraftMapper.java
+++ b/src/main/java/com/flyway/reservation/mapper/ReservationDraftMapper.java
@@ -1,6 +1,7 @@
 package com.flyway.reservation.mapper;
 
 import com.flyway.reservation.domain.FlightSnapshot;
+import com.flyway.reservation.dto.FlightInfoView;
 import com.flyway.reservation.dto.ReservationInsertDTO;
 import com.flyway.reservation.dto.ReservationSegmentInsertDTO;
 import org.apache.ibatis.annotations.Mapper;
@@ -16,5 +17,12 @@ public interface ReservationDraftMapper {
     int insertReservation(ReservationInsertDTO param);
 
     int insertReservationSegment(ReservationSegmentInsertDTO param);
+
+    FlightInfoView lockFlightInfoForUpdate(@Param("flightId") String flightId);
+
+    int decrementSeat(@Param("flightId") String flightId,
+                      @Param("cabinClass") String cabinClass,
+                      @Param("count") int count);
+
 
 }

--- a/src/main/java/com/flyway/reservation/repository/ReservationDraftRepository.java
+++ b/src/main/java/com/flyway/reservation/repository/ReservationDraftRepository.java
@@ -20,6 +20,6 @@ public interface ReservationDraftRepository {
     // 잔여석 처리
     FlightInfoView lockFlightInfoForUpdate(String flightId);
 
-    void decrementSeat(String flightId, String cabinClass, int count);
+    int decrementSeat(String flightId, String cabinClass, int count);
 
 }

--- a/src/main/java/com/flyway/reservation/repository/ReservationDraftRepository.java
+++ b/src/main/java/com/flyway/reservation/repository/ReservationDraftRepository.java
@@ -1,6 +1,7 @@
 package com.flyway.reservation.repository;
 
 import com.flyway.reservation.domain.FlightSnapshot;
+import com.flyway.reservation.dto.FlightInfoView;
 import com.flyway.reservation.dto.ReservationInsertDTO;
 import com.flyway.reservation.dto.ReservationSegmentInsertDTO;
 import org.apache.ibatis.annotations.Param;
@@ -15,5 +16,10 @@ public interface ReservationDraftRepository {
     void saveReservation(ReservationInsertDTO param);
 
     void saveReservationSegment(ReservationSegmentInsertDTO param);
+
+    // 잔여석 처리
+    FlightInfoView lockFlightInfoForUpdate(String flightId);
+
+    void decrementSeat(String flightId, String cabinClass, int count);
 
 }

--- a/src/main/java/com/flyway/reservation/repository/ReservationDraftRepositoryImpl.java
+++ b/src/main/java/com/flyway/reservation/repository/ReservationDraftRepositoryImpl.java
@@ -1,6 +1,7 @@
 package com.flyway.reservation.repository;
 
 import com.flyway.reservation.domain.FlightSnapshot;
+import com.flyway.reservation.dto.FlightInfoView;
 import com.flyway.reservation.dto.ReservationInsertDTO;
 import com.flyway.reservation.dto.ReservationSegmentInsertDTO;
 import com.flyway.reservation.mapper.ReservationDraftMapper;
@@ -28,5 +29,13 @@ public class ReservationDraftRepositoryImpl implements ReservationDraftRepositor
     @Override
     public void saveReservationSegment(ReservationSegmentInsertDTO param) {
         draftMapper.insertReservationSegment(param);
+    }
+    @Override
+    public FlightInfoView lockFlightInfoForUpdate(String flightId) {
+        return draftMapper.lockFlightInfoForUpdate(flightId);
+    }
+    @Override
+    public void decrementSeat(String flightId, String cabinClassCode, int count) {
+        draftMapper.decrementSeat(flightId, cabinClassCode, count);
     }
 }

--- a/src/main/java/com/flyway/reservation/repository/ReservationDraftRepositoryImpl.java
+++ b/src/main/java/com/flyway/reservation/repository/ReservationDraftRepositoryImpl.java
@@ -35,7 +35,7 @@ public class ReservationDraftRepositoryImpl implements ReservationDraftRepositor
         return draftMapper.lockFlightInfoForUpdate(flightId);
     }
     @Override
-    public void decrementSeat(String flightId, String cabinClassCode, int count) {
-        draftMapper.decrementSeat(flightId, cabinClassCode, count);
+    public int decrementSeat(String flightId, String cabinClassCode, int count) {
+        return draftMapper.decrementSeat(flightId, cabinClassCode, count);
     }
 }

--- a/src/main/java/com/flyway/reservation/service/PassengerServiceService.java
+++ b/src/main/java/com/flyway/reservation/service/PassengerServiceService.java
@@ -24,7 +24,7 @@ public class PassengerServiceService {
 
     private final PassengerServiceRepository serviceRepository;
     private final ReservationBookingRepository bookingRepository;
-    private ObjectMapper objectMapper;
+    private final ObjectMapper objectMapper = new  ObjectMapper();
 
     @Transactional(readOnly = true)
     public ServicePopupViewModel getServicePopup(String reservationId, String userId) {

--- a/src/main/java/com/flyway/reservation/service/ReservationDraftService.java
+++ b/src/main/java/com/flyway/reservation/service/ReservationDraftService.java
@@ -48,7 +48,11 @@ public class ReservationDraftService {
             throw new IllegalStateException("잔여석 부족 (가는편): 남은 좌석 " + outRemaining + "석");
         }
 
-        draftRepository.decrementSeat(req.getOutFlightId(), req.getCabinClassCode(), req.getPassengerCount());
+        int outUpdated = draftRepository.decrementSeat(req.getOutFlightId(), req.getCabinClassCode(),
+                req.getPassengerCount());
+        if (outUpdated == 0) {
+            throw new IllegalStateException("잔여석 차감 실패 (가는편): 좌석 부족 또는 유효하지 않은 좌석등급");
+        }
 
         // ========== 잔여석 처리 (오는편 - 왕복인 경우) ==========
         if (isRoundTrip) {
@@ -62,7 +66,11 @@ public class ReservationDraftService {
                 throw new IllegalStateException("잔여석 부족 (오는편): 남은 좌석 " + inRemaining + "석");
             }
 
-            draftRepository.decrementSeat(req.getInFlightId(), req.getCabinClassCode(), req.getPassengerCount());
+            int inUpdated = draftRepository.decrementSeat(req.getInFlightId(), req.getCabinClassCode(),
+                    req.getPassengerCount());
+            if (inUpdated == 0) {
+                throw new IllegalStateException("잔여석 차감 실패 (오는편): 좌석 부족 또는 유효하지 않은 좌석등급");
+            }
         }
 
         // ========== 예약 생성 ==========

--- a/src/main/java/com/flyway/reservation/service/ReservationDraftService.java
+++ b/src/main/java/com/flyway/reservation/service/ReservationDraftService.java
@@ -1,6 +1,7 @@
 package com.flyway.reservation.service;
 
 import com.flyway.reservation.domain.FlightSnapshot;
+import com.flyway.reservation.dto.FlightInfoView;
 import com.flyway.reservation.dto.ReservationInsertDTO;
 import com.flyway.reservation.dto.ReservationSegmentInsertDTO;
 import com.flyway.reservation.repository.ReservationDraftRepository;
@@ -22,6 +23,7 @@ public class ReservationDraftService {
     @Transactional
     public String createDraft(String userId, DraftCreateRequest req) {
 
+        // 기본 검증
         if (req.getOutFlightId() == null || req.getOutFlightId().isBlank()) {
             throw new IllegalArgumentException("outFlightId is required");
         }
@@ -35,6 +37,35 @@ public class ReservationDraftService {
         boolean isRoundTrip = (req.getInFlightId() != null && !req.getInFlightId().isBlank());
         String tripType = isRoundTrip ? "1" : "0";
 
+        // ========== 잔여석 처리 (가는편) ==========
+        FlightInfoView outInfo = draftRepository.lockFlightInfoForUpdate(req.getOutFlightId());
+        if (outInfo == null) {
+            throw new IllegalArgumentException("flight_info not found: " + req.getOutFlightId());
+        }
+
+        int outRemaining = getSeatCount(outInfo, req.getCabinClassCode());
+        if (outRemaining < req.getPassengerCount()) {
+            throw new IllegalStateException("잔여석 부족 (가는편): 남은 좌석 " + outRemaining + "석");
+        }
+
+        draftRepository.decrementSeat(req.getOutFlightId(), req.getCabinClassCode(), req.getPassengerCount());
+
+        // ========== 잔여석 처리 (오는편 - 왕복인 경우) ==========
+        if (isRoundTrip) {
+            FlightInfoView inInfo = draftRepository.lockFlightInfoForUpdate(req.getInFlightId());
+            if (inInfo == null) {
+                throw new IllegalArgumentException("flight_info not found: " + req.getInFlightId());
+            }
+
+            int inRemaining = getSeatCount(inInfo, req.getCabinClassCode());
+            if (inRemaining < req.getPassengerCount()) {
+                throw new IllegalStateException("잔여석 부족 (오는편): 남은 좌석 " + inRemaining + "석");
+            }
+
+            draftRepository.decrementSeat(req.getInFlightId(), req.getCabinClassCode(), req.getPassengerCount());
+        }
+
+        // ========== 예약 생성 ==========
         String reservationId = UUID.randomUUID().toString();
         LocalDateTime now = LocalDateTime.now();
         LocalDateTime expiredAt = now.plusMinutes(10);
@@ -51,6 +82,7 @@ public class ReservationDraftService {
                         .build()
         );
 
+        // ========== 가는편 segment 저장 ==========
         FlightSnapshot outSnap = draftRepository.findFlightSnapshot(req.getOutFlightId());
         if (outSnap == null) {
             throw new IllegalArgumentException("outFlightId not found: " + req.getOutFlightId());
@@ -71,6 +103,7 @@ public class ReservationDraftService {
                         .build()
         );
 
+        // ========== 오는편 segment 저장 (왕복) ==========
         if (isRoundTrip) {
             FlightSnapshot inSnap = draftRepository.findFlightSnapshot(req.getInFlightId());
             if (inSnap == null) {
@@ -94,5 +127,16 @@ public class ReservationDraftService {
         }
 
         return reservationId;
+    }
+
+    // 좌석등급별 잔여석 조회 헬퍼
+    private int getSeatCount(FlightInfoView info, String cabinClass) {
+        switch (cabinClass) {
+            case "FST": return info.getFirstClassSeat() != null ? info.getFirstClassSeat() : 0;
+            case "BIZ": return info.getBusinessClassSeat() != null ? info.getBusinessClassSeat() : 0;
+            case "ECO": return info.getEconomyClassSeat() != null ? info.getEconomyClassSeat() : 0;
+            default: return 0;
+        }
+
     }
 }

--- a/src/main/resources/mapper/reservation/ReservationDraftMapper.xml
+++ b/src/main/resources/mapper/reservation/ReservationDraftMapper.xml
@@ -63,5 +63,29 @@
             #{snapCabinClassCode}
                  )
     </insert>
+    <!-- flight_info 행 락 (FOR UPDATE) -->
+    <select id="lockFlightInfoForUpdate" parameterType="string"
+            resultType="com.flyway.reservation.dto.FlightInfoView">
+        SELECT
+            flight_info_id AS flightInfoId,
+            flight_id AS flightId,
+            first_class_seat AS firstClassSeat,
+            business_class_seat AS businessClassSeat,
+            economy_class_seat AS economyClassSeat
+        FROM flight_info
+        WHERE flight_id = #{flightId}
+            FOR UPDATE
+    </select>
 
+    <!-- 잔여석 차감 -->
+    <update id="decrementSeat">
+    UPDATE flight_info
+    SET
+    <choose>
+        <when test="cabinClass == 'FST'">first_class_seat = first_class_seat - #{count}</when>
+        <when test="cabinClass == 'BIZ'">business_class_seat = business_class_seat - #{count}</when>
+        <when test="cabinClass == 'ECO'">economy_class_seat = economy_class_seat - #{count}</when>
+    </choose>
+    WHERE flight_id = #{flightId}
+    </update>
 </mapper>

--- a/src/main/resources/mapper/reservation/ReservationDraftMapper.xml
+++ b/src/main/resources/mapper/reservation/ReservationDraftMapper.xml
@@ -87,5 +87,12 @@
         <when test="cabinClass == 'ECO'">economy_class_seat = economy_class_seat - #{count}</when>
     </choose>
     WHERE flight_id = #{flightId}
+        AND
+        <choose>
+            <when test="cabinClass == 'FST'">first_class_seat &gt;= #{count}</when>
+            <when test="cabinClass == 'BIZ'">business_class_seat &gt;= #{count}</when>
+            <when test="cabinClass == 'ECO'">economy_class_seat &gt;= #{count}</when>
+            <otherwise>1 = 0</otherwise>
+        </choose>
     </update>
 </mapper>

--- a/src/main/webapp/WEB-INF/views/reservations/service-popup.jsp
+++ b/src/main/webapp/WEB-INF/views/reservations/service-popup.jsp
@@ -97,7 +97,7 @@
 
                         <select id="extraKg_${pax.passengerId}_${seg.reservationSegmentId}"
                                 onchange="calculateBaggagePrice()"
-                                data-saved-details="${savedBaggage.serviceDetails}">
+                                data-saved-details='${savedBaggage.serviceDetails}'>
                             <option value="0">0kg</option>
                             <option value="5">+5kg</option>
                             <option value="10">+10kg</option>
@@ -306,11 +306,11 @@
                     var parsed = JSON.parse(details);
                     var id = el.id;
                     if (id.startsWith('extraKg_')) {
-                        el.value = parsed.extraWeightKg || 0;
+                        el.value = parsed.extraKg || 0;
                         // 같은 승객/구간의 extraBags도 설정
                         var bagsId = id.replace('extraKg_', 'extraBags_');
                         var bagsEl = document.getElementById(bagsId);
-                        if (bagsEl) bagsEl.value = parsed.extraBagCount || 0;
+                        if (bagsEl) bagsEl.value = parsed.extraBags || 0;
                     }
                 } catch (e) {
                     console.error('Failed to parse serviceDetails', e);


### PR DESCRIPTION
## 📌 PR 설명
동의 페이지 이동 시 잔여석을 감소시켜 같은 좌석을 동시에 예약되는 현상을 방지함
이후에 스케쥴러를 통해 10분 동안 아무 변화 없는 예약의 경우 자동 삭제 도입 예정

## ✅ 완료한 기능 명세

- [x] 예약 초안 생성 시 잔여석 감소
- [x] 동시성 제어 구현 
- [x] 예외처리 수정


<br>

## 📸 스크린샷

<br>

## 💭 고민과 해결과정
결제 직전 동시성 제어 문제 -> 좌석 id 에 대한 락을 거는 것이 아닌 잔여석을 감소시키는 방법으로 해결

<br>

### 🔗 관련 이슈
Closes #37 

<br>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Prevents overbooking by locking and managing seat inventory during reservation creation.
  * Full support for round-trip reservations with seat checks and inventory updates for both legs.

* **Bug Fixes**
  * Fixed baggage popup data mapping so saved extra weight and bag counts restore correctly.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->