### PR TITLE
[FLYW-157] Kakao OAuth 회원 탈퇴 연동

### DIFF
--- a/src/main/java/com/flyway/auth/client/KakaoUnlinkClient.java
+++ b/src/main/java/com/flyway/auth/client/KakaoUnlinkClient.java
@@ -1,0 +1,49 @@
+package com.flyway.auth.client;
+
+import com.flyway.auth.config.KakaoProperties;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.*;
+import org.springframework.stereotype.Component;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestTemplate;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class KakaoUnlinkClient {
+
+    private static final String UNLINK_URL = "https://kapi.kakao.com/v1/user/unlink";
+
+    private final RestTemplate restTemplate = new RestTemplate();
+    private final KakaoProperties kakaoProperties;
+
+    /**
+     * Admin Key, kakaoUserId 통하여 카카오 연동 해제
+     */
+    public void unlinkByKakaoUserId(String kakaoUserId) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+        headers.set("Authorization", "KakaoAK " + kakaoProperties.getKakaoAdminKey());
+
+        MultiValueMap<String, String> body = new LinkedMultiValueMap<>();
+        body.add("target_id_type", "user_id");
+        body.add("target_id", kakaoUserId);
+
+        HttpEntity<MultiValueMap<String, String>> entity = new HttpEntity<>(body, headers);
+
+        ResponseEntity<String> res = restTemplate.exchange(
+                UNLINK_URL,
+                HttpMethod.POST,
+                entity,
+                String.class
+        );
+
+        if (!res.getStatusCode().is2xxSuccessful()) {
+            log.warn("kakao unlink failed. status={}, body={}", res.getStatusCode(), res.getBody());
+        } else {
+            log.info("kakao unlink success. kakaoUserId={}", kakaoUserId);
+        }
+    }
+}

--- a/src/main/java/com/flyway/auth/client/KakaoUnlinkClient.java
+++ b/src/main/java/com/flyway/auth/client/KakaoUnlinkClient.java
@@ -1,23 +1,28 @@
 package com.flyway.auth.client;
 
 import com.flyway.auth.config.KakaoProperties;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.*;
 import org.springframework.stereotype.Component;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestClientException;
+import org.springframework.web.client.RestClientResponseException;
 import org.springframework.web.client.RestTemplate;
 
 @Component
