### PR TITLE
[FLYW-188] 티켓 문자 발송, 환불 트랜잭션 변경, 결제 계산 로직 수정,ajax 적용 

### DIFF
--- a/src/main/java/com/flyway/passenger/controller/PassengerServiceController.java
+++ b/src/main/java/com/flyway/passenger/controller/PassengerServiceController.java
@@ -3,6 +3,7 @@ package com.flyway.passenger.controller;
 import com.flyway.passenger.dto.BaggageSaveRequest;
 import com.flyway.reservation.dto.*;
 import com.flyway.passenger.service.PassengerServiceService;
+import com.flyway.reservation.dto.ServicePopupViewModel;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
@@ -12,7 +13,9 @@ import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.*;
 
 import java.lang.reflect.Method;
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 @Controller
@@ -74,6 +77,62 @@ public class PassengerServiceController {
         Map<String, Object> result = new HashMap<>();
         result.put("success", true);
         result.put("total", total);
+        return ResponseEntity.ok(result);
+    }
+    // 부가서비스 상세 정보 조회 (AJAX)
+    @GetMapping("/{reservationId}/services/details")
+    @ResponseBody
+    public ResponseEntity<Map<String, Object>> getServiceDetails(@PathVariable String reservationId) {
+        String userId = getAuthenticatedUserIdOrThrow();
+
+        // 기존 서비스 로직 활용
+        ServicePopupViewModel vm = serviceService.getServicePopup(reservationId, userId);
+
+        List<Map<String, Object>> segmentServices = new ArrayList<>();
+        for (var segment : vm.getSegments()) {
+            Map<String, Object> segData = new HashMap<>();
+            segData.put("segmentOrder", segment.getSegmentOrder());
+
+            // 해당 구간의 서비스 정보 수집
+            List<Map<String, Object>> baggageList = new ArrayList<>();
+            List<Map<String, Object>> mealList = new ArrayList<>();
+
+            for (var pax : vm.getPassengers()) {
+                // 수하물
+                if (pax.getBaggageServices() != null) {
+                    for (var bs : pax.getBaggageServices()) {
+                        if (segment.getReservationSegmentId().equals(bs.getReservationSegmentId())) {
+                            Map<String, Object> item = new HashMap<>();
+                            item.put("passengerName", pax.getFirstName() + " " + pax.getLastName());
+                            item.put("serviceName", bs.getServiceDetails()); // JSON 형태
+                            baggageList.add(item);
+                        }
+                    }
+                }
+                // 기내식
+                if (pax.getMealServices() != null) {
+                    for (var ms : pax.getMealServices()) {
+                        if (segment.getReservationSegmentId().equals(ms.getReservationSegmentId())) {
+                            Map<String, Object> item = new HashMap<>();
+                            item.put("passengerName", pax.getFirstName() + " " + pax.getLastName());
+                            item.put("serviceName", ms.getMealName());
+                            mealList.add(item);
+                        }
+                    }
+                }
+            }
+
+            segData.put("baggageServices", baggageList);
+            segData.put("mealServices", mealList);
+            segmentServices.add(segData);
+        }
+
+        Long total = serviceService.getServiceTotal(reservationId, userId);
+
+        Map<String, Object> result = new HashMap<>();
+        result.put("success", true);
+        result.put("total", total);
+        result.put("segments", segmentServices);
         return ResponseEntity.ok(result);
     }
 

--- a/src/main/java/com/flyway/payment/controller/PaymentController.java
+++ b/src/main/java/com/flyway/payment/controller/PaymentController.java
@@ -4,6 +4,7 @@ import com.flyway.payment.config.TossPaymentsConfig;
 import com.flyway.payment.domain.PaymentConfirmRequest;
 import com.flyway.payment.dto.PaymentViewDto;
 import com.flyway.payment.service.PaymentService;
+import com.flyway.reservation.dto.BookingViewModel;
 import com.flyway.reservation.dto.ReservationSegmentView;
 import com.flyway.passenger.repository.PassengerServiceRepository;
 import com.flyway.reservation.repository.ReservationBookingRepository;
@@ -57,11 +58,15 @@ public class PaymentController {
         log.info("[결제페이지] 진입 - reservationId: {}, userId: {}",
                 reservationId, user.getUserId());
 
-        // 실제 금액 계산
+        BookingViewModel booking = reservationBookingRepository.findReservationHeader(reservationId);
         List<ReservationSegmentView> segments = reservationBookingRepository.findSegments(reservationId);
+
         long flightTotal = segments.stream()
                 .mapToLong(seg -> seg.getSnapPrice() != null ? seg.getSnapPrice() : 0L)
                 .sum();
+
+        // 승객 수 곱하기
+        flightTotal *= booking.getPassengerCount();
 
         // 부가서비스 금액
         Long serviceTotal = passengerServiceRepository.findServiceTotal(reservationId);

--- a/src/main/java/com/flyway/payment/mapper/PaymentMapper.java
+++ b/src/main/java/com/flyway/payment/mapper/PaymentMapper.java
@@ -32,5 +32,7 @@ public interface PaymentMapper {
                               @Param("status") String status,
                               @Param("method") String method);
     List<PaymentViewDto> selectByUserId(@Param("userId") String userId);
+    // 결제 row lock (FOR UPDATE)
+    PaymentViewDto selectByPaymentIdForUpdate(@Param("paymentId") String paymentId);
 
 }

