### PR TITLE
[FLYW-132] batch-runner 독립 실행 환경 구축 및 스케줄러 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,6 +75,7 @@ $RECYCLE.BIN/
 
 # 기타 민감 정보
 **/application-dev.properties
+**/application-batch.properties
 **/application-secret.properties
 **/*-secret.properties
 

--- a/flyway-batch-runner/pom.xml
+++ b/flyway-batch-runner/pom.xml
@@ -1,0 +1,87 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.flyway</groupId>
+    <artifactId>flyway-batch-runner</artifactId>
+    <version>1.0.0</version>
+    <packaging>jar</packaging>
+
+    <properties>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <dependencies>
+        <!-- flyway(웹 프로젝트) classes.jar 의존 -->
+        <dependency>
+            <groupId>com.flyway</groupId>
+            <artifactId>flyway</artifactId>
+            <version>1.0-SNAPSHOT</version>
+            <classifier>classes</classifier>
+        </dependency>
+
+        <!-- runner 자체에 필요한 최소 스프링 -->
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-context</artifactId>
+            <version>5.3.31</version>
+        </dependency>
+
+    </dependencies>
+
+    <build>
+        <plugins>
+            <!-- 실행 가능한 fat-jar 생성 -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>3.6.0</version>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals><goal>shade</goal></goals>
+                        <configuration>
+                            <createDependencyReducedPom>false</createDependencyReducedPom>
+
+                            <filters>
+                                <filter>
+                                    <artifact>*:*</artifact>
+                                    <excludes>
+                                        <exclude>META-INF/*.SF</exclude>
+                                        <exclude>META-INF/*.DSA</exclude>
+                                        <exclude>META-INF/*.RSA</exclude>
+                                        <exclude>module-info.class</exclude>
+                                    </excludes>
+                                </filter>
+                            </filters>
+
+                            <transformers>
+                                <!-- Main Class -->
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                                    <mainClass>com.flyway.batch.runner.BatchRunnerApplication</mainClass>
+                                </transformer>
+
+                                <!-- Spring XML -->
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.AppendingTransformer">
+                                    <resource>META-INF/spring.handlers</resource>
+                                </transformer>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.AppendingTransformer">
+                                    <resource>META-INF/spring.schemas</resource>
+                                </transformer>
+
+                                <!-- Spring Factories -->
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.AppendingTransformer">
+                                    <resource>META-INF/spring.factories</resource>
+                                </transformer>
+                            </transformers>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/flyway-batch-runner/src/main/java/com/flyway/batch/runner/BatchRunnerApplication.java
+++ b/flyway-batch-runner/src/main/java/com/flyway/batch/runner/BatchRunnerApplication.java
@@ -1,0 +1,31 @@
+package com.flyway.batch.runner;
+
+import com.flyway.pricing.batch.BatchRootConfig;
+import org.springframework.beans.factory.xml.XmlBeanDefinitionReader;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.core.io.ClassPathResource;
+
+public class BatchRunnerApplication {
+
+    public static void main(String[] args) throws Exception {
+        AnnotationConfigApplicationContext ctx = new AnnotationConfigApplicationContext();
+
+        // batch 프로파일
+        ctx.getEnvironment().setActiveProfiles("batch");
+
+        // xml 로딩 (DataSource, SqlSessionFactory 등)
+        new XmlBeanDefinitionReader(ctx).loadBeanDefinitions(
+                new ClassPathResource("spring/root-context.xml")
+        );
+
+        // Java Config 로딩
+        ctx.register(BatchRunnerInfraConfig.class);
+        ctx.register(BatchRootConfig.class);
+
+        // 컨텍스트 시작
+        ctx.refresh();
+
+        // JVM 유지 (상시 실행)
+        Thread.sleep(Long.MAX_VALUE);
+    }
+}

--- a/flyway-batch-runner/src/main/java/com/flyway/batch/runner/BatchRunnerInfraConfig.java
+++ b/flyway-batch-runner/src/main/java/com/flyway/batch/runner/BatchRunnerInfraConfig.java
@@ -1,0 +1,14 @@
+package com.flyway.batch.runner;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class BatchRunnerInfraConfig {
+
+    @Bean
+    public ObjectMapper objectMapper() {
+        return new ObjectMapper();
+    }
+}

--- a/flyway-batch-runner/src/main/resources/spring/root-context.xml
+++ b/flyway-batch-runner/src/main/resources/spring/root-context.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:context="http://www.springframework.org/schema/context"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans
+      http://www.springframework.org/schema/beans/spring-beans.xsd
+      http://www.springframework.org/schema/context
+      http://www.springframework.org/schema/context/spring-context.xsd">
+
+    <!-- HikariCP 설정 (Properties에서 값 주입) -->
+    <bean id="hikariConfig" class="com.zaxxer.hikari.HikariConfig">
+        <property name="driverClassName" value="${db.driver}"/>
+        <property name="jdbcUrl" value="${db.url}"/>
+        <property name="username" value="${db.username}"/>
+        <property name="password" value="${db.password}"/>
+        <property name="maximumPoolSize" value="${db.hikari.maximum-pool-size}"/>
+        <property name="minimumIdle" value="${db.hikari.minimum-idle}"/>
+        <property name="connectionTimeout" value="${db.hikari.connection-timeout}"/>
+    </bean>
+
+    <bean id="dataSource" class="com.zaxxer.hikari.HikariDataSource" destroy-method="close">
+        <constructor-arg ref="hikariConfig"/>
+    </bean>
+
+    <!-- Transaction Manager -->
+    <bean id="transactionManager"
+          class="org.springframework.jdbc.datasource.DataSourceTransactionManager">
+        <property name="dataSource" ref="dataSource"/>
+    </bean>
+
+    <beans profile="default, batch">
+        <context:property-placeholder
+                location="file:/etc/flyway-batch-runner/application-batch.properties,classpath:config/application-batch.properties"
+                ignore-resource-not-found="true"
+                ignore-unresolvable="false"/>
+    </beans>
+
+
+</beans>

--- a/pom.xml
+++ b/pom.xml
@@ -129,13 +129,6 @@
             <version>2.23.1</version>
         </dependency>
 
-        <!-- Spring Cache Abstraction -->
-        <dependency>
-            <groupId>org.springframework</groupId>
-            <artifactId>spring-context-support</artifactId>
-            <version>${org.springframework-version}</version>
-        </dependency>
-
         <!-- Caffeine Cache (경량) -->
         <dependency>
             <groupId>com.github.ben-manes.caffeine</groupId>
@@ -354,13 +347,6 @@
             <version>2.11.0</version>
         </dependency>
 
-        <!-- JavaMail API -->
-        <dependency>
-            <groupId>com.sun.mail</groupId>
-            <artifactId>javax.mail</artifactId>
-            <version>1.6.2</version>
-        </dependency>
-
         <!-- Apache Commons Lang -->
         <dependency>
             <groupId>org.apache.commons</groupId>
@@ -431,7 +417,6 @@
             <version>1.6.2</version>
         </dependency>
 
-
     </dependencies>
 
     <build>
@@ -451,6 +436,27 @@
                 <artifactId>maven-war-plugin</artifactId>
                 <version>3.3.2</version>
             </plugin>
+
+            <!-- classes.jar 추가 산출 -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>3.3.0</version>
+                <executions>
+                    <execution>
+                        <id>attach-classes-jar</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                        <configuration>
+                            <classifier>classes</classifier>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+
         </plugins>
     </build>
+
 </project>

--- a/src/main/java/com/flyway/pricing/batch/BatchRootConfig.java
+++ b/src/main/java/com/flyway/pricing/batch/BatchRootConfig.java
@@ -1,0 +1,13 @@
+package com.flyway.pricing.batch;
+
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+@Configuration
+@EnableScheduling
+@ComponentScan(basePackages = {
+        "com.flyway.pricing"
+})
+public class BatchRootConfig {
+}

--- a/src/main/java/com/flyway/pricing/batch/BatchRootConfig.java
+++ b/src/main/java/com/flyway/pricing/batch/BatchRootConfig.java
@@ -2,10 +2,12 @@ package com.flyway.pricing.batch;
 
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
 @Configuration
 @EnableScheduling
+@Profile("batch")
 @ComponentScan(basePackages = {
         "com.flyway.pricing"
 })

--- a/src/main/java/com/flyway/pricing/batch/scheduler/RepriceBatchScheduler.java
+++ b/src/main/java/com/flyway/pricing/batch/scheduler/RepriceBatchScheduler.java
@@ -1,0 +1,81 @@
+package com.flyway.pricing.batch.scheduler;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.JobParameters;
+import org.springframework.batch.core.JobParametersBuilder;
+import org.springframework.batch.core.launch.JobLauncher;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+import org.springframework.scheduling.annotation.EnableScheduling;
+import org.springframework.scheduling.annotation.Scheduled;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
+@Profile("batch")
+@Slf4j
+@Configuration
+@EnableScheduling   // 스케줄링 기능 활성화
+@RequiredArgsConstructor
+public class RepriceBatchScheduler {
+
+    private final JobLauncher jobLauncher;
+    private final Job repriceJob;
+
+    // 날짜 포맷
+    private static final DateTimeFormatter FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
+
+    /**
+     * 1. 장기 예보 배치 (Daily)
+     * - 대상: D-30일 ~ D-3일
+     * - 빈도: 매일 자정 00:02 실행
+     */
+    @Scheduled(cron = "0 2 0 * * *")
+    public void runLongTermForecast() {
+        LocalDateTime now = LocalDateTime.now();
+
+        // 범위 계산: 지금으로부터 2일 뒤 ~ 30일 뒤까지 출발하는 항공편
+        String rangeStart = now.plusDays(2).format(FORMATTER);
+        String rangeEnd = now.plusDays(30).format(FORMATTER);
+
+        log.info(">>> [LONG_TERM BATCH] STARTED (range: {} ~ {})", rangeStart, rangeEnd);
+        runJob("LONG_TERM", rangeStart, rangeEnd);
+    }
+
+    /**
+     * 2. 단기/임박 예보 배치 (Frequent)
+     * - 대상: D-48시간(2일) ~ D-0시간(출발 직전)
+     * - 빈도: 1시간마다 실행 (정각)
+     */
+    @Scheduled(cron = "0 0 * * * *")
+    public void runShortTermForecast() {
+        LocalDateTime now = LocalDateTime.now();
+
+        // 범위 계산: 지금(출발 임박) ~ 48시간 뒤까지 출발하는 항공편
+        String rangeStart = now.format(FORMATTER);
+        String rangeEnd = now.plusHours(48).format(FORMATTER);
+
+        log.info(">>> [SHORT_TERM BATCH] STARTED (range: {} ~ {})", rangeStart, rangeEnd);
+        runJob("SHORT_TERM", rangeStart, rangeEnd);
+    }
+
+    // 공통 실행 로직
+    private void runJob(String type, String start, String end) {
+        try {
+            JobParameters jobParameters = new JobParametersBuilder()
+                    .addString("type", type)             // 로그/구분용 타입
+                    .addString("rangeStart", start)      // 조회 시작일시
+                    .addString("rangeEnd", end)          // 조회 종료일시
+                    .addLong("asOf", System.currentTimeMillis()) // 기준 시간 (Processor)
+                    .addLong("run.id", System.currentTimeMillis()) // 중복 실행 허용을 위한 ID
+                    .toJobParameters();
+
+            jobLauncher.run(repriceJob, jobParameters);
+
+        } catch (Exception e) {
+            log.error(">>> [BATCH FAILED] type: {}, error: {}", type, e.getMessage(), e);
+        }
+    }
+}