-@RequiredArgsConstructor
 @Slf4j
 public class KakaoUnlinkClient {
 
     private static final String UNLINK_URL = "https://kapi.kakao.com/v1/user/unlink";
 
-    private final RestTemplate restTemplate = new RestTemplate();
+    private final RestTemplate restTemplate;
     private final KakaoProperties kakaoProperties;
+
+    public KakaoUnlinkClient(RestTemplate externalApiRestTemplate, KakaoProperties kakaoProperties) {
+        this.restTemplate = externalApiRestTemplate;
+        this.kakaoProperties = kakaoProperties;
+    }
 
     /**
      * Admin Key, kakaoUserId 통하여 카카오 연동 해제
@@ -32,18 +37,24 @@ public class KakaoUnlinkClient {
         body.add("target_id", kakaoUserId);
 
         HttpEntity<MultiValueMap<String, String>> entity = new HttpEntity<>(body, headers);
+        try {
+            ResponseEntity<String> res = restTemplate.exchange(
+                    UNLINK_URL,
+                    HttpMethod.POST,
+                    entity,
+                    String.class
+            );
 
-        ResponseEntity<String> res = restTemplate.exchange(
-                UNLINK_URL,
-                HttpMethod.POST,
-                entity,
-                String.class
-        );
+            if (!res.getStatusCode().is2xxSuccessful()) {
+                log.warn("kakao unlink failed. status={}, body={}", res.getStatusCode(), res.getBody());
+            }
 
-        if (!res.getStatusCode().is2xxSuccessful()) {
-            log.warn("kakao unlink failed. status={}, body={}", res.getStatusCode(), res.getBody());
-        } else {
             log.info("kakao unlink success. kakaoUserId={}", kakaoUserId);
+        } catch (RestClientResponseException ex) {
+            log.warn("kakao unlink failed. status={}", ex.getRawStatusCode());
+        } catch (RestClientException ex) {
+            log.warn("kakao unlink failed. error={}", ex.getMessage(), ex);
         }
+
     }
 }

--- a/src/main/java/com/flyway/auth/config/KakaoProperties.java
+++ b/src/main/java/com/flyway/auth/config/KakaoProperties.java
@@ -16,4 +16,7 @@ public class KakaoProperties {
 
     @Value("${kakao.client-secret}")
     private String kakaoClientSecret;
+
+    @Value("${kakao.admin-key}")
+    private String kakaoAdminKey;
 }

--- a/src/main/java/com/flyway/auth/config/KakaoProperties.java
+++ b/src/main/java/com/flyway/auth/config/KakaoProperties.java
@@ -1,0 +1,19 @@
+package com.flyway.auth.config;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+@Component
+@Getter
+@Setter
+public class KakaoProperties {
+    @Value("${kakao.client-id}")
+    private String kakaoClientId;
+
+    @Value("${kakao.redirect-uri}")
+    private String kakaoRedirectUri;
+
+    @Value("${kakao.client-secret}")
+    private String kakaoClientSecret;
+}

--- a/src/main/java/com/flyway/auth/service/KakaoOAuthServiceImpl.java
+++ b/src/main/java/com/flyway/auth/service/KakaoOAuthServiceImpl.java
@@ -3,9 +3,7 @@ package com.flyway.auth.service;
 import com.flyway.auth.config.KakaoProperties;
 import com.flyway.auth.domain.KakaoToken;
 import com.flyway.auth.domain.KakaoUserInfo;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.*;
 import org.springframework.stereotype.Service;
 import org.springframework.util.LinkedMultiValueMap;
@@ -17,15 +15,18 @@ import java.nio.charset.StandardCharsets;
 
 @Slf4j
 @Service
-@RequiredArgsConstructor
 public class KakaoOAuthServiceImpl implements KakaoOAuthService {
     private static final String AUTHORIZE_URL = "https://kauth.kakao.com/oauth/authorize";
     private static final String TOKEN_URL = "https://kauth.kakao.com/oauth/token";
     private static final String USER_INFO_URL = "https://kapi.kakao.com/v2/user/me";
 
     private final KakaoProperties kakaoProperties;
+    private final RestTemplate restTemplate;
 
-    private final RestTemplate restTemplate = new RestTemplate();
+    public KakaoOAuthServiceImpl(KakaoProperties kakaoProperties, RestTemplate externalApiRestTemplate) {
+        this.kakaoProperties = kakaoProperties;
+        this.restTemplate = externalApiRestTemplate;
+    }
 
     public String buildAuthorizeUrl(String state) {
         String redirectUri = URLEncoder.encode(kakaoProperties.getKakaoRedirectUri(), StandardCharsets.UTF_8);

--- a/src/main/java/com/flyway/auth/service/KakaoOAuthServiceImpl.java
+++ b/src/main/java/com/flyway/auth/service/KakaoOAuthServiceImpl.java
@@ -1,7 +1,9 @@
 package com.flyway.auth.service;
 
+import com.flyway.auth.config.KakaoProperties;
 import com.flyway.auth.domain.KakaoToken;
 import com.flyway.auth.domain.KakaoUserInfo;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.*;
@@ -15,28 +17,22 @@ import java.nio.charset.StandardCharsets;
 
 @Slf4j
 @Service
+@RequiredArgsConstructor
 public class KakaoOAuthServiceImpl implements KakaoOAuthService {
     private static final String AUTHORIZE_URL = "https://kauth.kakao.com/oauth/authorize";
     private static final String TOKEN_URL = "https://kauth.kakao.com/oauth/token";
     private static final String USER_INFO_URL = "https://kapi.kakao.com/v2/user/me";
 
-    @Value("${kakao.client-id}")
-    private String kakaoClientId;
-
-    @Value("${kakao.redirect-uri}")
-    private String kakaoRedirectUri;
-
-    @Value("${kakao.client-secret}")
-    private String kakaoClientSecret;
+    private final KakaoProperties kakaoProperties;
 
     private final RestTemplate restTemplate = new RestTemplate();
 
     public String buildAuthorizeUrl(String state) {
-        String redirectUri = URLEncoder.encode(kakaoRedirectUri, StandardCharsets.UTF_8);
+        String redirectUri = URLEncoder.encode(kakaoProperties.getKakaoRedirectUri(), StandardCharsets.UTF_8);
         String encodedState = URLEncoder.encode(state, StandardCharsets.UTF_8);
         return AUTHORIZE_URL
                 + "?response_type=code"
-                + "&client_id=" + kakaoClientId
+                + "&client_id=" + kakaoProperties.getKakaoClientId()
                 + "&redirect_uri=" + redirectUri
                 + "&state=" + encodedState;
     }
@@ -47,9 +43,9 @@ public class KakaoOAuthServiceImpl implements KakaoOAuthService {
 
         MultiValueMap<String, String> body = new LinkedMultiValueMap<>();
         body.add("grant_type", "authorization_code");
-        body.add("client_id", kakaoClientId);
-        body.add("redirect_uri", kakaoRedirectUri);
-        body.add("client_secret", kakaoClientSecret);
+        body.add("client_id", kakaoProperties.getKakaoClientId());
+        body.add("redirect_uri", kakaoProperties.getKakaoRedirectUri());
+        body.add("client_secret", kakaoProperties.getKakaoClientSecret());
         body.add("code", code);
 
         HttpEntity<MultiValueMap<String, String>> request =

--- a/src/main/java/com/flyway/config/HttpClientConfig.java
+++ b/src/main/java/com/flyway/config/HttpClientConfig.java
@@ -1,0 +1,18 @@
+package com.flyway.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class HttpClientConfig {
+
+    @Bean
+    public RestTemplate externalApiRestTemplate() {
+        SimpleClientHttpRequestFactory factory = new SimpleClientHttpRequestFactory();
+        factory.setConnectTimeout(3000);
+        factory.setReadTimeout(5000);
+        return new RestTemplate(factory);
+    }
+}

--- a/src/main/java/com/flyway/user/mapper/UserIdentityMapper.java
+++ b/src/main/java/com/flyway/user/mapper/UserIdentityMapper.java
@@ -1,11 +1,9 @@
 package com.flyway.user.mapper;
 
-import com.flyway.user.domain.UserIdentity;
 import com.flyway.auth.domain.AuthProvider;
+import com.flyway.user.domain.UserIdentity;
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
-
-import java.util.List;
 
 @Mapper
 public interface UserIdentityMapper {
@@ -34,8 +32,9 @@ public interface UserIdentityMapper {
     );
 
     /**
-     * EMAIL 가입자의 provider_user_id(이메일) 익명화
+     * provider_user_id 익명화
      */
-    int anonymizeEmailProviderUserIdIfWithdrawn(@Param("userId") String userId,
-                                                @Param("anonymizedEmail") String anonymizedEmail);
+    int anonymizeProviderUserIdIfWithdrawn(@Param("userId") String userId,
+                                           @Param("provider") String provider,
+                                           @Param("anonymizedProviderUserId") String anonymizedProviderUserId);
 }