--- a/src/main/java/com/flyway/payment/repository/PaymentRepository.java
+++ b/src/main/java/com/flyway/payment/repository/PaymentRepository.java
@@ -40,6 +40,11 @@ public interface PaymentRepository {
     void updateStatus(String paymentId, String status);
 
     /**
+     * 결제 ID로 조회 + Row Lock (동시 환불 방지)
+     */
+    Optional<PaymentViewDto> lockPaymentForUpdate(String paymentId);
+
+    /**
      * 토스 paymentKey 저장
      */
     void updatePaymentKey(String paymentId, String paymentKey);

--- a/src/main/java/com/flyway/payment/repository/PaymentRepositoryImpl.java
+++ b/src/main/java/com/flyway/payment/repository/PaymentRepositoryImpl.java
@@ -58,4 +58,10 @@ public class PaymentRepositoryImpl implements PaymentRepository {
     public List<PaymentViewDto> findByUserId(String userId) {
         return paymentMapper.selectByUserId(userId);
     }
+
+    @Override
+    public Optional<PaymentViewDto> lockPaymentForUpdate(String paymentId) {
+        return Optional.ofNullable(paymentMapper.selectByPaymentIdForUpdate(paymentId));
+    }
+
 }

--- a/src/main/java/com/flyway/payment/service/PaymentService.java
+++ b/src/main/java/com/flyway/payment/service/PaymentService.java
@@ -1,6 +1,8 @@
 package com.flyway.payment.service;
 import com.flyway.admin.dto.AdminNotificationDto;
 import com.flyway.admin.service.AdminNotificationService;
+import com.flyway.passenger.dto.PassengerReservationDto;
+import com.flyway.passenger.mapper.PassengerQueryMapper;
 import com.flyway.payment.domain.*;
 import com.flyway.payment.dto.PaymentViewDto;
 import com.flyway.payment.client.TossPaymentsClient;
@@ -8,6 +10,7 @@ import com.flyway.payment.mapper.RefundMapper;
 import com.flyway.payment.repository.PaymentRepository;
 import com.flyway.pricing.event.PricingEventService;
 import com.flyway.pricing.event.PricingEventServiceImpl;
+import com.flyway.reservation.dto.BookingViewModel;
 import com.flyway.reservation.dto.ReservationCoreView;
 import com.flyway.reservation.dto.ReservationSegmentView;
 import com.flyway.reservation.repository.ReservationBookingRepository;
@@ -43,6 +46,7 @@ public class PaymentService {
     private final SeatService seatService;
     private final PricingEventService pricingEventService;
     private final AdminNotificationService adminNotificationService;
+
 
     /**
      * 결제 처리 메인 로직 (개선된 3단계 설계)
@@ -148,10 +152,19 @@ public class PaymentService {
                 .priority("NORMAL")
                 .build();
         adminNotificationService.createAndBroadcastNotification(notification);
-        // SMS 발송 (여기에 추가)
+        // SMS 발송
         String phone = smsMapper.selectPhoneByReservationId(payment.getReservationId());
         if (phone != null && !phone.isEmpty()) {
             smsService.sendPaymentComplete(phone, payment.getReservationId(), payment.getAmount());
+        }
+
+        // 탑승객 예약 항공편 정보 전송
+        try {
+            smsService.sendTicketInfoToPassengers(reservationId);
+        } catch (Exception e) {
+            log.warn("[SMS] 탑승객 티켓 발송 실패 - reservationId: {}, error: {}",
+                    reservationId, e.getMessage());
+            // SMS 실패해도 결제는 성공 처리
         }
 
         return paymentRepository.findByPaymentId(paymentId)
@@ -182,9 +195,31 @@ public class PaymentService {
     }
 
     /**
-     * 환불 처리
+     * 환불 처리 메인 로직 \
      */
     public PaymentViewDto processRefund(String paymentId, RefundRequest request) {
+        // 1단계: 환불 준비
+        PaymentViewDto payment = prepareRefund(paymentId);
+
+        try {
+            // 2단계: 토스 API 호출 (트랜잭션 밖)
+            request.setPaymentKey(payment.getPaymentKey());
+            TossPaymentResponse tossResponse = tossClient.cancelPayment(request);
+
+            // 3단계: 환불 완료
+            return completeRefund(paymentId, tossResponse, request);
+        } catch (Exception e) {
+            // 실패 처리
+            failRefund(paymentId);
+            throw new RuntimeException("환불 실패: " + e.getMessage(), e);
+        }
+    }
+
+    /**
+     * 1단계: 환불 준비 - 결제 검증 및 상태 변경
+     */
+    @Transactional
+    public PaymentViewDto prepareRefund(String paymentId) {
         PaymentViewDto payment = paymentRepository.findByPaymentId(paymentId)
                 .orElseThrow(() -> new RuntimeException("결제 정보를 찾을 수 없습니다: " + paymentId));
 
@@ -192,9 +227,21 @@ public class PaymentService {
             throw new RuntimeException("환불 가능한 상태가 아닙니다: " + payment.getStatus());
         }
 
-        // 토스 환불 API 호출
-        request.setPaymentKey(payment.getPaymentKey());
-        TossPaymentResponse tossResponse = tossClient.cancelPayment(request);
+        // 상태를 REFUNDING으로 변경 (중복 환불 방지)
+        paymentRepository.updateStatus(paymentId, "REFUNDING");
+
+        return payment;
+    }
+
+    /**
+     * 2단계 성공: 환불 완료 처리
+     */
+    @Transactional
+    public PaymentViewDto completeRefund(String paymentId, TossPaymentResponse tossResponse, RefundRequest request) {
+        PaymentViewDto payment = paymentRepository.findByPaymentId(paymentId)
+                .orElseThrow(() -> new RuntimeException("결제 정보를 찾을 수 없습니다: " + paymentId));
+
+        String reservationId = payment.getReservationId();
 
         // 결제 상태 업데이트
         String newStatus = "CANCELED".equals(tossResponse.getStatus())
@@ -203,55 +250,61 @@ public class PaymentService {
         paymentRepository.updateStatus(paymentId, newStatus);
 
         // 예약 상태 → CANCELLED
-        String reservationId = payment.getReservationId();
-        reservationBookingRepository.updateReservationStatus(payment.getReservationId(), "CANCELLED");
+        reservationBookingRepository.updateReservationStatus(reservationId, "CANCELLED");
 
         // 좌석 BOOKED -> AVAILABLE
         seatService.releaseBookedSeats(reservationId);
+
         // 잔여석 복구
         int passengerCount = refundMapper.selectPassengerCountByReservationId(reservationId);
         List<RefundSegmentDto> segments = refundMapper.selectSegmentsByReservationId(reservationId);
 
         for (RefundSegmentDto segment : segments) {
             refundMapper.incrementSeat(segment.getFlightId(), segment.getCabinClass(), passengerCount);
-
-            // [알림] 환불 완료 알림 생성
-            AdminNotificationDto notification = AdminNotificationDto.builder()
-                    .notificationType("REFUND_COMPLETED")
-                    .title("환불 처리 완료")
-                    .message("사용자 요청에 의해 환불이 완료되었습니다.")
-                    .relatedResourceType("RESERVATION")
-                    .relatedResourceId(reservationId)
-                    .priority("NORMAL")
-                    .build();
-            adminNotificationService.createAndBroadcastNotification(notification);
         }
 
-        String refundId = UUID.randomUUID().toString();
+        // 관리자 알림
+        AdminNotificationDto notification = AdminNotificationDto.builder()
+                .notificationType("REFUND_COMPLETED")
+                .title("환불 처리 완료")
+                .message("사용자 요청에 의해 환불이 완료되었습니다.")
+                .relatedResourceType("RESERVATION")
+                .relatedResourceId(reservationId)
+                .priority("NORMAL")
+                .build();
+        adminNotificationService.createAndBroadcastNotification(notification);
 
         // refund 테이블 INSERT
         refundMapper.insertRefund(
-                refundId,
+                UUID.randomUUID().toString(),
                 reservationId,
                 paymentId,
-                "DEFAULT_RF_ID",  // TODO: 실제 refund_policy 조회 후 설정
+                "DEFAULT_RF_ID",
                 payment.getAmount(),
                 payment.getAmount(),
                 request.getCancelReason(),
                 null
         );
 
-        // 환불 이벤트 기반 항공편 가격 재산정
-//        pricingEventService.repriceAfterRefund(reservationId, refundId);
-
         // SMS 발송
         String phone = smsMapper.selectPhoneByReservationId(reservationId);
         if (phone != null && !phone.isEmpty()) {
             smsService.sendRefundComplete(phone, reservationId, payment.getAmount());
         }
+
         return paymentRepository.findByPaymentId(paymentId)
                 .orElseThrow(() -> new RuntimeException("결제 정보를 찾을 수 없습니다: " + paymentId));
     }
+
+    /**
+     * 2단계 실패: 환불 실패 처리
+     */
+    @Transactional
+    public void failRefund(String paymentId) {
+        // 상태를 PAID로 원복
+        paymentRepository.updateStatus(paymentId, PaymentStatus.PAID.name());
+    }
+
 
     /**
      * 결제 조회
@@ -352,11 +405,16 @@ public class PaymentService {
             throw new RuntimeException("예약 구간 정보가 없습니다: " + reservationId);
         }
 
+        // 승객 수 조회
+        BookingViewModel booking = reservationBookingRepository.findReservationHeader(reservationId);
+
         long flightTotal = segments.stream()
                 .mapToLong(seg -> seg.getSnapPrice() != null ? seg.getSnapPrice() : 0L)
                 .sum();
 
-        // 부가서비스 금액 (수하물, 기내식)
+        // 승객 수 곱하기
+        flightTotal *= booking.getPassengerCount();
+
         Long serviceTotal = passengerServiceRepository.findServiceTotal(reservationId);
 
         return flightTotal + (serviceTotal != null ? serviceTotal : 0L);

--- a/src/main/java/com/flyway/payment/service/PaymentService.java
+++ b/src/main/java/com/flyway/payment/service/PaymentService.java
@@ -72,7 +72,7 @@ public class PaymentService {
      * 1단계: 결제 준비 - 예약 검증 및 PENDING 상태로 결제 생성
      */
     @Transactional
-    public PaymentViewDto  preparePaymentByOrderId(PaymentConfirmRequest request) {
+    public PaymentViewDto preparePaymentByOrderId(PaymentConfirmRequest request) {
         String reservationId = extractReservationId(request.getOrderId());
 
         // 예약 row 잠금 (동시 결제 방지)
@@ -117,7 +117,7 @@ public class PaymentService {
     }
 
     /**
-     *  결제 완료 처리
+     * 결제 완료 처리
      */
     @Transactional
     public PaymentViewDto completePayment(String paymentId, TossPaymentResponse tossResponse) {
@@ -186,7 +186,7 @@ public class PaymentService {
         AdminNotificationDto notification = AdminNotificationDto.builder()
                 .notificationType("PAYMENT_FAILED")
                 .title("결제 실패 발생")
-                .message("결제 실패가 발생했습니다: " )
+                .message("결제 실패가 발생했습니다: ")
                 .relatedResourceType("RESERVATION")
                 .relatedResourceId(reservationId)
                 .priority("HIGH")
@@ -220,7 +220,8 @@ public class PaymentService {
      */
     @Transactional
     public PaymentViewDto prepareRefund(String paymentId) {
-        PaymentViewDto payment = paymentRepository.findByPaymentId(paymentId)
+        // Row Lock으로 동시 환불 방지
+        PaymentViewDto payment = paymentRepository.lockPaymentForUpdate(paymentId)
                 .orElseThrow(() -> new RuntimeException("결제 정보를 찾을 수 없습니다: " + paymentId));
 
         if (!PaymentStatus.PAID.name().equals(payment.getStatus())) {
@@ -318,6 +319,7 @@ public class PaymentService {
     public PaymentViewDto findByReservationId(String reservationId) {
         return paymentRepository.findByReservationId(reservationId).orElse(null);
     }
+
     //환불에서 조회
     @Transactional(readOnly = true)
     public List<PaymentViewDto> findPaymentsByUserId(String userId) {
@@ -352,7 +354,6 @@ public class PaymentService {
     public String generateOrderId(String reservationId) {
         return "ORDER_" + reservationId + "_" + System.currentTimeMillis();
     }
-
 
 
     /**
@@ -405,15 +406,23 @@ public class PaymentService {
             throw new RuntimeException("예약 구간 정보가 없습니다: " + reservationId);
         }
 
-        // 승객 수 조회
+        // 승객 수 조회 - null 체크 추가
         BookingViewModel booking = reservationBookingRepository.findReservationHeader(reservationId);
+        if (booking == null) {
+            throw new RuntimeException("예약 정보를 찾을 수 없습니다: " + reservationId);
+        }
+
+        Integer passengerCount = booking.getPassengerCount();
+        if (passengerCount == null || passengerCount <= 0) {
+            throw new RuntimeException("승객 수가 올바르지 않습니다: " + reservationId);
+        }
 
         long flightTotal = segments.stream()
                 .mapToLong(seg -> seg.getSnapPrice() != null ? seg.getSnapPrice() : 0L)
                 .sum();
 
         // 승객 수 곱하기
-        flightTotal *= booking.getPassengerCount();
+        flightTotal *= passengerCount;
 
         Long serviceTotal = passengerServiceRepository.findServiceTotal(reservationId);
 

--- a/src/main/java/com/flyway/reservation/controller/ReservationBookingController.java
+++ b/src/main/java/com/flyway/reservation/controller/ReservationBookingController.java
@@ -12,7 +12,9 @@ import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.*;
 
 import java.lang.reflect.Method;
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 @Controller
@@ -43,6 +45,26 @@ public class ReservationBookingController {
         bookingService.savePassengers(reservationId, userId, form.getPassengers());
 
         return "redirect:/reservations/" + reservationId + "/booking?saved=1";
+    }
+    // 좌석 정보 조회 API (AJAX용)
+    @GetMapping("/{reservationId}/seats/info")
+    @ResponseBody
+    public ResponseEntity<Map<String, Object>> getSeatInfo(@PathVariable String reservationId) {
+        String userId = getAuthenticatedUserIdOrThrow();
+        BookingViewModel vm = bookingService.getBookingView(reservationId, userId);
+
+        List<Map<String, Object>> segmentSeats = new ArrayList<>();
+        for (var segment : vm.getSegments()) {
+            Map<String, Object> segData = new HashMap<>();
+            segData.put("segmentOrder", segment.getSegmentOrder());
+            segData.put("passengerSeats", segment.getPassengerSeats());
+            segmentSeats.add(segData);
+        }
+
+        Map<String, Object> result = new HashMap<>();
+        result.put("success", true);
+        result.put("segments", segmentSeats);
+        return ResponseEntity.ok(result);
     }
 //json형식
     @PostMapping("/{reservationId}/passengers/api")

--- a/src/main/java/com/flyway/sender/dto/PassengerSmsInfo.java
+++ b/src/main/java/com/flyway/sender/dto/PassengerSmsInfo.java
@@ -1,0 +1,17 @@
+package com.flyway.sender.dto;
+
+import lombok.*;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class PassengerSmsInfo {
+
+    private String passengerId;
+    private String firstName;
+    private String lastName;
+    private String phoneNumber;
+
+}

--- a/src/main/java/com/flyway/sender/dto/PassengerTicketInfo.java
+++ b/src/main/java/com/flyway/sender/dto/PassengerTicketInfo.java
@@ -1,0 +1,28 @@
+package com.flyway.sender.dto;
+
+import lombok.*;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class PassengerTicketInfo {
+
+    private String passengerId;
+    private String firstName;
+    private String lastName;
+    private String phoneNumber;
+
+    // 구간 정보
+    private String reservationSegmentId;
+    private Integer segmentOrder;
+
+    // 좌석 정보
+    private String seatNo;
+
+    // 부가서비스
+    private String serviceType;
+    private String mealName;
+    private String serviceDetails;
+}

--- a/src/main/java/com/flyway/sender/mapper/SmsMapper.java
+++ b/src/main/java/com/flyway/sender/mapper/SmsMapper.java
@@ -1,7 +1,11 @@
 package com.flyway.sender.mapper;
 
+import com.flyway.sender.dto.PassengerSmsInfo;
+import com.flyway.sender.dto.PassengerTicketInfo;
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
+
+import java.util.List;
 
 @Mapper
 public interface SmsMapper {
@@ -9,4 +13,10 @@ public interface SmsMapper {
     String selectPhoneByUserId(@Param("userId") String userId);
 
     String selectPhoneByReservationId(@Param("reservationId") String reservationId);
+
+    List<PassengerSmsInfo> selectPassengersByReservationId(
+            @Param("reservationId") String reservationId);
+
+    List<PassengerTicketInfo> selectPassengerTicketInfo(
+            @Param("reservationId") String reservationId);
 }

--- a/src/main/java/com/flyway/sender/service/SmsService.java
+++ b/src/main/java/com/flyway/sender/service/SmsService.java
@@ -1,6 +1,11 @@
 package com.flyway.sender.service;
 
+import com.flyway.reservation.dto.ReservationSegmentView;
+import com.flyway.reservation.repository.ReservationBookingRepository;
 import com.flyway.sender.config.SmsConfig;
+import com.flyway.sender.dto.PassengerSmsInfo;
+import com.flyway.sender.dto.PassengerTicketInfo;
+import com.flyway.sender.mapper.SmsMapper;
 import lombok.extern.slf4j.Slf4j;
 import net.nurigo.sdk.NurigoApp;
 import net.nurigo.sdk.message.model.Message;
@@ -10,16 +15,27 @@ import net.nurigo.sdk.message.service.DefaultMessageService;
 import org.springframework.stereotype.Service;
 
 import javax.annotation.PostConstruct;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 @Slf4j
 @Service
 public class SmsService {
 
     private final SmsConfig smsConfig;
+    private final SmsMapper smsMapper;
+    private final ReservationBookingRepository reservationBookingRepository;
     private DefaultMessageService messageService;
 
-    public SmsService(SmsConfig smsConfig) {
+    public SmsService(SmsConfig smsConfig,
+                      SmsMapper smsMapper,
+                      ReservationBookingRepository reservationBookingRepository) {
         this.smsConfig = smsConfig;
+        this.smsMapper = smsMapper;
+        this.reservationBookingRepository = reservationBookingRepository;
     }
 
     @PostConstruct
@@ -61,5 +77,136 @@ public class SmsService {
                 reservationId, amount
         );
         sendSms(to, content);
+    }
+
+    // 탑승객에게 티켓 정보 SMS 발송 (reservationId만 받음)
+    public void sendTicketInfoToPassengers(String reservationId) {
+
+        // 항공편 정보 조회
+        List<ReservationSegmentView> segments =
+                reservationBookingRepository.findSegments(reservationId);
+
+        // 탑승객별 티켓 정보 조회 (좌석/기내식/수하물 포함)
+        List<PassengerTicketInfo> ticketInfoList =
+                smsMapper.selectPassengerTicketInfo(reservationId);
+
+        if (ticketInfoList == null || ticketInfoList.isEmpty()) {
+            log.info("[SMS] 티켓 발송 대상 없음 - reservationId: {}", reservationId);
+            return;
+        }
+
+        // passengerId별로 그룹핑
+        Map<String, List<PassengerTicketInfo>> passengerMap = ticketInfoList.stream()
+                .collect(Collectors.groupingBy(PassengerTicketInfo::getPassengerId));
+
+        for (Map.Entry<String, List<PassengerTicketInfo>> entry : passengerMap.entrySet()) {
+            List<PassengerTicketInfo> paxInfoList = entry.getValue();
+            PassengerTicketInfo firstInfo = paxInfoList.get(0);
+
+            try {
+                String content = buildTicketSmsContent(firstInfo, segments, paxInfoList);
+                sendSms(firstInfo.getPhoneNumber(), content);
+                log.info("[SMS] 티켓 발송 - passenger: {} {}, phone: {}",
+                        firstInfo.getFirstName(), firstInfo.getLastName(), firstInfo.getPhoneNumber());
+            } catch (Exception e) {
+                log.error("[SMS] 티켓 발송 실패 - passengerId: {}, error: {}",
+                        firstInfo.getPassengerId(), e.getMessage());
+            }
+        }
+    }
+
+    /**
+     * 티켓 SMS 내용 생성
+     */
+    private String buildTicketSmsContent(PassengerTicketInfo pax,
+                                         List<ReservationSegmentView> segments,
+                                         List<PassengerTicketInfo> paxInfoList) {
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("[Flyway 항공권]\n");
+        sb.append("탑승객: ").append(pax.getFirstName()).append(" ").append(pax.getLastName()).append("\n\n");
+
+        for (ReservationSegmentView seg : segments) {
+            sb.append("【구간 ").append(seg.getSegmentOrder()).append("】\n");
+            sb.append(seg.getSnapFlightNumber()).append("\n");
+            sb.append(seg.getSnapDepartureAirport()).append(" → ").append(seg.getSnapArrivalAirport()).append("\n");
+            sb.append(formatDateTime(seg.getSnapDepartureTime())).append("\n");
+
+            // 해당 구간의 모든 정보 가져오기
+            List<PassengerTicketInfo> segmentInfoList = paxInfoList.stream()
+                    .filter(info -> seg.getReservationSegmentId().equals(info.getReservationSegmentId()))
+                    .collect(Collectors.toList());
+
+            // 좌석 (아무 row에서나 - 같은 값)
+            segmentInfoList.stream().findFirst().ifPresent(info -> {
+                if (info.getSeatNo() != null && !info.getSeatNo().isEmpty()) {
+                    sb.append("좌석: ").append(info.getSeatNo()).append("\n");
+                }
+            });
+
+            // 기내식 (service_type = '1')
+            segmentInfoList.stream()
+                    .filter(info -> "1".equals(info.getServiceType()))
+                    .findFirst()
+                    .ifPresent(info -> {
+                        if (info.getMealName() != null && !info.getMealName().isEmpty()) {
+                            sb.append("기내식: ").append(info.getMealName()).append("\n");
+                        }
+                    });
+
+            // 수하물 (service_type = '0')
+            segmentInfoList.stream()
+                    .filter(info -> "0".equals(info.getServiceType()))
+                    .findFirst()
+                    .ifPresent(info -> {
+                        if (info.getServiceDetails() != null && !info.getServiceDetails().isEmpty()) {
+                            String baggageInfo = parseBaggageInfo(info.getServiceDetails());
+                            if (!baggageInfo.isEmpty()) {
+                                sb.append("수하물: ").append(baggageInfo).append("\n");
+                            }
+                        }
+                    });
+
+            sb.append("\n");
+        }
+
+        return sb.toString();
+    }
+    private String formatDateTime(LocalDateTime dt) {
+        if (dt == null) return "";
+        return dt.format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm"));
+    }
+
+    private String parseBaggageInfo(String serviceDetails) {
+        try {
+            StringBuilder result = new StringBuilder();
+
+            if (serviceDetails.contains("extraKg")) {
+                int kgStart = serviceDetails.indexOf("extraKg") + 9;
+                int kgEnd = serviceDetails.indexOf(",", kgStart);
+                if (kgEnd == -1) kgEnd = serviceDetails.indexOf("}", kgStart);
+                String kgStr = serviceDetails.substring(kgStart, kgEnd).trim();
+                int kg = Integer.parseInt(kgStr);
+                if (kg > 0) {
+                    result.append("+").append(kg).append("kg");
+                }
+            }
+
+            if (serviceDetails.contains("extraBags")) {
+                int bagStart = serviceDetails.indexOf("extraBags") + 11;
+                int bagEnd = serviceDetails.indexOf("}", bagStart);
+                String bagStr = serviceDetails.substring(bagStart, bagEnd).trim();
+                int bags = Integer.parseInt(bagStr);
+                if (bags > 0) {
+                    if (result.length() > 0) result.append(", ");
+                    result.append("추가 ").append(bags).append("개");
+                }
+            }
+
+            return result.toString();
+        } catch (Exception e) {
+            log.warn("[SMS] 수하물 정보 파싱 실패: {}", serviceDetails);
+            return "";
+        }
     }
 }

--- a/src/main/resources/mapper/payment/PaymentMapper.xml
+++ b/src/main/resources/mapper/payment/PaymentMapper.xml
@@ -35,26 +35,43 @@
                      #{status}
                  )
     </insert>
-
     <!-- 결제 ID로 조회 -->
     <select id="selectByPaymentId" parameterType="string"
             resultType="com.flyway.payment.dto.PaymentViewDto">
         SELECT
-        p.payment_id      AS paymentId,
-        p.reservation_id  AS reservationId,
-        r.user_id         AS userId,
-        p.payment_key     AS paymentKey,
-        p.order_id        AS orderId,
-        p.amount          AS amount,
-        p.payment_method  AS method,
-        p.status          AS status,
-        p.paid_at         AS paidAt,
-        p.created_at      AS createdAt
+            p.payment_id      AS paymentId,
+            p.reservation_id  AS reservationId,
+            r.user_id         AS userId,
+            p.payment_key     AS paymentKey,
+            p.order_id        AS orderId,
+            p.amount          AS amount,
+            p.payment_method  AS method,
+            p.status          AS status,
+            p.paid_at         AS paidAt,
+            p.created_at      AS createdAt
         FROM payment p
-        JOIN reservation r ON p.reservation_id = r.reservation_id
+                 JOIN reservation r ON p.reservation_id = r.reservation_id
         WHERE p.payment_id = #{paymentId}
     </select>
-
+    <!-- 결제 ID로 조회 + Row Lock (동시 환불 방지) -->
+    <select id="selectByPaymentIdForUpdate" parameterType="string"
+            resultType="com.flyway.payment.dto.PaymentViewDto">
+        SELECT
+            p.payment_id      AS paymentId,
+            p.reservation_id  AS reservationId,
+            r.user_id         AS userId,
+            p.payment_key     AS paymentKey,
+            p.order_id        AS orderId,
+            p.amount          AS amount,
+            p.payment_method  AS method,
+            p.status          AS status,
+            p.paid_at         AS paidAt,
+            p.created_at      AS createdAt
+        FROM payment p
+                 JOIN reservation r ON p.reservation_id = r.reservation_id
+        WHERE p.payment_id = #{paymentId}
+            FOR UPDATE
+    </select>
 
     <!-- 주문 ID로 조회 -->
     <select id="selectByOrderId" parameterType="string"

--- a/src/main/resources/mapper/sender/SmsMapper.xml
+++ b/src/main/resources/mapper/sender/SmsMapper.xml
@@ -17,4 +17,52 @@
         WHERE r.reservation_id = #{reservationId}
     </select>
 
+    <!-- 탑승객 전화번호 목록 조회 -->
+    <select id="selectPassengersByReservationId"
+            resultType="com.flyway.sender.dto.PassengerSmsInfo">
+        SELECT
+            passenger_id   AS passengerId,
+            first_name     AS firstName,
+            last_name      AS lastName,
+            phone_number   AS phoneNumber
+        FROM passenger
+        WHERE reservation_id = #{reservationId}
+          AND phone_number IS NOT NULL
+          AND phone_number != ''
+    </select>
+    <!-- 탑승객별 티켓 정보 (좌석/기내식/수하물 ) -->
+    <select id="selectPassengerTicketInfo"
+            resultType="com.flyway.sender.dto.PassengerTicketInfo">
+        SELECT
+            p.passenger_id              AS passengerId,
+            p.first_name                AS firstName,
+            p.last_name                 AS lastName,
+            p.phone_number              AS phoneNumber,
+            rs.reservation_segment_id   AS reservationSegmentId,
+            rs.segment_order            AS segmentOrder,
+            acs.seat_no                 AS seatNo,
+            ps.service_type             AS serviceType,
+            mo.meal_name                AS mealName,
+            ps.service_details          AS serviceDetails
+        FROM passenger p
+                 JOIN reservation_segment rs
+                      ON rs.reservation_id = p.reservation_id
+                 LEFT JOIN passenger_seat pst
+                           ON pst.passenger_id = p.passenger_id
+                               AND pst.reservation_segment_id = rs.reservation_segment_id
+                 LEFT JOIN flight_seat fs
+                           ON fs.flight_seat_id = pst.flight_seat_id
+                 LEFT JOIN aircraft_seat acs
+                           ON acs.airplane_seat_id = fs.aircraft_seat_id
+                 LEFT JOIN passenger_service ps
+                           ON ps.passenger_id = p.passenger_id
+                               AND ps.reservation_segment_id = rs.reservation_segment_id
+                 LEFT JOIN meal_option mo
+                           ON mo.meal_id = ps.meal_id
+        WHERE p.reservation_id = #{reservationId}
+          AND p.phone_number IS NOT NULL
+          AND p.phone_number != ''
+        ORDER BY p.passenger_id, rs.segment_order, ps.added_at
+    </select>
+
 </mapper>

--- a/src/main/webapp/WEB-INF/views/payment/payment.jsp
+++ b/src/main/webapp/WEB-INF/views/payment/payment.jsp
@@ -263,7 +263,7 @@
     document.querySelectorAll('.method-btn').forEach(function(btn) {
         btn.addEventListener('click', function() {
             document.querySelectorAll('.method-btn').forEach(function(b) {
-                b.classList.remove('active');d
+                b.classList.remove('active');
             });
             this.classList.add('active');
             selectedMethod = this.dataset.method;

--- a/src/main/webapp/WEB-INF/views/payment/payment.jsp
+++ b/src/main/webapp/WEB-INF/views/payment/payment.jsp
@@ -263,7 +263,7 @@
     document.querySelectorAll('.method-btn').forEach(function(btn) {
         btn.addEventListener('click', function() {
             document.querySelectorAll('.method-btn').forEach(function(b) {
-                b.classList.remove('active');
+                b.classList.remove('active');d
             });
             this.classList.add('active');
             selectedMethod = this.dataset.method;

--- a/src/main/webapp/WEB-INF/views/reservations/booking.jsp
+++ b/src/main/webapp/WEB-INF/views/reservations/booking.jsp
@@ -367,16 +367,18 @@
                 </div>
 
                 <!-- Seat Details -->
-                <c:forEach var="s" items="${vm.segments}">
-                    <c:if test="${not empty s.passengerSeats}">
-                        <div class="pl-3 mb-2 text-xs text-slate-400 border-l-2 border-slate-100">
-                            <span class="block mb-1">${s.segmentOrder == 1 ? '가는편' : '오는편'} 좌석:</span>
-                            <c:forEach var="seat" items="${s.passengerSeats}" varStatus="st">
-                                ${seat.passengerName} ${seat.seatNo}<c:if test="${!st.last}">, </c:if>
-                            </c:forEach>
-                        </div>
-                    </c:if>
-                </c:forEach>
+                <div id="seatInfoContainer">
+                    <c:forEach var="s" items="${vm.segments}">
+                        <c:if test="${not empty s.passengerSeats}">
+                            <div class="pl-3 mb-2 text-xs text-slate-400 border-l-2 border-slate-100">
+                                <span class="block mb-1">${s.segmentOrder == 1 ? '가는편' : '오는편'} 좌석:</span>
+                                <c:forEach var="seat" items="${s.passengerSeats}" varStatus="st">
+                                    ${seat.passengerName} ${seat.seatNo}<c:if test="${!st.last}">, </c:if>
+                                </c:forEach>
+                            </div>
+                        </c:if>
+                    </c:forEach>
+                </div>
 
                 <div class="flex justify-between mb-3 text-sm text-slate-500">
                     <span>부가서비스</span>
@@ -384,45 +386,47 @@
                 </div>
 
                 <!-- Service Details -->
-                <c:forEach var="s" items="${vm.segments}">
-                    <c:set var="hasBaggage" value="false"/>
-                    <c:forEach var="svc" items="${s.passengerServices}">
-                        <c:if test="${svc.serviceType == '0'}"><c:set var="hasBaggage" value="true"/></c:if>
+                <div id="serviceInfoContainer">
+                    <c:forEach var="s" items="${vm.segments}">
+                        <c:set var="hasBaggage" value="false"/>
+                        <c:forEach var="svc" items="${s.passengerServices}">
+                            <c:if test="${svc.serviceType == '0'}"><c:set var="hasBaggage" value="true"/></c:if>
+                        </c:forEach>
+                        <c:if test="${hasBaggage}">
+                            <div class="pl-3 mb-2 text-xs text-slate-400 border-l-2 border-slate-100">
+                                <span class="block mb-1">${s.segmentOrder == 1 ? '가는편' : '오는편'} 수하물:</span>
+                                <c:set var="isFirst" value="true" />
+                                <c:forEach var="svc" items="${s.passengerServices}">
+                                    <c:if test="${svc.serviceType == '0'}">
+                                        <c:if test="${!isFirst}">, </c:if>
+                                        ${svc.passengerName} ${svc.serviceName}
+                                        <c:set var="isFirst" value="false" />
+                                    </c:if>
+                                </c:forEach>
+                            </div>
+                        </c:if>
                     </c:forEach>
-                    <c:if test="${hasBaggage}">
-                        <div class="pl-3 mb-2 text-xs text-slate-400 border-l-2 border-slate-100">
-                            <span class="block mb-1">${s.segmentOrder == 1 ? '가는편' : '오는편'} 수하물:</span>
-                            <c:set var="isFirst" value="true" />
-                            <c:forEach var="svc" items="${s.passengerServices}">
-                                <c:if test="${svc.serviceType == '0'}">
-                                    <c:if test="${!isFirst}">, </c:if>
-                                    ${svc.passengerName} ${svc.serviceName}
-                                    <c:set var="isFirst" value="false" />
-                                </c:if>
-                            </c:forEach>
-                        </div>
-                    </c:if>
-                </c:forEach>
 
-                <c:forEach var="s" items="${vm.segments}">
-                    <c:set var="hasMeal" value="false"/>
-                    <c:forEach var="svc" items="${s.passengerServices}">
-                        <c:if test="${svc.serviceType == '1'}"><c:set var="hasMeal" value="true"/></c:if>
+                    <c:forEach var="s" items="${vm.segments}">
+                        <c:set var="hasMeal" value="false"/>
+                        <c:forEach var="svc" items="${s.passengerServices}">
+                            <c:if test="${svc.serviceType == '1'}"><c:set var="hasMeal" value="true"/></c:if>
+                        </c:forEach>
+                        <c:if test="${hasMeal}">
+                            <div class="pl-3 mb-2 text-xs text-slate-400 border-l-2 border-slate-100">
+                                <span class="block mb-1">${s.segmentOrder == 1 ? '가는편' : '오는편'} 기내식:</span>
+                                <c:set var="isFirst" value="true" />
+                                <c:forEach var="svc" items="${s.passengerServices}">
+                                    <c:if test="${svc.serviceType == '1'}">
+                                        <c:if test="${!isFirst}">, </c:if>
+                                        ${svc.passengerName} ${svc.serviceName}
+                                        <c:set var="isFirst" value="false" />
+                                    </c:if>
+                                </c:forEach>
+                            </div>
+                        </c:if>
                     </c:forEach>
-                    <c:if test="${hasMeal}">
-                        <div class="pl-3 mb-2 text-xs text-slate-400 border-l-2 border-slate-100">
-                            <span class="block mb-1">${s.segmentOrder == 1 ? '가는편' : '오는편'} 기내식:</span>
-                            <c:set var="isFirst" value="true" />
-                            <c:forEach var="svc" items="${s.passengerServices}">
-                                <c:if test="${svc.serviceType == '1'}">
-                                    <c:if test="${!isFirst}">, </c:if>
-                                    ${svc.passengerName} ${svc.serviceName}
-                                    <c:set var="isFirst" value="false" />
-                                </c:if>
-                            </c:forEach>
-                        </div>
-                    </c:if>
-                </c:forEach>
+                </div>
 
                 <div class="mt-4 pt-4 border-t border-gray-100 flex justify-between items-end">
                     <span class="font-extrabold text-slate-800">총 결제금액</span>
@@ -495,17 +499,89 @@
         window.open(popupUrl, 'servicePopup', popupOption);
     }
 
-    // 부가서비스 총액 갱신 (팝업에서 호출)
-    async function refreshServiceTotal() {
+    // 부가서비스 정보 갱신 (총액 + 상세)
+    async function refreshServiceInfo() {
         try {
-            const res = await fetchWithRefresh('/reservations/' + reservationId + '/services/total');
+            const res = await fetchWithRefresh('/reservations/' + reservationId + '/services/details');
             const data = await res.json();
             if (data.success) {
+                // 총액 갱신
                 document.getElementById('servicePrice').textContent = '₩' + numberWithCommas(data.total);
+
+                // 상세 정보 갱신
+                let html = '';
+                data.segments.forEach(function(seg) {
+                    var label = seg.segmentOrder === 1 ? '가는편' : '오는편';
+
+                    // 수하물
+                    if (seg.baggageServices && seg.baggageServices.length > 0) {
+                        html += '<div class="pl-3 mb-2 text-xs text-slate-400 border-l-2 border-slate-100">';
+                        html += '<span class="block mb-1">' + label + ' 수하물:</span>';
+                        seg.baggageServices.forEach(function(svc, idx) {
+                            if (idx > 0) html += ', ';
+                            html += svc.passengerName + ' ' + parseBaggageInfo(svc.serviceName);
+                        });
+                        html += '</div>';
+                    }
+
+                    // 기내식
+                    if (seg.mealServices && seg.mealServices.length > 0) {
+                        html += '<div class="pl-3 mb-2 text-xs text-slate-400 border-l-2 border-slate-100">';
+                        html += '<span class="block mb-1">' + label + ' 기내식:</span>';
+                        seg.mealServices.forEach(function(svc, idx) {
+                            if (idx > 0) html += ', ';
+                            html += svc.passengerName + ' ' + svc.serviceName;
+                        });
+                        html += '</div>';
+                    }
+                });
+                document.getElementById('serviceInfoContainer').innerHTML = html;
+
                 updateTotalPrice();
             }
         } catch (err) {
-            console.error('Failed to refresh service total', err);
+            console.error('Failed to refresh service info', err);
+        }
+    }
+
+    // 수하물 JSON 파싱 (예: {"extraKg":5,"extraBags":1} → "+5kg, 추가 1개")
+    function parseBaggageInfo(jsonStr) {
+        try {
+            var obj = JSON.parse(jsonStr);
+            var parts = [];
+            if (obj.extraKg > 0) parts.push('+' + obj.extraKg + 'kg');
+            if (obj.extraBags > 0) parts.push('추가 ' + obj.extraBags + '개');
+            return parts.length > 0 ? parts.join(', ') : '기본';
+        } catch (e) {
+            return jsonStr || '기본';
+        }
+    }
+
+    // 기존 호환성 유지
+    function refreshServiceTotal() {
+        refreshServiceInfo();
+    }
+    async function refreshSeatInfo() {
+        try {
+            const res = await fetchWithRefresh('/reservations/' + reservationId + '/seats/info');
+            const data = await res.json();
+            if (data.success) {
+                let html = '';
+                data.segments.forEach(function(seg) {
+                    if (seg.passengerSeats && seg.passengerSeats.length > 0) {
+                        html += '<div class="pl-3 mb-2 text-xs text-slate-400 border-l-2 border-slate-100">';
+                        html += '<span class="block mb-1">' + (seg.segmentOrder === 1 ? '가는편' : '오는편') + '좌석:</span>';
+                        seg.passengerSeats.forEach(function(seat, idx) {
+                            html += seat.passengerName + ' ' + seat.seatNo;
+                            if (idx < seg.passengerSeats.length - 1) html += ', ';
+                        });
+                        html += '</div>';
+                    }
+                });
+                document.getElementById('seatInfoContainer').innerHTML = html;
+            }
+        } catch (err) {
+            console.error('Failed to refresh seat info', err);
         }
     }
     // 총 금액 업데이트
@@ -552,7 +628,7 @@
         document.getElementById('flightPrice').textContent = '₩' + numberWithCommas(flightTotal);
 
         if (passengerSaved) {
-            refreshServiceTotal();
+            refreshServiceInfo();
         }
         updateTotalPrice();
 
@@ -570,6 +646,8 @@
     window.openSeatPopup = openSeatPopup;
     window.openServicePopup = openServicePopup;
     window.refreshServiceTotal = refreshServiceTotal;
+    window.refreshServiceInfo = refreshServiceInfo;
+    window.refreshSeatInfo = refreshSeatInfo;
     window.goPayment = goPayment;
 
     async function savePassengers(event) {

--- a/src/main/webapp/WEB-INF/views/reservations/service-popup.jsp
+++ b/src/main/webapp/WEB-INF/views/reservations/service-popup.jsp
@@ -281,9 +281,11 @@
                 await mealRes.json();
             }
 
-            // 부모 창에 총액 갱신 요청
-            if (window.opener && window.opener.refreshServiceTotal) {
-                window.opener.refreshServiceTotal();
+            // 부모 창에 부가서비스 정보 갱신 요청
+            if (window.opener && typeof window.opener.refreshServiceInfo === 'function') {
+                window.opener.refreshServiceInfo();
+            } else if (window.opener && typeof window.opener.refreshServiceTotal === 'function') {
+                window.opener.refreshServiceTotal();  // fallback
             }
             alert('저장되었습니다.');
             window.close();


### PR DESCRIPTION
## 📌 PR 설명
<br>결제 시 인원수 만큼 결제 금액 계산되도록 수정 
항공권 정보 및 부가서비스 선택 사항 문자 발송
환불 트랜잭션 외부 api는 트랜잭션 밖으로 빼서 db 커넥션 점유 시간 줄임 
예매 페이지에서 ajax 적용하여 새로고침을 하지 않아도 부가서비스 선택사항 표시하게 함 

## ✅ 완료한 기능 명세

- [x] 결제 시 인원수 만큼 결제 금액 계산 수정
- [x]  항공권 정보 및 부가서비스 선택 사항 문자 발송
- [x] 환불 트랜잭션 변경
- [x] ajax 반

<br>

## 📸 스크린샷

<br>

## 💭 고민과 해결과정
환불도중 오류나 취소 시 db 일부 칼럼만 수정되어 데이터 불일치가 생기는 것을 막기위해 트랜잭션 적용
토스 외부 api 호출은 소요시간이 길기 때문에  트랜잭션 밖으로 빼서 db 커넥션 점유 시간 줄임 
<br>

### 🔗 관련 이슈
Closes #212

<br>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Detailed per-segment service info endpoint (baggage & meals)
  * Seat info endpoint for reservations
  * Ticket-info SMS delivery to passengers
  * Structured multi-step refund workflow (prepare/complete/fail)
  * Payment totals now account for passenger count

* **Bug Fixes**
  * More tolerant ticket delivery during payment completion to avoid blocking

* **UI Improvements**
  * Booking page: dynamic service and seat refresh functions and rendering
<!-- end of auto-generated comment: release notes by coderabbit.ai -->