### PR TITLE
[FLYW-168] 예매페이지 가격 재조회

### DIFF
--- a/src/main/java/com/flyway/search/controller/FlightApiController.java
+++ b/src/main/java/com/flyway/search/controller/FlightApiController.java
@@ -3,6 +3,7 @@ package com.flyway.search.controller;
 import com.flyway.search.domain.*;
 import com.flyway.search.dto.FlightDetailDto;
 import com.flyway.search.dto.FlightSearchRequest;
+import com.flyway.search.dto.LastPriceDto;
 import com.flyway.search.dto.SearchResultDto;
 import com.flyway.search.service.FlightService;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -47,6 +48,11 @@ public class FlightApiController {
     @GetMapping("/api/public/flights/details")
     public FlightDetailDto details(@RequestParam String cabinClass, @RequestParam String routeType) {
         return service.details(cabinClass, routeType);
+    }
+
+    @GetMapping("/api/public/flights/prices")
+    public List<LastPriceDto> prices(@RequestParam String outFlightId, @RequestParam String inFlightId, @RequestParam String cabinClassCode) {
+        return service.findPrice(outFlightId, inFlightId, cabinClassCode);
     }
 
 }

--- a/src/main/java/com/flyway/search/dto/LastPriceDto.java
+++ b/src/main/java/com/flyway/search/dto/LastPriceDto.java
@@ -1,0 +1,10 @@
+package com.flyway.search.dto;
+
+import lombok.Data;
+
+@Data
+public class LastPriceDto {
+    private String flightId;
+    private String flightNumber;
+    private Long flightPrice;
+}

--- a/src/main/java/com/flyway/search/mapper/FlightMapper.java
+++ b/src/main/java/com/flyway/search/mapper/FlightMapper.java
@@ -4,6 +4,7 @@ import com.flyway.search.domain.*;
 import com.flyway.search.dto.FlightDetailDto;
 import com.flyway.search.dto.FlightSearchRequest;
 import com.flyway.search.dto.FlightSearchResponse;
+import com.flyway.search.dto.LastPriceDto;
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
 
@@ -18,4 +19,5 @@ public interface FlightMapper {
     List<FlightSearchResponse> outbound(FlightSearchRequest dto);
     List<FlightSearchResponse> inbound(FlightSearchRequest dto);
     FlightDetailDto details(@Param("cabinClass") String cabinClass, @Param("routeType") String routeType);
+    List<LastPriceDto> findPrice(@Param("outFlightId") String outFlightId, @Param("inFlightId") String inFlightId,@Param("cabinClassCode") String cabinClassCode);
 }

--- a/src/main/java/com/flyway/search/repository/FlightRepository.java
+++ b/src/main/java/com/flyway/search/repository/FlightRepository.java
@@ -6,7 +6,7 @@ import com.flyway.search.domain.Flight;
 import com.flyway.search.dto.FlightDetailDto;
 import com.flyway.search.dto.FlightSearchRequest;
 import com.flyway.search.dto.FlightSearchResponse;
-import com.flyway.search.mapper.FlightMapper;
+import com.flyway.search.dto.LastPriceDto;
 
 import java.util.List;
 
@@ -24,4 +24,6 @@ public interface FlightRepository {
     List<FlightSearchResponse> findInboundFlights(FlightSearchRequest dto);
 
     FlightDetailDto findDetails(String cabinClass, String routeType);
+
+    List<LastPriceDto> findPrice(String outFlightId, String inFlightId, String cabinClassCode);
 }

--- a/src/main/java/com/flyway/search/repository/FlightRepositoryImpl.java
+++ b/src/main/java/com/flyway/search/repository/FlightRepositoryImpl.java
@@ -6,6 +6,7 @@ import com.flyway.search.domain.Flight;
 import com.flyway.search.dto.FlightDetailDto;
 import com.flyway.search.dto.FlightSearchRequest;
 import com.flyway.search.dto.FlightSearchResponse;
+import com.flyway.search.dto.LastPriceDto;
 import com.flyway.search.mapper.FlightMapper;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
@@ -36,4 +37,8 @@ public class FlightRepositoryImpl implements FlightRepository {
     }
 
     public FlightDetailDto findDetails(String cabinClass, String routeType) { return mapper.details(cabinClass, routeType); }
+
+    public List<LastPriceDto> findPrice(String outFlightId, String inFlightId, String cabinClassCode) {
+        return mapper.findPrice(outFlightId, inFlightId, cabinClassCode);
+    }
 }

--- a/src/main/java/com/flyway/search/service/FlightService.java
+++ b/src/main/java/com/flyway/search/service/FlightService.java
@@ -3,6 +3,7 @@ package com.flyway.search.service;
 import com.flyway.search.domain.*;
 import com.flyway.search.dto.FlightDetailDto;
 import com.flyway.search.dto.FlightSearchRequest;
+import com.flyway.search.dto.LastPriceDto;
 import com.flyway.search.dto.SearchResultDto;
 
 import java.util.List;
@@ -14,4 +15,5 @@ public interface FlightService {
     List<Airline> airline(Airline vo);
     SearchResultDto search(FlightSearchRequest dto);
     FlightDetailDto details(String cabinClass, String routeType);
+    List<LastPriceDto> findPrice(String outFlightId, String inFlightId, String cabinClassCode);
 }

