### PR TITLE
[FLYW-186] 환불 시스템 사용자 식별 보안 조치 

### DIFF
--- a/src/main/java/com/flyway/payment/controller/PaymentApiController.java
+++ b/src/main/java/com/flyway/payment/controller/PaymentApiController.java
@@ -3,9 +3,12 @@ package com.flyway.payment.controller;
 import com.flyway.payment.domain.RefundRequest;
 import com.flyway.payment.dto.PaymentViewDto;
 import com.flyway.payment.service.PaymentService;
+import com.flyway.security.principal.CustomUserDetails;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.HashMap;
@@ -15,6 +18,7 @@ import java.util.Map;
  * 결제 API 컨트롤러 (REST API)
  *
  * 마이페이지 등 다른 모듈에서 호출하는 API입니다.
+ * 로그인만 하면 다른 사람 것도 조회가능한 현상 수정
  */
 @Slf4j
 @RestController
@@ -28,9 +32,20 @@ public class PaymentApiController {
      * 결제 정보 조회
      */
     @GetMapping("/{paymentId}")
-    public ResponseEntity<PaymentViewDto> getPayment(@PathVariable String paymentId) {
+    public ResponseEntity<PaymentViewDto> getPayment(
+            @PathVariable String paymentId,
+            @AuthenticationPrincipal CustomUserDetails user) {
 
         PaymentViewDto payment = paymentService.getPayment(paymentId);
+        if (payment == null) {
+            return ResponseEntity.notFound().build();
+        }
+
+        // 본인 결제인지 확인
+        if (!payment.getUserId().equals(user.getUserId())) {
+            return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
+        }
+
         return ResponseEntity.ok(payment);
     }
 
@@ -39,9 +54,20 @@ public class PaymentApiController {
      */
     @GetMapping("/reservation/{reservationId}")
     public ResponseEntity<PaymentViewDto> getPaymentByReservation(
-            @PathVariable String reservationId) {
+            @PathVariable String reservationId,
+            @AuthenticationPrincipal CustomUserDetails user) {
 
         PaymentViewDto payment = paymentService.getPaymentByReservation(reservationId);
+
+        if (payment == null) {
+            return ResponseEntity.notFound().build();
+        }
+
+        // 본인 결제인지 확인
+        if (!payment.getUserId().equals(user.getUserId())) {
+            return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
+        }
+
         return ResponseEntity.ok(payment);
     }
 
@@ -56,12 +82,31 @@ public class PaymentApiController {
     @PostMapping("/{paymentId}/refund")
     public ResponseEntity<Map<String, Object>> processRefund(
             @PathVariable String paymentId,
-            @RequestBody RefundRequest request) {
+            @RequestBody RefundRequest request,
+            @AuthenticationPrincipal CustomUserDetails user) {
 
-        log.info("[환불] 요청 - paymentId: {}, reason: {}",
-                paymentId, request.getCancelReason());
+        log.info("[환불] 요청 - paymentId: {}, userId: {}, reason: {}",
+                paymentId, user.getUserId(), request.getCancelReason());
 
         try {
+            // 본인 결제인지 확인
+            PaymentViewDto payment = paymentService.getPayment(paymentId);
+            if (payment == null) {
+                return ResponseEntity.badRequest().body(Map.of(
+                        "success", false,
+                        "message", "결제 정보를 찾을 수 없습니다."
+                ));
+            }
+
+            if (!payment.getUserId().equals(user.getUserId())) {
+                log.warn("[환불] 권한 없음 - paymentId: {}, 요청자: {}, 소유자: {}",
+                        paymentId, user.getUserId(), payment.getUserId());
+                return ResponseEntity.status(HttpStatus.FORBIDDEN).body(Map.of(
+                        "success", false,
+                        "message", "환불 권한이 없습니다."
+                ));
+            }
+
             PaymentViewDto result = paymentService.refund(paymentId, request);
 
             Map<String, Object> response = new HashMap<>();
@@ -70,12 +115,12 @@ public class PaymentApiController {
 
             return ResponseEntity.ok(response);
 
-        } catch (Exception e) {
+        }catch (Exception e) {
             log.error("[환불] 실패 - paymentId: {}, error: {}", paymentId, e.getMessage());
 
             Map<String, Object> response = new HashMap<>();
             response.put("success", false);
-            response.put("message", e.getMessage());
+            response.put("message", "환불 처리 중 문제가 발생했습니다.");
 
             return ResponseEntity.badRequest().body(response);
         }

--- a/src/main/java/com/flyway/payment/dto/PaymentViewDto.java
+++ b/src/main/java/com/flyway/payment/dto/PaymentViewDto.java
@@ -13,6 +13,7 @@ public class PaymentViewDto {
 
     private String paymentId;        // 우리 DB의 결제 ID
     private String reservationId;    // 예약 ID
+    private String userId;
     private String paymentKey;       // 토스 결제 키
     private String orderId;          // 주문 ID
     private Long amount;             // 결제 금액

--- a/src/main/java/com/flyway/payment/service/PaymentService.java
+++ b/src/main/java/com/flyway/payment/service/PaymentService.java
@@ -1,4 +1,6 @@
 package com.flyway.payment.service;
+import com.flyway.admin.dto.AdminNotificationDto;
+import com.flyway.admin.service.AdminNotificationService;
 import com.flyway.payment.domain.*;
 import com.flyway.payment.dto.PaymentViewDto;
 import com.flyway.payment.client.TossPaymentsClient;
@@ -37,6 +39,7 @@ public class PaymentService {
     private final SmsService smsService;
     private final SmsMapper smsMapper;
     private final SeatService seatService;
+    private final AdminNotificationService adminNotificationService;
 
     /**
      * 결제 처리 메인 로직 (개선된 3단계 설계)
@@ -121,6 +124,16 @@ public class PaymentService {
 
         reservationBookingRepository.updateReservationStatus(payment.getReservationId(), "CONFIRMED");
 
+
+        AdminNotificationDto notification = AdminNotificationDto.builder()
+                .notificationType("NEW_RESERVATION")
+                .title("신규 예약 발생")
+                .message("새로운 예약이 확정되었습니다.")
+                .relatedResourceType("RESERVATION")
+                .relatedResourceId(reservationId)
+                .priority("NORMAL")
+                .build();
+        adminNotificationService.createAndBroadcastNotification(notification);
         // SMS 발송 (여기에 추가)
         String phone = smsMapper.selectPhoneByReservationId(payment.getReservationId());
         if (phone != null && !phone.isEmpty()) {
@@ -141,6 +154,17 @@ public class PaymentService {
 
         // 예약 상태 → HELD (원복)
         reservationBookingRepository.updateReservationStatus(reservationId, "HELD");
+
+        // [알림] 결제 실패 알림 생성
+        AdminNotificationDto notification = AdminNotificationDto.builder()
+                .notificationType("PAYMENT_FAILED")
+                .title("결제 실패 발생")
+                .message("결제 실패가 발생했습니다: " )
+                .relatedResourceType("RESERVATION")
+                .relatedResourceId(reservationId)
+                .priority("HIGH")
+                .build();
+        adminNotificationService.createAndBroadcastNotification(notification);
     }
 
     /**
@@ -176,6 +200,17 @@ public class PaymentService {
 
         for (RefundSegmentDto segment : segments) {
             refundMapper.incrementSeat(segment.getFlightId(), segment.getCabinClass(), passengerCount);
+
+            // [알림] 환불 완료 알림 생성
+            AdminNotificationDto notification = AdminNotificationDto.builder()
+                    .notificationType("REFUND_COMPLETED")
+                    .title("환불 처리 완료")
+                    .message("사용자 요청에 의해 환불이 완료되었습니다.")
+                    .relatedResourceType("RESERVATION")
+                    .relatedResourceId(reservationId)
+                    .priority("NORMAL")
+                    .build();
+            adminNotificationService.createAndBroadcastNotification(notification);
         }
 
 

--- a/src/main/resources/mapper/payment/PaymentMapper.xml
+++ b/src/main/resources/mapper/payment/PaymentMapper.xml
@@ -40,18 +40,21 @@
     <select id="selectByPaymentId" parameterType="string"
             resultType="com.flyway.payment.dto.PaymentViewDto">
         SELECT
-            payment_id      AS paymentId,
-            reservation_id  AS reservationId,
-            payment_key  AS paymentKey,
-            order_id        AS orderId,
-            amount          AS amount,
-            payment_method  AS method,
-            status          AS status,
-            paid_at         AS paidAt,
-            created_at      AS createdAt
-        FROM payment
-        WHERE payment_id = #{paymentId}
+        p.payment_id      AS paymentId,
+        p.reservation_id  AS reservationId,
+        r.user_id         AS userId,
+        p.payment_key     AS paymentKey,
+        p.order_id        AS orderId,
+        p.amount          AS amount,
+        p.payment_method  AS method,
+        p.status          AS status,
+        p.paid_at         AS paidAt,
+        p.created_at      AS createdAt
+        FROM payment p
+        JOIN reservation r ON p.reservation_id = r.reservation_id
+        WHERE p.payment_id = #{paymentId}
     </select>
+
 
     <!-- 주문 ID로 조회 -->
     <select id="selectByOrderId" parameterType="string"
@@ -74,19 +77,21 @@
     <select id="selectByReservationId" parameterType="string"
             resultType="com.flyway.payment.dto.PaymentViewDto">
         SELECT
-            payment_id      AS paymentId,
-            reservation_id  AS reservationId,
-            payment_key  AS paymentKey,
-            order_id        AS orderId,
-            amount          AS amount,
-            payment_method  AS method,
-            status          AS status,
-            paid_at         AS paidAt,
-            created_at      AS createdAt
-        FROM payment
-        WHERE reservation_id = #{reservationId}
-        ORDER BY created_at DESC
-            LIMIT 1
+        p.payment_id      AS paymentId,
+        p.reservation_id  AS reservationId,
+        r.user_id         AS userId,
+        p.payment_key     AS paymentKey,
+        p.order_id        AS orderId,
+        p.amount          AS amount,
+        p.payment_method  AS method,
+        p.status          AS status,
+        p.paid_at         AS paidAt,
+        p.created_at      AS createdAt
+        FROM payment p
+        JOIN reservation r ON p.reservation_id = r.reservation_id
+        WHERE p.reservation_id = #{reservationId}
+        ORDER BY p.created_at DESC
+        LIMIT 1
     </select>
     <!-- 사용자 ID로 결제 내역 조회 -->
     <select id="selectByUserId" parameterType="string" resultType="com.flyway.payment.dto.PaymentViewDto">


### PR DESCRIPTION
## 📌 PR 설명
<br> 로그인을 하면 다른 유저의 예약 내역도 환불이 가능한 현상 수정
dto userId 식별 추가

## ✅ 완료한 기능 명세

- [x] 환불 사용자 식별 기능 추가

<br>

## 📸 스크린샷

<br>

## 💭 고민과 해결과정
samsite로 환불 시스템도 외부 api를 사용해 로그인 토큰 확인을 제외하야 하나 싶었지만 환불 기능은 토스 측으로 전송만 하지 콜백을 받는 구조는 아니라 로그인 userId로 식별 가능하게 할 수 있었습니다.
<br>

### 🔗 관련 이슈
Closes #207 

<br>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added authentication verification and authorization checks for payment operations
  * Integrated admin notifications for payment lifecycle events (new reservations, failures, refunds)

* **Bug Fixes**
  * Improved error messaging for payment operations with standardized, user-friendly responses

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->