--- a/src/main/java/com/flyway/pricing/batch/scheduler/RepriceBatchScheduler.java
+++ b/src/main/java/com/flyway/pricing/batch/scheduler/RepriceBatchScheduler.java
@@ -12,6 +12,8 @@ import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.scheduling.annotation.Scheduled;
 
 import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 
 @Profile("batch")
@@ -20,6 +22,8 @@ import java.time.format.DateTimeFormatter;
 @EnableScheduling   // 스케줄링 기능 활성화
 @RequiredArgsConstructor
 public class RepriceBatchScheduler {
+
+    private static final ZoneId KST = ZoneId.of("Asia/Seoul");
 
     private final JobLauncher jobLauncher;
     private final Job repriceJob;
@@ -32,9 +36,9 @@ public class RepriceBatchScheduler {
      * - 대상: D-30일 ~ D-3일
      * - 빈도: 매일 자정 00:02 실행
      */
-    @Scheduled(cron = "0 2 0 * * *")
+    @Scheduled(cron = "0 2 0 * * *", zone = "Asia/Seoul")
     public void runLongTermForecast() {
-        LocalDateTime now = LocalDateTime.now();
+        ZonedDateTime now = ZonedDateTime.now(KST);
 
         // 범위 계산: 지금으로부터 2일 뒤 ~ 30일 뒤까지 출발하는 항공편
         String rangeStart = now.plusDays(2).format(FORMATTER);
@@ -49,7 +53,7 @@ public class RepriceBatchScheduler {
      * - 대상: D-48시간(2일) ~ D-0시간(출발 직전)
      * - 빈도: 1시간마다 실행 (정각)
      */
-    @Scheduled(cron = "0 0 * * * *")
+    @Scheduled(cron = "0 0 * * * *", zone = "Asia/Seoul")
     public void runShortTermForecast() {
         LocalDateTime now = LocalDateTime.now();
 

--- a/src/main/java/com/flyway/pricing/batch/writer/RepriceWriterConfig.java
+++ b/src/main/java/com/flyway/pricing/batch/writer/RepriceWriterConfig.java
@@ -98,7 +98,7 @@ public class RepriceWriterConfig {
                         "  :cabinClassCode, " +
                         "  :newPrice, " +
                         "  :currentPrice, " +
-                        "  'INIT', " +
+                        "  'BATCH', " +
                         "  :policyVersion, " +
                         "  NULL, " +             // 배치는 이벤트 트리거 ID 없음
                         "  :calcContextJson, " +

--- a/src/main/java/com/flyway/template/config/FlywayConfig.java
+++ b/src/main/java/com/flyway/template/config/FlywayConfig.java
@@ -5,8 +5,10 @@ import javax.sql.DataSource;
 import org.flywaydb.core.Flyway;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
 
 @Configuration
+@Profile("!batch")
 public class FlywayConfig {
 
 	@Bean(initMethod = "migrate")

--- a/src/test/java/com/flyway/pricing/batch/h2/BatchTestConfig.java
+++ b/src/test/java/com/flyway/pricing/batch/h2/BatchTestConfig.java
@@ -1,5 +1,6 @@
 package com.flyway.pricing.batch.h2;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.batch.core.Job;
 import org.springframework.batch.core.Step;
 import org.springframework.batch.core.configuration.annotation.EnableBatchProcessing;
@@ -37,6 +38,11 @@ public class BatchTestConfig {
         return jobBuilderFactory.get("repriceJob")
                 .start(repriceFlightsStep)
                 .build();
+    }
+
+    @Bean
+    public ObjectMapper objectMapper() {
+        return new ObjectMapper();
     }
 
     @Bean

--- a/src/test/java/com/flyway/pricing/batch/h2/RepriceStepIntegrationTest.java
+++ b/src/test/java/com/flyway/pricing/batch/h2/RepriceStepIntegrationTest.java
@@ -1,6 +1,5 @@
 package com.flyway.pricing.batch.h2;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.flyway.pricing.service.DynamicPricingCalculator;
 import com.flyway.pricing.batch.reader.RepriceReaderConfig;
 import com.flyway.pricing.batch.writer.RepriceWriterConfig;
@@ -16,8 +15,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.batch.core.*;
 import org.springframework.batch.test.JobLauncherTestUtils;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.test.context.junit.jupiter.SpringExtension;

--- a/src/test/java/com/flyway/pricing/batch/h2/RepriceStepIntegrationTest.java
+++ b/src/test/java/com/flyway/pricing/batch/h2/RepriceStepIntegrationTest.java
@@ -1,5 +1,6 @@
 package com.flyway.pricing.batch.h2;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.flyway.pricing.service.DynamicPricingCalculator;
 import com.flyway.pricing.batch.reader.RepriceReaderConfig;
 import com.flyway.pricing.batch.writer.RepriceWriterConfig;
@@ -15,16 +16,24 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.batch.core.*;
 import org.springframework.batch.test.JobLauncherTestUtils;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.mockito.Mockito;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.BDDMockito.given;
+
+
+/**
+ *     [H2 테스트 진행을 위한 설정]
+ *  1) `RepriceReaderConfig`의 #72 line 주석 처리
+ *  2) #110~112의 테이블 alias 제거 (`f.`, `fsp.`)
+ *  3) ReprcieStepIntegrationTest.java 실행 후, 원상 복구 *****
+ */
 
 
 @ExtendWith(SpringExtension.class)
@@ -49,6 +58,19 @@ class RepriceStepIntegrationTest {
     void setUp() {
 
         // 1. 비즈니스 테이블 생성 (H2 메모리 DB)
+        jdbcTemplate.execute("CREATE TABLE IF NOT EXISTS aircraft (" +
+                "aircraft_id VARCHAR(36) PRIMARY KEY, " +
+                "economy_class_seats INT, " +
+                "business_class_seats INT, " +
+                "first_class_seats INT)");
+
+        jdbcTemplate.execute("CREATE TABLE IF NOT EXISTS flight_info (" +
+                "flight_id VARCHAR(36) PRIMARY KEY, " +
+                "aircraft_id VARCHAR(36), " +
+                "economy_class_seat INT, " +
+                "business_class_seat INT, " +
+                "first_class_seat INT)");
+
         jdbcTemplate.execute("CREATE TABLE IF NOT EXISTS flight (" +
                 "flight_id VARCHAR(36) PRIMARY KEY, departure_time DATETIME)");
 
@@ -59,10 +81,19 @@ class RepriceStepIntegrationTest {
                 "PRIMARY KEY(flight_id, cabin_class_code))");
 
         jdbcTemplate.execute("CREATE TABLE IF NOT EXISTS price_history (" +
-                "price_history_id VARCHAR(36), flight_id VARCHAR(36), cabin_class_code VARCHAR(10), " +
-                "current_price BIGINT, update_type VARCHAR(20), calculated_at DATETIME)");
+                "price_history_id VARCHAR(36), " +
+                "flight_id VARCHAR(36), " +
+                "cabin_class_code VARCHAR(10), " +
+                "current_price BIGINT, " +
+                "old_price BIGINT, " +
+                "update_type VARCHAR(20), " +
+                "policy_version VARCHAR(20), " +
+                "trigger_ref_id VARCHAR(36), " +
+                "calculated_at DATETIME, " +
+                "calc_context_json TEXT)");
 
         // 2. 테스트 데이터 Insert (출발 5일 남은 항공편)
+
         // (1) 항공기 정보 (총 100석)
         jdbcTemplate.update("INSERT INTO aircraft VALUES ('AC-001', 100, 30, 10)");
 
@@ -87,8 +118,15 @@ class RepriceStepIntegrationTest {
     @DisplayName("Step 실행 테스트")
     void testStepExecution() {
 
+        // Reader가 요구하는 필수 파라미터(rangeStart, rangeEnd) 추가
+        String rangeStart = LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"));
+        String rangeEnd = LocalDateTime.now().plusDays(30).format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"));
+
         JobParameters jobParameters = new JobParametersBuilder()
-                .addLong("asOf", System.currentTimeMillis())
+                .addLong("asOf", System.currentTimeMillis())       // Processor
+                .addString("rangeStart", rangeStart)               // Reader
+                .addString("rangeEnd", rangeEnd)                   // Reader
+                .addLong("run.id", System.currentTimeMillis())
                 .toJobParameters();
 
         // when


### PR DESCRIPTION
## 📌 PR 설명
앞서 구현한 배치(#78) 작업을 일정 주기마다 실행하는 스프링 스케줄러를 구현했습니다. 

기존 flyway 애플리케이션과 분리된 형태로 Spring Batch 스케줄러를 독립 실행하기 위한, `batch-runner` 모듈의 초기 실행 환경을 구성하였습니다.
- batch-runner는 배치를 직접 실행하지 않고, 스케줄러를 기동하여 flyway batch job을 트리거하는 역할만 수행합니다.
- 기존 flyway 모듈의 배치 로직(`com.flyway.pricing.batch`)을 재사용합니다.
- XML 기반 DataSource / Transaction 설정과 Java Config 기반 인프라 설정을 혼합한 구조입니다.


<br>

## ✅ 완료한 기능 명세

- [x] 스케줄러 구현
- [x] batch-runner 실행 엔트리 포인트 추가
- [x]  batch-runner 루트 설정 구성
- [x] batch-runner 인프라 설정 분리
- [x] batch-runner 전용 pom.xml 구성

<br>

## 실행 방법

<br>

- 실행 클래스
  - `com.flyway.batch.runner.BatchRunnerApplication`

- 활성 프로파일
  - `batch`
  - (IDE 실행 시) `SPRING_PROFILES_ACTIVE=batch`

- 설정 파일
  - `classpath:config/application-batch.properties`

<br>

## 참고 사항 🌟 

<br>

- batch-runner는 배치 Job을 직접 실행하지 않습니다.
- Job 트리거는 Scheduler에서만 발생합니다.
- Web / Controller / API 관련 컴포넌트는 스캔 대상에서 제외됩니다.
- 운영 환경에서는 EC2 단독 프로세스(systemd) 실행을 전제로 합니다.

### 이후 작업 예정
- batch-runner EC2 배포 및 systemd 서비스 등록 (완료: 02/02)

<br>


### 🔗 관련 이슈
Closes #79 

<br>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a standalone batch runner module and an executable shaded artifact.
  * Added scheduled batch jobs for short- and long-term price forecasts.

* **Changes**
  * Reader now uses explicit rangeStart/rangeEnd time-range parameters.
  * Price history update_type changed from 'INIT' to 'BATCH'.
  * Flyway-related config is disabled when batch profile is active.

* **Tests**
  * Updated integration/unit tests and test configs to match new schema and time-range params.

* **Chores**
  * Added application-batch.properties ignore rule to .gitignore.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->