--- a/src/main/java/com/flyway/search/service/FlightServiceImpl.java
+++ b/src/main/java/com/flyway/search/service/FlightServiceImpl.java
@@ -140,10 +140,14 @@ public class FlightServiceImpl implements FlightService{
         LastPriceDto outFlight = prePrice.stream()
                 .filter(f -> f.getFlightId().equals(outFlightId))
                 .findFirst()
-                .orElse(prePrice.get(0));
+                .orElse(null);
+
+        if(outFlight == null) {
+            return prePrice;
+        }
 
         LastPriceDto inFlight = null;
-        if (prePrice.size() > 1) {
+        if (inFlightId != null && prePrice.size() > 1) {
             inFlight = prePrice.stream()
                     .filter(f -> f.getFlightId().equals(inFlightId))
                     .findFirst()

--- a/src/main/java/com/flyway/search/service/FlightServiceImpl.java
+++ b/src/main/java/com/flyway/search/service/FlightServiceImpl.java
@@ -125,4 +125,44 @@ public class FlightServiceImpl implements FlightService{
         if (a == null || b == null || a.length() < 2 || b.length() < 2) return false;
         return a.substring(0, 2).equalsIgnoreCase(b.substring(0, 2));
     }
+
+    // 예매 페이지 이동 시 가격 재조회
+    @Override
+    public List<LastPriceDto> findPrice(String outFlightId, String inFlightId, String cabinClassCode) {
+        List<LastPriceDto> prePrice = flightRepository.findPrice(outFlightId, inFlightId, cabinClassCode);
+
+
+        if (prePrice.isEmpty()) {
+            return prePrice;
+        }
+
+
+        LastPriceDto outFlight = prePrice.stream()
+                .filter(f -> f.getFlightId().equals(outFlightId))
+                .findFirst()
+                .orElse(prePrice.get(0));
+
+        LastPriceDto inFlight = null;
+        if (prePrice.size() > 1) {
+            inFlight = prePrice.stream()
+                    .filter(f -> f.getFlightId().equals(inFlightId))
+                    .findFirst()
+                    .orElse(null);
+        }
+
+        if (inFlight == null || !sameAirline(outFlight.getFlightNumber(), inFlight.getFlightNumber())) {
+            return prePrice;
+        }
+
+        double originalOut = outFlight.getFlightPrice();
+        double originalIn = inFlight.getFlightPrice();
+
+        double rawTotal = (originalOut + originalIn) * 10.0 / 14.0;
+        long totalPrice = (long) ((rawTotal + 500) / 1000) * 1000;
+
+        outFlight.setFlightPrice(totalPrice / 2);
+        inFlight.setFlightPrice(totalPrice / 2);
+
+        return prePrice;
+    }
 }

--- a/src/main/resources/mapper/flights/FlightsMapper.xml
+++ b/src/main/resources/mapper/flights/FlightsMapper.xml
@@ -137,7 +137,7 @@
     <select id="findPrice" resultType="com.flyway.search.dto.LastPriceDto">
         SELECT
             f.flight_id AS flightId,
-            f.flight_number AS flight_number,
+            f.flight_number AS flightNumber,
             fsp.current_price AS flightPrice
         FROM flight f
         JOIN flight_seat_price fsp

--- a/src/main/resources/mapper/flights/FlightsMapper.xml
+++ b/src/main/resources/mapper/flights/FlightsMapper.xml
@@ -133,4 +133,16 @@
         WHERE route_type = #{routeType} AND cabin_class_code = #{cabinClass}
     </select>
 
+    <!--    예약 가격 조회-->
+    <select id="findPrice" resultType="com.flyway.search.dto.LastPriceDto">
+        SELECT
+            f.flight_id AS flightId,
+            f.flight_number AS flight_number,
+            fsp.current_price AS flightPrice
+        FROM flight f
+        JOIN flight_seat_price fsp
+            ON f.flight_id = fsp.flight_id AND fsp.cabin_class_code = #{cabinClassCode}
+        WHERE f.flight_id IN (#{outFlightId}, #{inFlightId})
+    </select>
+
 </mapper>

--- a/src/main/webapp/WEB-INF/views/search/search.jsp
+++ b/src/main/webapp/WEB-INF/views/search/search.jsp
@@ -330,6 +330,8 @@
     <input type="hidden" name="inFlightId" id="hiddenInFlightId">
     <input type="hidden" name="passengerCount" id="hiddenPassengerCount">
     <input type="hidden" name="cabinClassCode" id="hiddenCabinClassCode">
+    <input type="hidden" name="outPrice" id="hiddenOutPrice">
+    <input type="hidden" name="inPrice" id="hiddenInPrice">
 </form>
 </body>
 </html>


### PR DESCRIPTION
## 📌 PR 설명
- 항공편 카드 클릭시 가격 재조회
- 가격 api로 넘겨주기
<br>

## ✅ 완료한 기능 명세

- [x] 예매페이지 이동 시 가격 재조회

<br>

### 🔗 관련 이슈
Closes #156 
<br>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Search now fetches per-flight prices on selection and auto-populates reservation price fields.
  * Reservation submissions include outbound/inbound prices (hidden) so totals carry through.

* **Behavior Changes**
  * Selection validates paired outbound/inbound flights and alerts if price data is missing.
  * Pricing for paired flights is normalized and split before submission.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->