### PR TITLE
[FLYW-191] 이벤트 재가격 오류 해결

### DIFF
--- a/src/main/java/com/flyway/payment/service/PaymentService.java
+++ b/src/main/java/com/flyway/payment/service/PaymentService.java
@@ -41,7 +41,7 @@ public class PaymentService {
     private final SmsService smsService;
     private final SmsMapper smsMapper;
     private final SeatService seatService;
-    private final PricingEventServiceImpl pricingEventServiceImpl;
+    private final PricingEventService pricingEventService;
     private final AdminNotificationService adminNotificationService;
 
     /**
@@ -137,7 +137,7 @@ public class PaymentService {
         reservationBookingRepository.updateReservationStatus(payment.getReservationId(), "CONFIRMED");
 
         // 결제 이벤트 기반 항공편 가격 재산정
-//        pricingEventServiceImpl.repriceAfterPayment(reservationId, paymentId);
+//        pricingEventService.repriceAfterPayment(reservationId, paymentId);
 
         AdminNotificationDto notification = AdminNotificationDto.builder()
                 .notificationType("NEW_RESERVATION")
@@ -242,7 +242,7 @@ public class PaymentService {
         );
 
         // 환불 이벤트 기반 항공편 가격 재산정
-//        pricingEventServiceImpl.repriceAfterRefund(reservationId, refundId);
+//        pricingEventService.repriceAfterRefund(reservationId, refundId);
 
         // SMS 발송
         String phone = smsMapper.selectPhoneByReservationId(reservationId);

--- a/src/main/java/com/flyway/pricing/event/PricingEventServiceImpl.java
+++ b/src/main/java/com/flyway/pricing/event/PricingEventServiceImpl.java
@@ -59,7 +59,8 @@ public class PricingEventServiceImpl implements PricingEventService {
         LocalDateTime now = LocalDateTime.now();
 
         // 예약 구간 조회
-        List<EventRepriceSegment> segments = eventRepriceRepository.findRepriceSegments(reservationId);
+        List<EventRepriceSegment> segments =
+                new ArrayList<>(eventRepriceRepository.findRepriceSegments(reservationId));
 
         if (segments.isEmpty()) {
             log.warn("[EVENT_REPRICE] no segments. reservationId={}", reservationId);


### PR DESCRIPTION
## 📌 PR 설명
빌드 차단(컴파일 에러)과 배포를 위한 war 추출 실패를 유발하던 이벤트 재가격 관련 코드를 수정했습니다.

<br>

## ✅ 완료한 기능 명세

- [x] `PaymentService`에서 의존성 주입 수정 (PricingEventServiceImpl 구현체 의존 ->PricingEventService 인터페이스)
- [x] `PricingEventServiceImplTest` 실패 원인이었던, `PricingEventServiceImple` 내의 불변 리스트 정렬 예외 방지 
(ArrayList 복사 후 정렬)

<br>

### 🔗 관련 이슈
Closes #218 

<br>