### PR TITLE
[FLYW-175] 좌석 BOOKED 트랜잭션 구현 

### DIFF
--- a/src/main/java/com/flyway/seat/mapper/SeatMapper.java
+++ b/src/main/java/com/flyway/seat/mapper/SeatMapper.java
@@ -101,4 +101,19 @@ public interface SeatMapper {
     // 예약(reservationId) 기준 탑승자 목록 조회 (좌석 팝업 다인원 탭용)
     List<PassengerDTO> selectPassengersByReservationId(@Param("reservationId") String reservationId);
 
+    // 결제 확정 (reservationId 기준 유효한 HOLD 좌석 수 카운트 함)
+    int countActiveHoldSeatsByReservation(
+            @Param("reservationId") String reservationId,
+            @Param("now") LocalDateTime now
+    );
+
+    // reservationId가 잡고 있던 HOLD 좌석들을 BOOKED로 확정
+    int bookHoldSeatsByReservation(
+            @Param("reservationId") String reservationId,
+            @Param("now") LocalDateTime now
+    );
+
+    int releaseBookedSeatsByReservation(
+            @Param("reservationId") String reservationId);
+
 }

--- a/src/main/java/com/flyway/seat/service/SeatService.java
+++ b/src/main/java/com/flyway/seat/service/SeatService.java
@@ -38,4 +38,9 @@ public interface SeatService {
 
     // 예약(reservationId) 기준 탑승자 목록(다인원 탭용)
     List<PassengerDTO> findPassengers(String reservationId);
+
+    void bookHoldSeats(String reservationId);
+
+    void releaseBookedSeats(String reservationId);
+
 }

--- a/src/main/resources/mapper/seat/SeatMapper.xml
+++ b/src/main/resources/mapper/seat/SeatMapper.xml
@@ -181,6 +181,20 @@
         ORDER BY p.passenger_id
     </select>
 
+    <!-- 결제 확정용 (reservationId 기준 유효한 HOLD 좌석 개수) -->
+    <select id="countActiveHoldSeatsByReservation" resultType="int">
+        SELECT COUNT(*)
+        FROM passenger_seat ps
+            JOIN reservation_segment rs
+                ON rs.reservation_segment_id = ps.reservation_segment_id
+            JOIN flight_seat fs
+                ON fs.flight_seat_id = ps.flight_seat_id
+        WHERE rs.reservation_id = #{reservationId}
+            AND fs.seat_status = 'HOLD'
+            AND fs.hold_reservation_segment_id = rs.reservation_segment_id
+            AND fs.hold_expires_at IS NOT NULL
+            AND fs.hold_expires_at &gt;= #{now}
+    </select>
 
 
 
@@ -229,6 +243,39 @@
           AND hold_reservation_segment_id = #{reservationSegmentId}
     </update>
 
+    <update id="bookHoldSeatsByReservation">
+        UPDATE flight_seat fs
+            JOIN passenger_seat ps
+                ON ps.flight_seat_id = fs.flight_seat_id
+            JOIN reservation_segment rs
+                ON rs.reservation_segment_id = ps.reservation_segment_id
+        SET fs.seat_status = 'BOOKED',
+            fs.booked_at = NOW(),
+            fs.hold_reservation_segment_id = NULL,
+            fs.hold_expires_at = NULL
+        WHERE rs.reservation_id = #{reservationId}
+            AND fs.seat_status = 'HOLD'
+            AND fs.hold_reservation_segment_id = rs.reservation_segment_id
+            AND fs.hold_expires_at IS NOT NULL
+            AND fs.hold_expires_at &gt;= #{now}
+    </update>
+
+    <!-- 환불/취소용 reservationId가 BOOKED로 확정했던 좌석들을 AVAILABLE로 되돌림 -->
+    <update id="releaseBookedSeatsByReservation">
+        UPDATE flight_seat fs
+            JOIN passenger_seat ps
+        ON ps.flight_seat_id = fs.flight_seat_id
+            JOIN reservation_segment rs
+            ON rs.reservation_segment_id = ps.reservation_segment_id
+            SET fs.seat_status = 'AVAILABLE',
+                fs.booked_at = NULL
+        WHERE rs.reservation_id = #{reservationId}
+          AND fs.seat_status = 'BOOKED'
+    </update>
+
+
+
+
     <!-- passenger_seat upsert -->
     <insert id="upsertPassengerSeat">
         INSERT INTO passenger_seat (
@@ -254,5 +301,4 @@
         WHERE reservation_segment_id = #{reservationSegmentId}
           AND passenger_id = #{passengerId}
     </delete>
-
 </mapper>


### PR DESCRIPTION
## 📌 PR 설명
<br>

## ✅ 완료한 기능 명세

- [x] 결제 완료와 함께 BOOKED로 트랜잭션
- [x] 결제 완료 시 BOOKED 전환 테스트 완료
- [x] 환불과 함께 AVAILABLE로 트랜잭션
- [x] 환불 후 BOOKED -> AVAILABLE 테스트 완료

<br>

## 📸 스크린샷

<br>

## 💭 고민과 해결과정

<br>
seatService.bookHoldSeats()가 반드시 이미 열려있는 트랜잭션 안에서만 실행되도록(MANDATORY) 설정돼 있는데 같은 클래스 내부 호출(self-invocation) 때문에 @Transactional이 적용이 안 됨

-> 같은 객체 내부에서 메서드를 직접 호출하면, 스프링 AOP 프록시를 안 거치기 때문에
completePayment()의 @Transactional이 없는 것처럼 동작

SeatService 쪽 MANDATORY를 REQUIRED로 변경하여 해결함!

### 🔗 관련 이슈
Closes #181 

<br>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automatic seat confirmation upon successful payment completion, ensuring reserved seats are securely booked
  * Improved coordination between payment transactions and seat availability management
  * Streamlined reservation workflow for enhanced booking experience

* **Bug Fixes**
  * Better refund processing that reliably releases seats back to available inventory and prevents double-booking

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->