### PR TITLE
[FLYW-183] 재검색 시 도착공항 재호출 및 날짜 값 수정

### DIFF
--- a/src/main/webapp/WEB-INF/views/common/head.jsp
+++ b/src/main/webapp/WEB-INF/views/common/head.jsp
@@ -13,3 +13,4 @@
 <link rel="stylesheet" href="${pageContext.request.contextPath}/resources/common/css/layout.css?v=<%= System.currentTimeMillis() %>">
 <link rel="stylesheet" href="${pageContext.request.contextPath}/resources/common/css/base.css">
 <link rel="stylesheet" href="${pageContext.request.contextPath}/resources/common/css/header-hero.css?v=<%= System.currentTimeMillis() %>">
+<link rel="stylesheet" href="${pageContext.request.contextPath}/resources/common/css/common-header.css">

--- a/src/main/webapp/WEB-INF/views/home.jsp
+++ b/src/main/webapp/WEB-INF/views/home.jsp
@@ -295,6 +295,13 @@
 
                 const isOneWay = window.state && window.state.tripType === "OW";
 
+                const toYYYYMMDD = (date) => {
+                    if (!date) return '';
+                    return date.getFullYear() + '-' +
+                        String(date.getMonth() + 1).padStart(2, '0') + '-' +
+                        String(date.getDate()).padStart(2, '0');
+                };
+
                 rangePicker = flatpickr(dateFieldWrap, {
                     locale: "ko",
                     mode: isOneWay ? "single" : "range",
@@ -314,43 +321,43 @@
 
                         if (isOW && selectedDates.length === 1) {
                             // 편도 - 단일 날짜 선택
-                            const start = formatDate(selectedDates[0]);
+                            const start = toYYYYMMDD(selectedDates[0]);
                             dateRangeText.textContent = start;
                             dateRangeText.classList.remove('selecting');
 
                             if (window.state) {
-                                window.state.dateStart = selectedDates[0].toISOString().split('T')[0];
+                                window.state.dateStart = start;
                                 window.state.dateEnd = null;
                             }
-                            if (startInput) startInput.value = selectedDates[0].toISOString().split('T')[0];
+                            if (startInput) startInput.value = start;
                             if (endInput) endInput.value = '';
 
                         } else if (!isOW && selectedDates.length === 1) {
                             // 왕복 - 첫 번째 날짜 선택
-                            const start = formatDate(selectedDates[0]);
+                            const start = toYYYYMMDD(selectedDates[0]);
                             dateRangeText.textContent = start + '  →  오는날 선택';
                             dateRangeText.classList.add('selecting');
 
                             if (window.state) {
-                                window.state.dateStart = selectedDates[0].toISOString().split('T')[0];
+                                window.state.dateStart = start;
                                 window.state.dateEnd = null;
                             }
-                            if (startInput) startInput.value = selectedDates[0].toISOString().split('T')[0];
+                            if (startInput) startInput.value = start;
                             if (endInput) endInput.value = '';
 
                         } else if (selectedDates.length === 2) {
                             // 왕복 - 두 날짜 모두 선택
-                            const start = formatDate(selectedDates[0]);
-                            const end = formatDate(selectedDates[1]);
+                            const start = toYYYYMMDD(selectedDates[0]);
+                            const end = toYYYYMMDD(selectedDates[1]);
                             dateRangeText.textContent = start + '  →  ' + end;
                             dateRangeText.classList.remove('selecting');
 
                             if (window.state) {
-                                window.state.dateStart = selectedDates[0].toISOString().split('T')[0];
-                                window.state.dateEnd = selectedDates[1].toISOString().split('T')[0];
+                                window.state.dateStart = start;
+                                window.state.dateEnd = end;
                             }
-                            if (startInput) startInput.value = selectedDates[0].toISOString().split('T')[0];
-                            if (endInput) endInput.value = selectedDates[1].toISOString().split('T')[0];
+                            if (startInput) startInput.value = start;
+                            if (endInput) endInput.value = end;
                         }
                     }
                 });