--- a/src/main/java/com/flyway/user/mapper/UserIdentityMapper.java
+++ b/src/main/java/com/flyway/user/mapper/UserIdentityMapper.java
@@ -21,7 +21,7 @@ public interface UserIdentityMapper {
     /**
      * userId로 인증 정보 조회
      */
-    UserIdentity findByUserId(String email);
+    UserIdentity findByUserId(@Param("userId") String userId);
 
     /**
      * provider + providerUserId로 인증 정보 조회 (OAuth 재로그인 시 기존 사용자 찾기)

--- a/src/main/java/com/flyway/user/mapper/UserIdentityMapper.java
+++ b/src/main/java/com/flyway/user/mapper/UserIdentityMapper.java
@@ -15,7 +15,15 @@ public interface UserIdentityMapper {
      */
     void insertIdentity(UserIdentity identity);
 
+    /**
+     * Email 가입 회원 중 중복 이메일 보유 회원 조회
+     */
     boolean existsEmailIdentity(@Param("email") String email);
+
+    /**
+     * userId로 인증 정보 조회
+     */
+    UserIdentity findByUserId(String email);
 
     /**
      * provider + providerUserId로 인증 정보 조회 (OAuth 재로그인 시 기존 사용자 찾기)

--- a/src/main/java/com/flyway/user/repository/UserIdentityRepository.java
+++ b/src/main/java/com/flyway/user/repository/UserIdentityRepository.java
@@ -12,6 +12,11 @@ public interface UserIdentityRepository {
     void save(UserIdentity identity);
 
     /**
+     * userId로 조회
+     */
+    UserIdentity findByUserId(String userId);
+
+    /**
      * (인증 제공자, 제공자 유저 ID)로 조회
      * (OAuth 재로그인 시 기존 사용자 식별)
      */

--- a/src/main/java/com/flyway/user/repository/UserIdentityRepository.java
+++ b/src/main/java/com/flyway/user/repository/UserIdentityRepository.java
@@ -33,5 +33,5 @@ public interface UserIdentityRepository {
     /**
      * EMAIL 가입자의 provider_user_id(이메일) 익명화
      */
-    int anonymizeEmailProviderUserIdIfWithdrawn(String userId, String anonymizedEmail);
+    int anonymizeProviderUserIdIfWithdrawn(String userId, AuthProvider provider, String anonymizedEmail);
 }

--- a/src/main/java/com/flyway/user/repository/UserIdentityRepositoryImpl.java
+++ b/src/main/java/com/flyway/user/repository/UserIdentityRepositoryImpl.java
@@ -18,6 +18,11 @@ public class UserIdentityRepositoryImpl implements UserIdentityRepository {
     }
 
     @Override
+    public UserIdentity findByUserId(String userId) {
+        return userIdentityMapper.findByUserId(userId);
+    }
+
+    @Override
     public UserIdentity findByProviderUserId(AuthProvider provider, String providerUserId) {
         return userIdentityMapper.findByProviderUserId(provider, providerUserId);
     }

--- a/src/main/java/com/flyway/user/repository/UserIdentityRepositoryImpl.java
+++ b/src/main/java/com/flyway/user/repository/UserIdentityRepositoryImpl.java
@@ -33,7 +33,7 @@ public class UserIdentityRepositoryImpl implements UserIdentityRepository {
     }
 
     @Override
-    public int anonymizeEmailProviderUserIdIfWithdrawn(String userId, String anonymizedEmail) {
-        return userIdentityMapper.anonymizeEmailProviderUserIdIfWithdrawn(userId, anonymizedEmail);
+    public int anonymizeProviderUserIdIfWithdrawn(String userId, AuthProvider provider, String anonymizedProviderUserId) {
+        return userIdentityMapper.anonymizeProviderUserIdIfWithdrawn(userId, provider.toString(), anonymizedProviderUserId);
     }
 }

--- a/src/main/java/com/flyway/user/service/UserWithdrawalServiceImpl.java
+++ b/src/main/java/com/flyway/user/service/UserWithdrawalServiceImpl.java
@@ -89,7 +89,11 @@ public class UserWithdrawalServiceImpl implements UserWithdrawalService {
             return;
         }
 
-        kakaoUnlinkClient.unlinkByKakaoUserId(kakaoUserId);
+        try {
+            kakaoUnlinkClient.unlinkByKakaoUserId(kakaoUserId);
+        } catch (Exception e) {
+            log.warn("kakao unlink failed; continuing withdrawal. userId={}", userId, e);
+        }
     }
 
     private String maskName(String name) {

--- a/src/main/java/com/flyway/user/service/UserWithdrawalServiceImpl.java
+++ b/src/main/java/com/flyway/user/service/UserWithdrawalServiceImpl.java
@@ -1,12 +1,16 @@
 package com.flyway.user.service;
 
+import com.flyway.auth.client.KakaoUnlinkClient;
+import com.flyway.auth.domain.AuthProvider;
 import com.flyway.auth.service.AuthTokenService;
 import com.flyway.template.exception.BusinessException;
 import com.flyway.template.exception.ErrorCode;
+import com.flyway.user.domain.UserIdentity;
 import com.flyway.user.repository.UserIdentityRepository;
 import com.flyway.user.repository.UserProfileRepository;
 import com.flyway.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -16,6 +20,7 @@ import javax.servlet.http.HttpServletResponse;
 import javax.servlet.http.HttpSession;
 import java.time.LocalDateTime;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class UserWithdrawalServiceImpl implements UserWithdrawalService {
@@ -24,41 +29,67 @@ public class UserWithdrawalServiceImpl implements UserWithdrawalService {
     private final UserIdentityRepository userIdentityRepository;
     private final UserProfileRepository userProfileRepository;
     private final AuthTokenService authTokenService;
-
-    private static final String DELETED_EMAIL_DOMAIN = "@deleted.local";
+    private final KakaoUnlinkClient kakaoUnlinkClient;
 
     @Override
     @Transactional
     public void withdraw(String userId, LocalDateTime now, HttpServletRequest request, HttpServletResponse response) {
+        /* 회원 상태 탈퇴로 변경 */
         int updated = userRepository.markWithdrawn(userId, now);
         if (updated == 0) {
             throw new BusinessException(ErrorCode.USER_ALREADY_WITHDRAWN);
         }
 
+        /* 세션, 컨텍스트 무효화 */
         HttpSession session = request.getSession(false);
         if (session != null) session.invalidate();
         SecurityContextHolder.clearContext();
 
+        /* Refresh Token 폐기 */
         authTokenService.revokeAllRefreshTokens(userId, now);
 
+        /* Kakao OAuth 회원의 경우 카카오 연동 해제 */
+        tryKakaoUnlink(userId);
+
+        /* 개인정보 익명화 처리 */
         anonymizeWithdrawnUser(userId);
+
+        /* 로그아웃 처리 */
         authTokenService.logout(request, response);
     }
 
     @Override
     @Transactional
     public void anonymizeWithdrawnUser(String userId) {
-        String anonymizedEmail = "withdrawn_" + userId + DELETED_EMAIL_DOMAIN;
+        AuthProvider provider = userIdentityRepository.findByUserId(userId).getProvider();
+        String anonymizedProviderUserId = "withdrawn_" + userId + "@deleted." + provider;
 
-        int usersUpdated = userRepository.anonymizeEmailIfWithdrawn(userId, anonymizedEmail);
+        int usersUpdated = userRepository.anonymizeEmailIfWithdrawn(userId, anonymizedProviderUserId);
 
         if (usersUpdated == 0) {
             throw new BusinessException(ErrorCode.USER_NOT_WITHDRAWN);
         }
 
         String userName = userProfileRepository.findByUserId(userId).getName();
-        userIdentityRepository.anonymizeEmailProviderUserIdIfWithdrawn(userId, anonymizedEmail);
+
+        /* 이름, provider_user_id 익명화  */
+        userIdentityRepository.anonymizeProviderUserIdIfWithdrawn(userId, provider, anonymizedProviderUserId);
         userProfileRepository.nullifyProfileIfWithdrawn(userId, maskName(userName));
+    }
+
+    private void tryKakaoUnlink(String userId) {
+        UserIdentity identity = userIdentityRepository.findByUserId(userId);
+        if (identity == null) return;
+
+        if (identity.getProvider() != AuthProvider.KAKAO) return;
+
+        String kakaoUserId = identity.getProviderUserId();
+        if (kakaoUserId == null || kakaoUserId.isBlank()) {
+            log.warn("kakao unlink skipped: providerUserId missing. userId={}", userId);
+            return;
+        }
+
+        kakaoUnlinkClient.unlinkByKakaoUserId(kakaoUserId);
     }
 
     private String maskName(String name) {

--- a/src/main/java/com/flyway/user/service/UserWithdrawalServiceImpl.java
+++ b/src/main/java/com/flyway/user/service/UserWithdrawalServiceImpl.java
@@ -96,6 +96,6 @@ public class UserWithdrawalServiceImpl implements UserWithdrawalService {
         if (name == null || name.isBlank()) return null;
         if (name.length() == 1) return "*";
         if (name.length() == 2) return name.charAt(0) + "*";
-        return "" + name.charAt(0) + "*".repeat(name.length() - 2) + name.charAt(name.length() - 1);
+        return name.charAt(0) + "*".repeat(name.length() - 2) + name.charAt(name.length() - 1);
     }
 }

--- a/src/main/resources/mapper/user/UserIdentityMapper.xml
+++ b/src/main/resources/mapper/user/UserIdentityMapper.xml
@@ -27,6 +27,17 @@
           AND provider_user_id = #{email}
     </select>
 
+    <!-- userId로 Identity 조회 -->
+    <select id="findByUserId" parameterType="map" resultType="com.flyway.user.domain.UserIdentity">
+        SELECT user_identity_id,
+               user_id,
+               provider,
+               provider_user_id,
+               created_at
+        FROM user_identity
+        WHERE user_id = #{userId}
+    </select>
+
     <!-- provider + provider_user_id 로 Identity 조회 (OAuth 재로그인 시 기존 회원 조회) -->
     <select id="findByProviderUserId" parameterType="map" resultType="com.flyway.user.domain.UserIdentity">
         SELECT user_identity_id,

--- a/src/main/resources/mapper/user/UserIdentityMapper.xml
+++ b/src/main/resources/mapper/user/UserIdentityMapper.xml
@@ -50,13 +50,13 @@
           AND provider_user_id = #{providerUserId}
     </select>
 
-    <!-- EMAIL 가입자의 provider_user_id(이메일) 익명화 -->
-    <update id="anonymizeEmailProviderUserIdIfWithdrawn">
+    <!-- provider_user_id 익명화 -->
+    <update id="anonymizeProviderUserIdIfWithdrawn">
         UPDATE user_identity ui
             JOIN users u ON u.user_id = ui.user_id
-        SET ui.provider_user_id = #{anonymizedEmail}
+        SET ui.provider_user_id = #{anonymizedProviderUserId}
         WHERE ui.user_id = #{userId}
-          AND ui.provider = 'EMAIL'
+          AND ui.provider = #{provider}
           AND u.status = 'WITHDRAWN'
     </update>
 

--- a/src/test/java/com/flyway/user/service/UserWithdrawalServiceImplTest.java
+++ b/src/test/java/com/flyway/user/service/UserWithdrawalServiceImplTest.java
@@ -1,0 +1,130 @@
+package com.flyway.user.service;
+
+import com.flyway.auth.client.KakaoUnlinkClient;
+import com.flyway.auth.domain.AuthProvider;
+import com.flyway.auth.service.AuthTokenService;
+import com.flyway.template.exception.BusinessException;
+import com.flyway.template.exception.ErrorCode;
+import com.flyway.user.domain.UserIdentity;
+import com.flyway.user.domain.UserProfile;
+import com.flyway.user.repository.UserIdentityRepository;
+import com.flyway.user.repository.UserProfileRepository;
+import com.flyway.user.repository.UserRepository;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.mock.web.MockHttpSession;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import java.time.LocalDateTime;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+class UserWithdrawalServiceImplTest {
+
+    private UserRepository userRepository;
+    private UserIdentityRepository userIdentityRepository;
+    private UserProfileRepository userProfileRepository;
+    private AuthTokenService authTokenService;
+    private KakaoUnlinkClient kakaoUnlinkClient;
+
+    private UserWithdrawalServiceImpl service;
+
+    @BeforeEach
+    void setUp() {
+        userRepository = mock(UserRepository.class);
+        userIdentityRepository = mock(UserIdentityRepository.class);
+        userProfileRepository = mock(UserProfileRepository.class);
+        authTokenService = mock(AuthTokenService.class);
+        kakaoUnlinkClient = mock(KakaoUnlinkClient.class);
+
+        service = new UserWithdrawalServiceImpl(
+                userRepository,
+                userIdentityRepository,
+                userProfileRepository,
+                authTokenService,
+                kakaoUnlinkClient
+        );
+    }
+
+    @AfterEach
+    void tearDown() {
+        SecurityContextHolder.clearContext();
+    }
+
+    @Test
+    @DisplayName("회원 탈퇴 시 카카오 연동 해제가 호출되고 개인정보가 익명화된다")
+    void withdraw_kakaoUser_unlinksAndAnonymizes() {
+        String userId = "user-1";
+        LocalDateTime now = LocalDateTime.now();
+
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        MockHttpSession session = (MockHttpSession) request.getSession(true);
+
+        SecurityContextHolder.getContext().setAuthentication(
+                new UsernamePasswordAuthenticationToken("user-1", "pw")
+        );
+
+        when(userRepository.markWithdrawn(userId, now)).thenReturn(1);
+
+        UserIdentity identity = UserIdentity.builder()
+                .userId(userId)
+                .provider(AuthProvider.KAKAO)
+                .providerUserId("12345")
+                .build();
+        when(userIdentityRepository.findByUserId(userId)).thenReturn(identity);
+
+        UserProfile profile = UserProfile.builder()
+                .userId(userId)
+                .name("Alice")
+                .build();
+        when(userProfileRepository.findByUserId(userId)).thenReturn(profile);
+
+        String anonymizedEmail = "withdrawn_user-1@deleted.KAKAO";
+        when(userRepository.anonymizeEmailIfWithdrawn(userId, anonymizedEmail)).thenReturn(1);
+        when(userIdentityRepository.anonymizeProviderUserIdIfWithdrawn(userId, AuthProvider.KAKAO, anonymizedEmail))
+                .thenReturn(1);
+        when(userProfileRepository.nullifyProfileIfWithdrawn(userId, "A***e")).thenReturn(1);
+
+        service.withdraw(userId, now, request, response);
+
+        assertTrue(session.isInvalid());
+        assertNull(SecurityContextHolder.getContext().getAuthentication());
+        verify(authTokenService).revokeAllRefreshTokens(userId, now);
+        verify(kakaoUnlinkClient).unlinkByKakaoUserId("12345");
+        verify(userRepository).anonymizeEmailIfWithdrawn(userId, anonymizedEmail);
+        verify(userIdentityRepository).anonymizeProviderUserIdIfWithdrawn(userId, AuthProvider.KAKAO, anonymizedEmail);
+        verify(userProfileRepository).nullifyProfileIfWithdrawn(userId, "A***e");
+        verify(authTokenService).logout(request, response);
+    }
+
+    @Test
+    @DisplayName("이미 탈퇴 처리된 사용자는 예외가 발생한다")
+    void withdraw_alreadyWithdrawn_throws() {
+        String userId = "user-1";
+        LocalDateTime now = LocalDateTime.now();
+
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        when(userRepository.markWithdrawn(userId, now)).thenReturn(0);
+
+        BusinessException exception = assertThrows(BusinessException.class,
+                () -> service.withdraw(userId, now, request, response));
+
+        assertEquals(ErrorCode.USER_ALREADY_WITHDRAWN, exception.getErrorCode());
+        verifyNoInteractions(userIdentityRepository, userProfileRepository, authTokenService, kakaoUnlinkClient);
+    }
+}


### PR DESCRIPTION
## 📌 PR 설명
탈퇴 시 Kakao OAuth 회원을 대상으로 카카오 연동 해제(unlink) 처리를 구현하였습니다.

`user_identity.provider_user_id` 익명화 로직을 EMAIL 전용 → provider 공통으로 확장했습니다.

<br>

## ✅ 완료한 기능 명세

- [x] Kakao 연동 해제 클라이언트 추가
  - [x] KakaoUnlinkClient 신규 생성
  - [x] Admin Key(kakao.admin-key) 기반으로 POST https://kapi.kakao.com/v1/user/unlink 호출
- [x] KakaoProperties 설정 확장
  - [x] kakao.admin-key 프로퍼티 추가
- [x] 탈퇴 처리 플로우 개선 (UserWithdrawalServiceImpl)
  - [x] Kakao OAuth 회원이면 카카오 unlink 시도(실패/누락 시 스킵 + 로그)
  - [x] 개인정보 익명화 수행 후 로그아웃 처리
- [x] user_identity.provider_user_id 익명화 로직 일반화
  - [x] Mapper/Repository 메서드명을 anonymizeProviderUserIdIfWithdrawn 로 변경
  - [x] withdrawn_{userId}@deleted.{provider} 형태로 이메일/ProviderUserId 익명화 값 생성


<br>

### 🔗 관련 이슈
Closes #144

<br>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Kakao unlink capability and automatic unlink during account withdrawal.
* **Enhancements**
  * Improved withdrawal anonymization to remove provider-specific identifiers and mask profiles; added lookup by user ID to support this flow.
  * External API client configuration added for reliable outbound calls.
* **Tests**
  * New tests covering withdrawal flows, Kakao unlink success, and duplicate-withdrawal handling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->