--- a/src/main/webapp/WEB-INF/views/home.jsp
+++ b/src/main/webapp/WEB-INF/views/home.jsp
@@ -321,8 +321,9 @@
 
                         if (isOW && selectedDates.length === 1) {
                             // 편도 - 단일 날짜 선택
+                            const startText = formatDate(selectedDates[0]);
                             const start = toYYYYMMDD(selectedDates[0]);
-                            dateRangeText.textContent = start;
+                            dateRangeText.textContent = startText;
                             dateRangeText.classList.remove('selecting');
 
                             if (window.state) {
@@ -334,8 +335,9 @@
 
                         } else if (!isOW && selectedDates.length === 1) {
                             // 왕복 - 첫 번째 날짜 선택
+                            const startText = formatDate(selectedDates[0]);
                             const start = toYYYYMMDD(selectedDates[0]);
-                            dateRangeText.textContent = start + '  →  오는날 선택';
+                            dateRangeText.textContent = startText + '  →  오는날 선택';
                             dateRangeText.classList.add('selecting');
 
                             if (window.state) {
@@ -347,9 +349,11 @@
 
                         } else if (selectedDates.length === 2) {
                             // 왕복 - 두 날짜 모두 선택
+                            const startText = formatDate(selectedDates[0]);
+                            const endText = formatDate(selectedDates[1]);
                             const start = toYYYYMMDD(selectedDates[0]);
                             const end = toYYYYMMDD(selectedDates[1]);
-                            dateRangeText.textContent = start + '  →  ' + end;
+                            dateRangeText.textContent = startText + '  →  ' + endText;
                             dateRangeText.classList.remove('selecting');
 
                             if (window.state) {

--- a/src/main/webapp/WEB-INF/views/search/search.jsp
+++ b/src/main/webapp/WEB-INF/views/search/search.jsp
@@ -6,7 +6,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-
+    <jsp:include page="/WEB-INF/views/common/head.jsp" />
     <title>검색 결과 - Flyway</title>
 
     <link rel="stylesheet" href="${pageContext.request.contextPath}/resources/common/css/base.css">

--- a/src/main/webapp/resources/common/css/common-header.css
+++ b/src/main/webapp/resources/common/css/common-header.css
@@ -1,0 +1,46 @@
+body .glass-header-bg {
+    background: rgba(255, 255, 255, 0.92);
+    border: 1px solid #e2e8f0;
+    box-shadow: 0 10px 24px rgba(48, 147, 247, 0.12);
+    backdrop-filter: none;
+    -webkit-backdrop-filter: none;
+    transition: none;
+}
+
+body .glass-header-bg::before {
+    display: none;
+}
+
+body.scrolled .glass-header-bg {
+    background: rgba(255, 255, 255, 0.92);
+    border: 1px solid #e2e8f0;
+    box-shadow: 0 10px 24px rgba(48, 147, 247, 0.12);
+}
+
+body .glass-header a,
+body .glass-header button {
+    color: #1f3b5c;
+}
+
+body .glass-header .tilt-btn {
+    box-shadow: none !important;
+    text-shadow: none !important;
+}
+
+body .glass-header .logo-text-3d {
+    filter: none !important;
+    transition: none !important;
+}
+
+body .glass-header .auth-text-btn {
+    background: transparent !important;
+    border-color: transparent !important;
+    box-shadow: none !important;
+    color: #64748B !important;
+}
+
+body .glass-header .auth-text-btn:hover {
+    background: transparent !important;
+    border-color: transparent !important;
+    opacity: 0.7;
+}

--- a/src/main/webapp/resources/search/js/search.js
+++ b/src/main/webapp/resources/search/js/search.js
@@ -25,8 +25,19 @@ document.addEventListener("DOMContentLoaded", async () => {
 
     const hasQuery = loadStateFromQuery();
     if (hasQuery) {
+        // 출발 공항 값이 있으면 도착공항 재호출
+        if (state.from && state.from.code) {
+            await loadArrAirports(state.from.code);
+
+            // 가짜 입력 이벤트를 주어 도착공항 리스트를 다시 채움
+            const toDropdownInput = document.querySelector('.dropdown[data-field="to"] .dropdown-search');
+            if (toDropdownInput) {
+                toDropdownInput.dispatchEvent(new Event('input'));
+            }
+        }
+
         syncSearchBarFromState();
-        executeSearch(); // ← 검색 API 호출만 분리
+        await executeSearch();
     }
 });
 


### PR DESCRIPTION
## 📌 PR 설명
- 검색 페이지에서 재검색하는 경우, 출발 공항 값은 존재하지만 도착 공항(to) 리스트가 정상적으로 갱신되지 않는 문제 수정
- 날짜 선택 시 값이 utc 기준으로 들어오는 문제 수정
<br>

## ✅ 완료한 기능 명세

- [x] 재검색 시 출발 공항 값이 존재하면 도착 공항 리스트 재호출

- [x] 도착 공항 드롭다운이 즉시 갱신되도록 입력 이벤트 트리거

- [x] utc 기준 날짜 한국 날짜 기준으로 수정 

<br>

## 📸 스크린샷
<img width="1474" height="566" alt="image" src="https://github.com/user-attachments/assets/eb7ccfd5-5d1e-462f-b4f4-4babe3e522bf" />

<br>

## 💭 고민과 해결과정
- 문제 상황
재검색  시 출발 공항은 정상적으로 세팅되지만,
도착 공항 드롭다운 리스트가 다시 로딩되지 않음

출발 공항을 다시 입력해야만 리스트가 갱신되는 문제 발생

- 원인 분석

도착 공항 리스트는 출발 공항 선택 이벤트를 기준으로만 호출되고 있었음

URL 기반 재검색에서는 해당 이벤트가 발생하지 않아
도착 공항 API가 호출되지 않음

- 해결 방법
출발 공항 값이 있으면 도착 공항 API를 명시적으로 재호출

이후 드롭다운 검색 input에 가짜 input 이벤트를 발생시켜
리스트 렌더링을 강제로 트리거

<br>

### 🔗 관련 이슈
Closes #199 

<br>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensures arrival options are loaded and refreshed when a departure is preselected, and waits for data before executing searches.
  * Standardizes date formatting for start/end inputs and internal search state for consistent display and search behavior.

* **Style**
  * Adds a shared header stylesheet with updated translucent header styling and button/link visuals.
  * Switches pages to include the shared head content for consistent resource ordering and header appearance.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->