### PR TITLE
[FLYW-195] 좌석 맵 UI 수정

### DIFF
--- a/src/main/webapp/WEB-INF/views/reservations/booking.jsp
+++ b/src/main/webapp/WEB-INF/views/reservations/booking.jsp
@@ -71,6 +71,139 @@
             width: 14px;
             height: 14px;
         }
+
+        /* Passport Toggle Checkbox */
+        .passport-toggle:checked + span {
+            border-color: #1f6feb;
+            background-color: #1f6feb;
+        }
+        .passport-toggle:checked + span svg {
+            opacity: 1;
+        }
+        .passport-toggle:focus + span {
+            box-shadow: 0 0 0 3px rgba(31, 111, 235, 0.2);
+        }
+
+        /* Wheel Date Picker - Inline Dropdown Style */
+        .wheel-picker-wrapper {
+            position: absolute;
+            top: 100%;
+            left: 0;
+            right: 0;
+            z-index: 100;
+            padding-top: 8px;
+            opacity: 0;
+            visibility: hidden;
+            transform: translateY(-10px);
+            transition: all 0.2s ease;
+        }
+        .wheel-picker-wrapper.active {
+            opacity: 1;
+            visibility: visible;
+            transform: translateY(0);
+        }
+        .wheel-picker {
+            background: white;
+            border-radius: 16px;
+            box-shadow: 0 10px 40px rgba(0, 0, 0, 0.15);
+            border: 1px solid #e5e7eb;
+            overflow: hidden;
+        }
+        .wheel-picker__header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            padding: 12px 16px;
+            border-bottom: 1px solid #f1f5f9;
+            background: #f8fafc;
+        }
+        .wheel-picker__title {
+            font-size: 13px;
+            font-weight: 700;
+            color: #475569;
+        }
+        .wheel-picker__btn {
+            font-size: 12px;
+            font-weight: 600;
+            padding: 6px 12px;
+            border: none;
+            border-radius: 6px;
+            cursor: pointer;
+            transition: all 0.2s;
+        }
+        .wheel-picker__btn--cancel {
+            background: #e2e8f0;
+            color: #64748b;
+        }
+        .wheel-picker__btn--cancel:hover {
+            background: #cbd5e1;
+        }
+        .wheel-picker__btn--confirm {
+            background: #1f6feb;
+            color: white;
+        }
+        .wheel-picker__btn--confirm:hover {
+            background: #1a5fd1;
+        }
+        .wheel-picker__wheels {
+            display: flex;
+            padding: 0 8px;
+            position: relative;
+        }
+        .wheel-picker__wheel {
+            flex: 1;
+            height: 150px;
+            overflow-y: scroll;
+            scroll-snap-type: y mandatory;
+            -webkit-overflow-scrolling: touch;
+            scrollbar-width: none;
+        }
+        .wheel-picker__wheel::-webkit-scrollbar {
+            display: none;
+        }
+        .wheel-picker__wheel::before,
+        .wheel-picker__wheel::after {
+            content: '';
+            display: block;
+            height: 55px;
+        }
+        .wheel-picker__item {
+            height: 40px;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            font-size: 14px;
+            font-weight: 500;
+            color: #9ca3af;
+            scroll-snap-align: center;
+            transition: all 0.15s;
+            cursor: pointer;
+        }
+        .wheel-picker__item:hover {
+            color: #64748b;
+        }
+        .wheel-picker__item.selected {
+            font-size: 18px;
+            font-weight: 700;
+            color: #1f6feb;
+        }
+        .wheel-picker__highlight {
+            position: absolute;
+            top: 50%;
+            left: 12px;
+            right: 12px;
+            height: 40px;
+            transform: translateY(-50%);
+            background: rgba(31, 111, 235, 0.06);
+            border-radius: 8px;
+            border-top: 1.5px solid #1f6feb;
+            border-bottom: 1.5px solid #1f6feb;
+            pointer-events: none;
+        }
+        /* 생년월일 필드 wrapper */
+        .birth-input-wrapper {
+            position: relative;
+        }
     </style>
 </head>
 
@@ -159,7 +292,7 @@
                                 </div>
                                 <div class="airport-code uppercase">${s.snapArrivalAirport}</div>
                                 <div class="airport-name">
-                                    ${s.snapArrivalCity}
+                                        ${s.snapArrivalCity}
                                     <fmt:formatDate value="${depDate}" pattern="yyyyMMdd" var="depDay"/>
                                     <fmt:formatDate value="${arrDate}" pattern="yyyyMMdd" var="arrDay"/>
                                     <c:set var="dayDiff" value="${arrDay - depDay}"/>
@@ -186,9 +319,9 @@
                 </div>
 
                 <c:url var="saveUrl" value="/reservations/${vm.reservationId}/passengers"/>
-                <form id="passengerForm" onsubmit="return savePassengers(event)">
+                <form id="passengerForm">
                     <c:forEach var="p" items="${vm.passengers}" varStatus="st">
-                        <div class="mb-8 last:mb-0 border-b last:border-0 border-gray-100 pb-8 last:pb-0">
+                        <div class="mb-8 last:mb-0 pb-8 last:pb-0">
                             <h4 class="font-bold text-sm text-gray-800 mb-4">탑승자 ${st.index + 1}</h4>
                             <input type="hidden" name="passengers[${st.index}].passengerId" value="${p.passengerId}"/>
 
@@ -197,35 +330,39 @@
                                 <div class="flex flex-col gap-1.5">
                                     <label class="text-xs font-bold text-slate-500 ml-0.5">한글 성</label>
                                     <input name="passengers[${st.index}].krLastName" value="${p.krLastName}" placeholder="홍" pattern="^[가-힣]+$" required
-                                           oninput="this.value = this.value.replace(/[^가-힣ㄱ-ㅎㅏ-ㅣ]/g, '')"
-                                           class="w-full p-3 rounded-xl border border-gray-200 bg-gray-50 text-sm font-semibold focus:bg-white focus:border-primary focus:ring-4 focus:ring-blue-500/10 outline-none transition-all"/>
+                                           oninput="handleKoreanInput(this)"
+                                           class="kr-name-input w-full p-3 rounded-xl border border-gray-200 bg-gray-50 text-sm font-semibold focus:bg-white focus:border-primary focus:ring-4 focus:ring-blue-500/10 outline-none transition-all"/>
                                 </div>
                                 <div class="flex flex-col gap-1.5">
                                     <label class="text-xs font-bold text-slate-500 ml-0.5">한글 이름</label>
                                     <input name="passengers[${st.index}].krFirstName" value="${p.krFirstName}" placeholder="길동" pattern="^[가-힣]+$" required
-                                           oninput="this.value = this.value.replace(/[^가-힣ㄱ-ㅎㅏ-ㅣ]/g, '')"
-                                           class="w-full p-3 rounded-xl border border-gray-200 bg-gray-50 text-sm font-semibold focus:bg-white focus:border-primary focus:ring-4 focus:ring-blue-500/10 outline-none transition-all"/>
+                                           oninput="handleKoreanInput(this)"
+                                           class="kr-name-input w-full p-3 rounded-xl border border-gray-200 bg-gray-50 text-sm font-semibold focus:bg-white focus:border-primary focus:ring-4 focus:ring-blue-500/10 outline-none transition-all"/>
                                 </div>
 
                                 <!-- Row 2: English Name -->
                                 <div class="flex flex-col gap-1.5">
                                     <label class="text-xs font-bold text-slate-500 ml-0.5">영문 성 (Last Name)</label>
                                     <input name="passengers[${st.index}].lastName" value="${p.lastName}" placeholder="HONG" pattern="^[A-Z\s]+$" required
-                                           oninput="this.value = this.value.replace(/[^a-zA-Z\s]/g, '').toUpperCase()"
-                                           class="w-full p-3 rounded-xl border border-gray-200 bg-gray-50 text-sm font-semibold focus:bg-white focus:border-primary focus:ring-4 focus:ring-blue-500/10 outline-none transition-all uppercase"/>
+                                           oninput="handleEnglishInput(this)"
+                                           class="en-name-input w-full p-3 rounded-xl border border-gray-200 bg-gray-50 text-sm font-semibold focus:bg-white focus:border-primary focus:ring-4 focus:ring-blue-500/10 outline-none transition-all uppercase"/>
                                 </div>
                                 <div class="flex flex-col gap-1.5">
                                     <label class="text-xs font-bold text-slate-500 ml-0.5">영문 이름 (First Name)</label>
                                     <input name="passengers[${st.index}].firstName" value="${p.firstName}" placeholder="GILDONG" pattern="^[A-Z\s]+$" required
-                                           oninput="this.value = this.value.replace(/[^a-zA-Z\s]/g, '').toUpperCase()"
-                                           class="w-full p-3 rounded-xl border border-gray-200 bg-gray-50 text-sm font-semibold focus:bg-white focus:border-primary focus:ring-4 focus:ring-blue-500/10 outline-none transition-all uppercase"/>
+                                           oninput="handleEnglishInput(this)"
+                                           class="en-name-input w-full p-3 rounded-xl border border-gray-200 bg-gray-50 text-sm font-semibold focus:bg-white focus:border-primary focus:ring-4 focus:ring-blue-500/10 outline-none transition-all uppercase"/>
                                 </div>
 
                                 <!-- Row 3: Birth & Gender -->
                                 <div class="flex flex-col gap-1.5">
                                     <label class="text-xs font-bold text-slate-500 ml-0.5">생년월일</label>
-                                    <input type="date" name="passengers[${st.index}].birth" value="${p.birth}" max="9999-12-31" required
-                                           class="w-full p-3 rounded-xl border border-gray-200 bg-gray-50 text-sm font-semibold focus:bg-white focus:border-primary focus:ring-4 focus:ring-blue-500/10 outline-none transition-all"/>
+                                    <div class="birth-input-wrapper">
+                                        <input type="text" name="passengers[${st.index}].birth" value="${p.birth}"
+                                               placeholder="생년월일 선택" readonly required
+                                               data-passenger-index="${st.index}"
+                                               class="birth-input w-full p-3 rounded-xl border border-gray-200 bg-gray-50 text-sm font-semibold focus:bg-white focus:border-primary focus:ring-4 focus:ring-blue-500/10 outline-none transition-all cursor-pointer"/>
+                                    </div>
                                 </div>
                                 <div class="flex flex-col gap-1.5">
                                     <label class="text-xs font-bold text-slate-500 ml-0.5">성별</label>
@@ -256,11 +393,24 @@
 
                                 <!-- Row 5: Passport Info -->
                                 <div class="md:col-span-2 mt-2">
-                                    <div class="text-xs font-bold text-gray-800 mb-3 flex items-center gap-2">
-                                        여권 정보
+                                    <div class="flex items-center gap-3 mb-3">
+                                        <label class="flex items-center gap-2 cursor-pointer group">
+                                            <input type="checkbox" class="passport-toggle sr-only" data-index="${st.index}"
+                                                   <c:if test="${not empty p.passportNo}">checked</c:if>>
+                                            <span class="w-5 h-5 rounded-full border-2 border-gray-300 flex items-center justify-center transition-all
+                                                         group-hover:border-primary
+                                                         [input:checked+&]:border-primary [input:checked+&]:bg-primary">
+                                                <svg class="w-3 h-3 text-white opacity-0 [input:checked~&]:opacity-100 transition-opacity" fill="currentColor" viewBox="0 0 20 20">
+                                                    <path fill-rule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clip-rule="evenodd"/>
+                                                </svg>
+                                            </span>
+                                            <span class="text-xs font-bold text-gray-800">여권 정보</span>
+                                        </label>
                                         <span class="text-[11px] font-normal text-gray-400 bg-gray-100 px-2 py-0.5 rounded-full">선택사항 (나중에 등록 가능)</span>
                                     </div>
-                                    <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+                                    <div class="passport-fields grid grid-cols-1 md:grid-cols-2 gap-4 transition-all duration-300"
+                                         data-index="${st.index}"
+                                         style="${empty p.passportNo ? 'display: none; opacity: 0;' : ''}">
                                         <div class="flex flex-col gap-1.5">
                                             <label class="text-xs font-bold text-slate-500 ml-0.5">여권번호</label>
                                             <input name="passengers[${st.index}].passportNo" value="${p.passportNo}" placeholder="M12345678" pattern="^[A-Z0-9]{7,9}$" oninput="this.value = this.value.toUpperCase()"
@@ -309,26 +459,37 @@
                     탑승자 정보 저장 후 선택 가능합니다. (현재: <span class="${vm.passengerSaved ? 'text-green-600 font-bold' : 'text-red-500 font-bold'}">${vm.passengerSaved ? '저장 완료' : '미저장'}</span>)
                 </div>
 
-                <div class="flex flex-col gap-3">
-                    <c:forEach var="s" items="${vm.segments}" varStatus="status">
-                        <div class="flex items-center justify-between bg-slate-50 border border-slate-200 p-4 rounded-xl hover:bg-white hover:border-primary transition-all group">
-                            <div>
-                                <span class="inline-block px-2 py-0.5 rounded text-[11px] font-extrabold mb-1 ${status.first ? 'bg-blue-50 text-primary' : 'bg-slate-100 text-slate-600'}">
-                                    ${status.first ? '가는편' : '오는편'}
-                                </span>
-                                <div class="text-sm font-bold text-gray-800">
-                                    <c:out value="${s.snapDepartureCity}"/> → <c:out value="${s.snapArrivalCity}"/>
-                                </div>
-                                <div class="text-xs text-gray-500">
-                                    <c:out value="${s.snapAirlineName}"/> <c:out value="${s.snapFlightNumber}"/>
-                                </div>
-                            </div>
-                            <button type="button" ${vm.passengerSaved ? "" : "disabled"} onclick="openSeatPopup('${s.reservationSegmentId}')"
-                                    class="px-4 py-2 bg-white border border-slate-300 rounded-lg text-xs font-bold text-slate-600 group-hover:bg-primary group-hover:border-primary group-hover:text-white transition-all disabled:opacity-50 disabled:cursor-not-allowed">
-                                좌석 선택
-                            </button>
+                <!-- 좌석 선택 통합 카드 -->
+                <div class="flex items-center justify-between bg-slate-50 border border-slate-200 p-4 rounded-xl hover:bg-white hover:border-primary transition-all group">
+                    <div class="flex items-center gap-3">
+                        <div class="w-10 h-10 bg-blue-50 text-primary rounded-xl flex items-center justify-center shrink-0">
+                            <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                                <rect x="4" y="4" width="6" height="6" rx="1"></rect>
+                                <rect x="14" y="4" width="6" height="6" rx="1"></rect>
+                                <rect x="4" y="14" width="6" height="6" rx="1"></rect>
+                                <rect x="14" y="14" width="6" height="6" rx="1"></rect>
+                            </svg>
                         </div>
-                    </c:forEach>
+                        <div>
+                            <div class="text-sm font-bold text-gray-800">좌석 선택</div>
+                            <div class="text-xs text-gray-500">
+                                <c:forEach var="s" items="${vm.segments}" varStatus="status">
+                                    <c:out value="${s.snapDepartureCity}"/> → <c:out value="${s.snapArrivalCity}"/><c:if test="${!status.last}"> / </c:if>
+                                </c:forEach>
+                            </div>
+                        </div>
+                    </div>
+                    <c:set var="firstSegmentId" value="${vm.segments[0].reservationSegmentId}" />
+                    <button type="button" ${vm.passengerSaved ? "" : "disabled"} onclick="openSeatPopup('${firstSegmentId}')"
+                            class="px-5 py-2.5 bg-primary text-white rounded-lg text-sm font-bold hover:bg-blue-700 transition-all disabled:opacity-50 disabled:cursor-not-allowed flex items-center gap-2">
+                        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                            <rect x="4" y="4" width="6" height="6" rx="1"></rect>
+                            <rect x="14" y="4" width="6" height="6" rx="1"></rect>
+                            <rect x="4" y="14" width="6" height="6" rx="1"></rect>
+                            <rect x="14" y="14" width="6" height="6" rx="1"></rect>
+                        </svg>
+                        선택하기
+                    </button>
                 </div>
 
                 <!-- Baggage / Ancillary Banner -->
@@ -462,6 +623,25 @@
     </div>
 </div>
 
+<!-- Wheel Date Picker Template (will be cloned for each birth input) -->
+<template id="wheelPickerTemplate">
+    <div class="wheel-picker-wrapper">
+        <div class="wheel-picker">
+            <div class="wheel-picker__header">
+                <button type="button" class="wheel-picker__btn wheel-picker__btn--cancel js-wheel-cancel">취소</button>
+                <span class="wheel-picker__title">생년월일</span>
+                <button type="button" class="wheel-picker__btn wheel-picker__btn--confirm js-wheel-confirm">확인</button>
+            </div>
+            <div class="wheel-picker__wheels">
+                <div class="wheel-picker__highlight"></div>
+                <div class="wheel-picker__wheel js-year-wheel"></div>
+                <div class="wheel-picker__wheel js-month-wheel"></div>
+                <div class="wheel-picker__wheel js-day-wheel"></div>
+            </div>
+        </div>
+    </div>
+</template>
+
 <script type="module">
     import { fetchWithRefresh } from '/resources/common/js/authFetch.js';
     var reservationId = '${vm.reservationId}';
@@ -469,15 +649,28 @@
     var passengerCount = ${vm.passengerCount};
     var segments = [
         <c:forEach var="s" items="${vm.segments}" varStatus="st">
-        { snapPrice: ${s.snapPrice != null ? s.snapPrice : 0} }<c:if test="${!st.last}">,</c:if>
+        {
+            snapPrice: ${s.snapPrice != null ? s.snapPrice : 0},
+            segmentId: '${s.reservationSegmentId}',
+            segmentOrder: ${s.segmentOrder},
+            depCity: '${s.snapDepartureCity}',
+            arrCity: '${s.snapArrivalCity}',
+            seatCount: ${fn:length(s.passengerSeats)}
+        }<c:if test="${!st.last}">,</c:if>
         </c:forEach>
     ];
 
     // 좌석 팝업
     function openSeatPopup(segmentId) {
-        if (!passengerSaved) { alert('탑승자 정보를 먼저 저장해주세요.'); return; }
+        if (!passengerSaved) {
+            Swal.warning('탑승자 정보를 먼저 저장해주세요.', '정보 미입력');
+            return;
+        }
 
-        if (!segmentId) { alert('구간 정보를 찾을 수 없습니다.'); return; }
+        if (!segmentId) {
+            Swal.error('구간 정보를 찾을 수 없습니다.', '오류');
+            return;
+        }
         const popupUrl = '/reservations/' + encodeURIComponent(reservationId)
             + '/segments/' + encodeURIComponent(segmentId) + '/seats';
         window.open(popupUrl, 'seatPopup', 'width=1100,height=800,scrollbars=yes,resizable=yes');
@@ -486,7 +679,7 @@
     // 부가서비스 팝업 열기
     function openServicePopup() {
         if (!passengerSaved) {
-            alert('탑승자 정보를 먼저 저장해주세요.');
+            Swal.warning('탑승자 정보를 먼저 저장해주세요.', '정보 미입력');
             return;
         }
 
@@ -529,9 +722,34 @@
     // 결제 페이지 이동
     function goPayment() {
         if (!passengerSaved) {
-            alert('탑승자 정보를 먼저 저장해주세요.');
+            Swal.warning('탑승자 정보를 먼저 저장해주세요.', '정보 미입력');
             return;
         }
+
+        // 좌석 선택 여부 체크
+        const incompleteSegment = segments.find(seg => seg.seatCount < passengerCount);
+
+        if (incompleteSegment) {
+            const segmentLabel = incompleteSegment.segmentOrder === 1 ? '가는편' : '오는편';
+            const routeText = incompleteSegment.depCity + ' → ' + incompleteSegment.arrCity;
+
+            Swal.fire({
+                icon: 'warning',
+                title: '좌석 미선택',
+                html: '<b>' + segmentLabel + '</b> (' + routeText + ')<br>모든 승객의 좌석을 선택해주세요.',
+                confirmButtonText: '좌석 선택하기',
+                confirmButtonColor: '#1f6feb',
+                showCancelButton: true,
+                cancelButtonText: '취소',
+                cancelButtonColor: '#64748b'
+            }).then((result) => {
+                if (result.isConfirmed) {
+                    openSeatPopup(incompleteSegment.segmentId);
+                }
+            });
+            return;
+        }
+
         // 결제 페이지로 이동 (PaymentController)
         location.href = '/payments/' + reservationId;
     }
@@ -566,7 +784,298 @@
                 el.min = today; // 여권만료는 오늘부터만 가능
             }
         });
+
+        // 여권 정보 토글
+        document.querySelectorAll('.passport-toggle').forEach(toggle => {
+            toggle.addEventListener('change', function() {
+                const idx = this.dataset.index;
+                const fields = document.querySelector('.passport-fields[data-index="' + idx + '"]');
+                if (this.checked) {
+                    fields.style.display = 'grid';
+                    setTimeout(() => { fields.style.opacity = '1'; }, 10);
+                } else {
+                    fields.style.opacity = '0';
+                    setTimeout(() => { fields.style.display = 'none'; }, 300);
+                    // 필드 초기화
+                    fields.querySelectorAll('input').forEach(input => { input.value = ''; });
+                }
+            });
+        });
+
+        // 휠 날짜 피커 초기화
+        initWheelDatePicker();
+
+        // 외부 클릭 시 피커 닫기
+        document.addEventListener('click', (e) => {
+            if (!e.target.closest('.birth-input-wrapper')) {
+                document.querySelectorAll('.wheel-picker-wrapper.active').forEach(picker => {
+                    picker.classList.remove('active');
+                });
+            }
+        });
+
+        // 폼 제출 이벤트 리스너
+        const passengerForm = document.getElementById('passengerForm');
+        if (passengerForm) {
+            passengerForm.addEventListener('submit', savePassengers);
+        }
     });
+
+    // 휠 날짜 피커 초기화
+    function initWheelDatePicker() {
+        const template = document.getElementById('wheelPickerTemplate');
+        const currentYear = new Date().getFullYear();
+
+        document.querySelectorAll('.birth-input').forEach(input => {
+            const wrapper = input.closest('.birth-input-wrapper');
+
+            // 템플릿 복제하여 각 입력 필드에 추가
+            const pickerClone = template.content.cloneNode(true);
+            const pickerWrapper = pickerClone.querySelector('.wheel-picker-wrapper');
+            const yearWheel = pickerClone.querySelector('.js-year-wheel');
+            const monthWheel = pickerClone.querySelector('.js-month-wheel');
+            const dayWheel = pickerClone.querySelector('.js-day-wheel');
+
+            // 휠 아이템 생성
+            for (let y = currentYear; y >= 1920; y--) {
+                const item = document.createElement('div');
+                item.className = 'wheel-picker__item';
+                item.dataset.value = y;
+                item.textContent = y + '년';
+                yearWheel.appendChild(item);
+            }
+
+            for (let m = 1; m <= 12; m++) {
+                const item = document.createElement('div');
+                item.className = 'wheel-picker__item';
+                item.dataset.value = String(m).padStart(2, '0');
+                item.textContent = m + '월';
+                monthWheel.appendChild(item);
+            }
+
+            for (let d = 1; d <= 31; d++) {
+                const item = document.createElement('div');
+                item.className = 'wheel-picker__item';
+                item.dataset.value = String(d).padStart(2, '0');
+                item.textContent = d + '일';
+                dayWheel.appendChild(item);
+            }
+
+            wrapper.appendChild(pickerClone);
+
+            // 입력 필드 클릭 시 피커 열기
+            input.addEventListener('click', (e) => {
+                e.stopPropagation();
+
+                // 다른 피커 닫기
+                document.querySelectorAll('.wheel-picker-wrapper.active').forEach(p => {
+                    if (p !== pickerWrapper) p.classList.remove('active');
+                });
+
+                const isOpen = pickerWrapper.classList.contains('active');
+                if (isOpen) {
+                    pickerWrapper.classList.remove('active');
+                } else {
+                    pickerWrapper.classList.add('active');
+
+                    // 기존 값으로 스크롤
+                    const currentValue = input.value;
+                    let year = 2000, month = '01', day = '01';
+                    if (currentValue) {
+                        const parts = currentValue.split('-');
+                        year = parseInt(parts[0]);
+                        month = parts[1];
+                        day = parts[2];
+                    }
+                    scrollToValue(yearWheel, year);
+                    scrollToValue(monthWheel, month);
+                    scrollToValue(dayWheel, day);
+                }
+            });
+
+            // 스크롤 이벤트
+            [yearWheel, monthWheel, dayWheel].forEach(wheel => {
+                wheel.addEventListener('scroll', () => updateSelectedItem(wheel));
+                wheel.addEventListener('scrollend', () => snapToItem(wheel));
+            });
+
+            // 취소 버튼
+            wrapper.querySelector('.js-wheel-cancel').addEventListener('click', (e) => {
+                e.stopPropagation();
+                pickerWrapper.classList.remove('active');
+            });
+
+            // 확인 버튼
+            wrapper.querySelector('.js-wheel-confirm').addEventListener('click', (e) => {
+                e.stopPropagation();
+                const year = getSelectedValue(yearWheel);
+                const month = getSelectedValue(monthWheel);
+                const day = getSelectedValue(dayWheel);
+                if (year && month && day) {
+                    input.value = year + '-' + month + '-' + day;
+                }
+                pickerWrapper.classList.remove('active');
+            });
+        });
+    }
+
+    function scrollToValue(wheel, value) {
+        const items = wheel.querySelectorAll('.wheel-picker__item');
+        for (const item of items) {
+            if (item.dataset.value == value) {
+                const itemTop = item.offsetTop - 55;
+                wheel.scrollTop = itemTop;
+                break;
+            }
+        }
+        setTimeout(() => updateSelectedItem(wheel), 50);
+    }
+
+    function updateSelectedItem(wheel) {
+        const items = wheel.querySelectorAll('.wheel-picker__item');
+        const wheelCenter = wheel.scrollTop + wheel.clientHeight / 2;
+
+        items.forEach(item => {
+            const itemCenter = item.offsetTop + item.clientHeight / 2 - 55;
+            const distance = Math.abs(wheelCenter - itemCenter - 55);
+
+            if (distance < 25) {
+                item.classList.add('selected');
+            } else {
+                item.classList.remove('selected');
+            }
+        });
+    }
+
+    function snapToItem(wheel) {
+        const selected = wheel.querySelector('.wheel-picker__item.selected');
+        if (selected) {
+            const targetTop = selected.offsetTop - 55;
+            wheel.scrollTo({ top: targetTop, behavior: 'smooth' });
+        }
+    }
+
+    function getSelectedValue(wheel) {
+        const selected = wheel.querySelector('.wheel-picker__item.selected');
+        return selected ? selected.dataset.value : null;
+    }
+
+    // =============================================
+    // 한글 ↔ 영문 자동 변환
+    // =============================================
+
+    // 한글 → 영문 로마자 변환 (Revised Romanization)
+    const CHO = ['g', 'kk', 'n', 'd', 'tt', 'r', 'm', 'b', 'pp', 's', 'ss', '', 'j', 'jj', 'ch', 'k', 't', 'p', 'h'];
+    const JUNG = ['a', 'ae', 'ya', 'yae', 'eo', 'e', 'yeo', 'ye', 'o', 'wa', 'wae', 'oe', 'yo', 'u', 'wo', 'we', 'wi', 'yu', 'eu', 'ui', 'i'];
+    const JONG = ['', 'k', 'k', 'k', 'n', 'n', 'n', 't', 'l', 'l', 'l', 'l', 'l', 'l', 'l', 'l', 'm', 'p', 'p', 't', 't', 'ng', 't', 't', 'k', 't', 'p', 't'];
+
+    function koreanToRoman(str) {
+        let result = '';
+        for (let i = 0; i < str.length; i++) {
+            const code = str.charCodeAt(i);
+            // 한글 완성형 범위 (가-힣)
+            if (code >= 0xAC00 && code <= 0xD7A3) {
+                const syllable = code - 0xAC00;
+                const cho = Math.floor(syllable / 588);
+                const jung = Math.floor((syllable % 588) / 28);
+                const jong = syllable % 28;
+                result += CHO[cho] + JUNG[jung] + JONG[jong];
+            } else if (/[a-zA-Z]/.test(str[i])) {
+                result += str[i];
+            }
+        }
+        return result.toUpperCase();
+    }
+
+    // 영문 키보드 → 한글 변환 (두벌식 기준)
+    const EN_TO_KR = {
+        'q': 'ㅂ', 'w': 'ㅈ', 'e': 'ㄷ', 'r': 'ㄱ', 't': 'ㅅ', 'y': 'ㅛ', 'u': 'ㅕ', 'i': 'ㅑ', 'o': 'ㅐ', 'p': 'ㅔ',
+        'a': 'ㅁ', 's': 'ㄴ', 'd': 'ㅇ', 'f': 'ㄹ', 'g': 'ㅎ', 'h': 'ㅗ', 'j': 'ㅓ', 'k': 'ㅏ', 'l': 'ㅣ',
+        'z': 'ㅋ', 'x': 'ㅌ', 'c': 'ㅊ', 'v': 'ㅍ', 'b': 'ㅠ', 'n': 'ㅜ', 'm': 'ㅡ',
+        'Q': 'ㅃ', 'W': 'ㅉ', 'E': 'ㄸ', 'R': 'ㄲ', 'T': 'ㅆ', 'O': 'ㅒ', 'P': 'ㅖ'
+    };
+
+    // 자모 조합
+    const CHO_MAP = { 'ㄱ': 0, 'ㄲ': 1, 'ㄴ': 2, 'ㄷ': 3, 'ㄸ': 4, 'ㄹ': 5, 'ㅁ': 6, 'ㅂ': 7, 'ㅃ': 8, 'ㅅ': 9, 'ㅆ': 10, 'ㅇ': 11, 'ㅈ': 12, 'ㅉ': 13, 'ㅊ': 14, 'ㅋ': 15, 'ㅌ': 16, 'ㅍ': 17, 'ㅎ': 18 };
+    const JUNG_MAP = { 'ㅏ': 0, 'ㅐ': 1, 'ㅑ': 2, 'ㅒ': 3, 'ㅓ': 4, 'ㅔ': 5, 'ㅕ': 6, 'ㅖ': 7, 'ㅗ': 8, 'ㅘ': 9, 'ㅙ': 10, 'ㅚ': 11, 'ㅛ': 12, 'ㅜ': 13, 'ㅝ': 14, 'ㅞ': 15, 'ㅟ': 16, 'ㅠ': 17, 'ㅡ': 18, 'ㅢ': 19, 'ㅣ': 20 };
+    const JONG_MAP = { '': 0, 'ㄱ': 1, 'ㄲ': 2, 'ㄳ': 3, 'ㄴ': 4, 'ㄵ': 5, 'ㄶ': 6, 'ㄷ': 7, 'ㄹ': 8, 'ㄺ': 9, 'ㄻ': 10, 'ㄼ': 11, 'ㄽ': 12, 'ㄾ': 13, 'ㄿ': 14, 'ㅀ': 15, 'ㅁ': 16, 'ㅂ': 17, 'ㅄ': 18, 'ㅅ': 19, 'ㅆ': 20, 'ㅇ': 21, 'ㅈ': 22, 'ㅊ': 23, 'ㅋ': 24, 'ㅌ': 25, 'ㅍ': 26, 'ㅎ': 27 };
+
+    function englishToKorean(str) {
+        // 영문 → 자모 변환
+        let jamo = '';
+        for (let i = 0; i < str.length; i++) {
+            jamo += EN_TO_KR[str[i]] || str[i];
+        }
+        // 자모 → 한글 조합 (간단 버전)
+        return assembleKorean(jamo);
+    }
+
+    function assembleKorean(jamo) {
+        // 간단한 자모 조합 (완벽하지 않지만 기본적인 조합)
+        const CHO_SET = new Set(Object.keys(CHO_MAP));
+        const JUNG_SET = new Set(Object.keys(JUNG_MAP));
+        const JONG_SET = new Set(Object.keys(JONG_MAP));
+
+        let result = '';
+        let i = 0;
+        while (i < jamo.length) {
+            const c = jamo[i];
+
+            // 초성 + 중성 조합 시도
+            if (CHO_SET.has(c) && i + 1 < jamo.length && JUNG_SET.has(jamo[i + 1])) {
+                const cho = CHO_MAP[c];
+                const jung = JUNG_MAP[jamo[i + 1]];
+                let jong = 0;
+
+                // 종성 확인
+                if (i + 2 < jamo.length && JONG_SET.has(jamo[i + 2])) {
+                    // 다음 글자가 초성+중성이면 종성으로 사용 안함
+                    if (i + 3 < jamo.length && JUNG_SET.has(jamo[i + 3])) {
+                        // 종성 없이 조합
+                    } else {
+                        jong = JONG_MAP[jamo[i + 2]];
+                        i++;
+                    }
+                }
+
+                result += String.fromCharCode(0xAC00 + (cho * 588) + (jung * 28) + jong);
+                i += 2;
+            } else {
+                result += c;
+                i++;
+            }
+        }
+        return result;
+    }
+
+    // 영문 필드 입력 핸들러
+    function handleEnglishInput(el) {
+        const val = el.value;
+        // 한글이 포함되어 있으면 로마자로 변환
+        if (/[가-힣]/.test(val)) {
+            el.value = koreanToRoman(val);
+        } else {
+            // 영문만 허용
+            el.value = val.replace(/[^a-zA-Z\s]/g, '').toUpperCase();
+        }
+    }
+
+    // 한글 필드 입력 핸들러
+    function handleKoreanInput(el) {
+        const val = el.value;
+        // 영문이 포함되어 있으면 한글로 변환
+        if (/[a-zA-Z]/.test(val)) {
+            const converted = englishToKorean(val);
+            // 한글만 남기기
+            el.value = converted.replace(/[^가-힣ㄱ-ㅎㅏ-ㅣ]/g, '');
+        } else {
+            // 한글만 허용
+            el.value = val.replace(/[^가-힣ㄱ-ㅎㅏ-ㅣ]/g, '');
+        }
+    }
+
+    window.handleEnglishInput = handleEnglishInput;
+    window.handleKoreanInput = handleKoreanInput;
     window.openSeatPopup = openSeatPopup;
     window.openServicePopup = openServicePopup;
     window.refreshServiceTotal = refreshServiceTotal;
@@ -574,6 +1083,7 @@
 
     async function savePassengers(event) {
         event.preventDefault();
+        console.log('savePassengers 함수 시작');
 
         const passengers = [];
         let index = 0;
@@ -601,38 +1111,60 @@
 
             const pNum = index + 1; // 탑승자 번호
 
+            // 0. 필수 필드 빈 값 체크
+            if (!krLastName || !krFirstName) {
+                Swal.warning('탑승자 ' + pNum + '의 한글 성명을 입력해주세요.', '입력 오류');
+                return false;
+            }
+            if (!lastName || !firstName) {
+                Swal.warning('탑승자 ' + pNum + '의 영문 성명을 입력해주세요.', '입력 오류');
+                return false;
+            }
+            if (!birth) {
+                Swal.warning('탑승자 ' + pNum + '의 생년월일을 입력해주세요.', '입력 오류');
+                return false;
+            }
+            if (!phoneNumber) {
+                Swal.warning('탑승자 ' + pNum + '의 연락처를 입력해주세요.', '입력 오류');
+                return false;
+            }
+            if (!email) {
+                Swal.warning('탑승자 ' + pNum + '의 이메일을 입력해주세요.', '입력 오류');
+                return false;
+            }
+
             // 1. 성별 체크
             if (!genderEl) {
-                alert(`탑승자 \${pNum}의 성별을 선택해주세요.`);
+                Swal.warning('탑승자 ' + pNum + '의 성별을 선택해주세요.', '입력 오류');
                 return false;
             }
 
             // 2. 한글 이름 검사
             if (!regKr.test(krLastName) || !regKr.test(krFirstName)) {
-                alert(`탑승자 \${pNum}의 한글 성명은 한글만 입력 가능합니다.`);
+                Swal.warning('탑승자 ' + pNum + '의 한글 성명은 한글만 입력 가능합니다.', '입력 오류');
                 return false;
             }
 
             // 3. 영문 이름 검사
             if (!regEn.test(lastName) || !regEn.test(firstName)) {
-                alert(`탑승자 \${pNum}의 영문 성명은 영문 대문자만 입력 가능합니다.`);
+                Swal.warning('탑승자 ' + pNum + '의 영문 성명은 영문 대문자만 입력 가능합니다.', '입력 오류');
                 return false;
             }
 
             // 4. 생년월일 검사 (미래 날짜 선택 방지)
             const today = getLocalISODate();
             if (birth > today) {
-                alert(`탑승자 \${pNum}의 생년월일이 올바르지 않습니다.`);
+                Swal.warning('탑승자 ' + pNum + '의 생년월일이 올바르지 않습니다.', '입력 오류');
                 return false;
             }
 
             // 5. 연락처 및 이메일 형식 검사
             if (!regPhone.test(phoneNumber)) {
-                alert(`탑승자 \${pNum}의 연락처 형식이 올바르지 않습니다. (예: 01012345678)`);
+                Swal.warning('탑승자 ' + pNum + '의 연락처 형식이 올바르지 않습니다. (예: 01012345678)', '입력 오류');
                 return false;
             }
             if (!regEmail.test(email)) {
-                alert(`탑승자 \${pNum}의 이메일 형식이 올바르지 않습니다.`);
+                Swal.warning('탑승자 ' + pNum + '의 이메일 형식이 올바르지 않습니다.', '입력 오류');
                 return false;
             }
 
@@ -645,7 +1177,17 @@
                 const minExpiry = new Date();
                 minExpiry.setMonth(minExpiry.getMonth() + 6);
                 if (new Date(passportExpiry) < minExpiry) {
-                    if(!confirm(`탑승자 \${pNum}의 여권 만료일이 6개월 미만입니다. 계속하시겠습니까?`)) return false;
+                    const confirmResult = await Swal.fire({
+                        icon: 'warning',
+                        title: '여권 만료일 확인',
+                        text: '탑승자 ' + pNum + '의 여권 만료일이 6개월 미만입니다. 계속하시겠습니까?',
+                        confirmButtonText: '계속',
+                        confirmButtonColor: '#1f6feb',
+                        showCancelButton: true,
+                        cancelButtonText: '취소',
+                        cancelButtonColor: '#64748b'
+                    });
+                    if (!confirmResult.isConfirmed) return false;
                 }
             }
 
@@ -664,6 +1206,15 @@
             index++;
         }
 
+        // 로딩 표시
+        Swal.fire({
+            title: '탑승자 정보를 저장하는 중...',
+            allowOutsideClick: false,
+            allowEscapeKey: false,
+            showConfirmButton: false,
+            didOpen: () => { Swal.showLoading(); }
+        });
+
         try {
             const res = await fetchWithRefresh('/reservations/' + reservationId + '/passengers/api', {
                 method: 'POST',
@@ -671,15 +1222,44 @@
                 body: JSON.stringify({ passengers: passengers })
             });
 
+            // 응답 상태 확인
+            if (!res.ok) {
+                Swal.close();
+                Swal.error('서버 오류가 발생했습니다. (HTTP ' + res.status + ')', '저장 실패');
+                return false;
+            }
+
             const data = await res.json();
+            Swal.close();
 
             if (data.success) {
-                location.href = '/reservations/' + reservationId + '/booking?saved=1';
+                // 저장 성공 시 상태 업데이트
+                passengerSaved = true;
+
+                // 좌석 선택, 부가서비스 버튼 활성화
+                document.querySelectorAll('button[onclick*="openSeatPopup"], button[onclick*="openServicePopup"]').forEach(btn => {
+                    btn.disabled = false;
+                });
+
+                // 결제 버튼 활성화
+                const payBtn = document.getElementById('payBtn');
+                if (payBtn) payBtn.disabled = false;
+
+                // 안내 텍스트 업데이트
+                const statusSpan = document.querySelector('.text-red-500.font-bold, .text-green-600.font-bold');
+                if (statusSpan) {
+                    statusSpan.className = 'text-green-600 font-bold';
+                    statusSpan.textContent = '저장 완료';
+                }
+
+                Swal.success('탑승자 정보가 저장되었습니다.', '저장 완료');
             } else {
-                alert('저장 실패: ' + (data.message || '오류가 발생했습니다.'));
+                Swal.error(data.message || '오류가 발생했습니다.', '저장 실패');
             }
         } catch (err) {
-            alert('저장 실패: ' + err.message);
+            Swal.close();
+            console.error('탑승자 저장 오류:', err);
+            Swal.error('저장 중 오류가 발생했습니다: ' + (err.message || '알 수 없는 오류'), '저장 실패');
         }
 
         return false;

--- a/src/main/webapp/WEB-INF/views/seat/seat-assets-css.jspf
+++ b/src/main/webapp/WEB-INF/views/seat/seat-assets-css.jspf
@@ -1,7 +1,10 @@
 <link rel="stylesheet" href="${pageContext.request.contextPath}/resources/common/css/variables.css">
 <link rel="stylesheet" href="${pageContext.request.contextPath}/resources/common/css/global.css">
 
-<%-- css --%>
+<%-- SweetAlert2 --%>
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/sweetalert2@11/dist/sweetalert2.min.css">
+
+<%-- Seat Selection CSS --%>
 <link rel="stylesheet" href="${pageContext.request.contextPath}/resources/seat/css/base.css">
 <link rel="stylesheet" href="${pageContext.request.contextPath}/resources/seat/css/component.css">
 <link rel="stylesheet" href="${pageContext.request.contextPath}/resources/seat/css/minimap.css">

--- a/src/main/webapp/WEB-INF/views/seat/seat-assets-js.jspf
+++ b/src/main/webapp/WEB-INF/views/seat/seat-assets-js.jspf
@@ -1,3 +1,8 @@
+<%-- SweetAlert2 --%>
+<script src="https://cdn.jsdelivr.net/npm/sweetalert2@11"></script>
+<script src="${pageContext.request.contextPath}/resources/common/js/swal-utils.js"></script>
+
+<%-- Seat Selection --%>
 <script defer src="${pageContext.request.contextPath}/resources/seat/js/seat-api.js?v=<%= System.currentTimeMillis() %>"></script>
 <script defer src="${pageContext.request.contextPath}/resources/seat/js/seat-grid.js?v=<%= System.currentTimeMillis() %>"></script>
 

--- a/src/main/webapp/WEB-INF/views/seat/seat-header.jspf
+++ b/src/main/webapp/WEB-INF/views/seat/seat-header.jspf
@@ -1,12 +1,35 @@
 <%@ page contentType="text/html; charset=UTF-8" pageEncoding="UTF-8" %>
 <header class="seat-header">
     <div class="seat-header__content">
-        <div class="seat-header__logo">
-            <img src="${pageContext.request.contextPath}/resources/seat/img/logo-icon.svg"
-                 alt="Flyway Logo"
-                 class="seat-header__logo-icon" />
-            <span class="seat-header__logo-text">flyway</span>
+        <div class="seat-header__left">
+            <div class="seat-header__logo">
+                <img src="${pageContext.request.contextPath}/resources/seat/img/logo-icon.svg"
+                     alt="Flyway Logo"
+                     class="seat-header__logo-icon" />
+                <span class="seat-header__logo-text">flyway</span>
+            </div>
+            <h1 class="seat-header__title">좌석 선택</h1>
         </div>
-        <h1 class="seat-header__title">사전 좌석 지정</h1>
+        <div class="seat-header__steps">
+            <div class="seat-header__step seat-header__step--done">
+                <span class="seat-header__step-number"></span>
+                <span>항공편</span>
+            </div>
+            <span class="seat-header__step-arrow"></span>
+            <div class="seat-header__step seat-header__step--done">
+                <span class="seat-header__step-number"></span>
+                <span>탑승객</span>
+            </div>
+            <span class="seat-header__step-arrow"></span>
+            <div class="seat-header__step seat-header__step--active">
+                <span class="seat-header__step-number">3</span>
+                <span>좌석</span>
+            </div>
+            <span class="seat-header__step-arrow"></span>
+            <div class="seat-header__step">
+                <span class="seat-header__step-number">4</span>
+                <span>결제</span>
+            </div>
+        </div>
     </div>
 </header>

--- a/src/main/webapp/WEB-INF/views/seat/seat-main.jspf
+++ b/src/main/webapp/WEB-INF/views/seat/seat-main.jspf
@@ -5,13 +5,19 @@
 <div class="segment-tabs" id="segment-tabs"
      data-ctx="${fn:escapeXml(pageContext.request.contextPath)}"
      data-rid="${fn:escapeXml(reservationId)}">
-    <c:forEach var="seg" items="${segments}">
+    <c:forEach var="seg" items="${segments}" varStatus="status">
         <button type="button"
                 class="segment-tab ${seg.reservationSegmentId == reservationSegmentId ? 'segment-tab--active' : ''}"
                 data-segment-id="${fn:escapeXml(seg.reservationSegmentId)}"
                 data-dep="${fn:escapeXml(seg.depAirportCode)}"
                 data-arr="${fn:escapeXml(seg.arrAirportCode)}"
                 data-deptime="${fn:escapeXml(seg.depTimeText)}">
+            <div class="segment-tab__label">
+                <c:choose>
+                    <c:when test="${status.first}">가는편</c:when>
+                    <c:otherwise>오는편</c:otherwise>
+                </c:choose>
+            </div>
             <div class="segment-tab__route">
                 <c:out value="${seg.depAirportCode}"/> → <c:out value="${seg.arrAirportCode}"/>
             </div>
@@ -29,25 +35,82 @@
     <div class="minimap-col">
         <div class="minimap" id="seat-minimap">
             <div class="minimap__plane">
+                <%-- 기수 (노즈콘) --%>
+                <div class="minimap__nose"></div>
+
+                <%-- 조종석 --%>
                 <div class="minimap__cockpit"></div>
 
-                <div class="minimap__seats" aria-hidden="true">
-                    <c:forEach var="i" begin="1" end="60">
-                        <span class="minimap__seat"></span>
+                <%-- 주날개 --%>
+                <div class="minimap__wing"></div>
+
+                <%-- 비상구 표시 (앞쪽) --%>
+                <div class="minimap__exit minimap__exit--front">
+                    <span class="minimap__exit-marker minimap__exit-marker--left"></span>
+                    <span class="minimap__exit-marker minimap__exit-marker--right"></span>
+                </div>
+
+                <%-- 비상구 표시 (날개 위) --%>
+                <div class="minimap__exit minimap__exit--overwing">
+                    <span class="minimap__exit-marker minimap__exit-marker--left"></span>
+                    <span class="minimap__exit-marker minimap__exit-marker--right"></span>
+                </div>
+
+                <%-- 비상구 표시 (뒤쪽) --%>
+                <div class="minimap__exit minimap__exit--rear">
+                    <span class="minimap__exit-marker minimap__exit-marker--left"></span>
+                    <span class="minimap__exit-marker minimap__exit-marker--right"></span>
+                </div>
+
+                <%-- 좌석 영역 --%>
+                <div class="minimap__cabin" aria-hidden="true">
+                    <c:forEach var="i" begin="1" end="20">
+                        <div class="minimap__seat-row">
+                            <div class="minimap__seat-group">
+                                <span class="minimap__seat"></span>
+                                <span class="minimap__seat"></span>
+                                <span class="minimap__seat"></span>
+                            </div>
+                            <div class="minimap__aisle"></div>
+                            <div class="minimap__seat-group">
+                                <span class="minimap__seat"></span>
+                                <span class="minimap__seat"></span>
+                                <span class="minimap__seat"></span>
+                            </div>
+                        </div>
                     </c:forEach>
                 </div>
 
+                <%-- 구역 선택 버튼 --%>
                 <button type="button"
                         class="minimap__zone minimap__zone--front is-active"
-                        data-zone="front" aria-label="앞쪽 구역 보기"></button>
+                        data-zone="front" aria-label="앞쪽 구역 보기">
+                    <span class="minimap__zone-label">앞</span>
+                </button>
 
                 <button type="button"
                         class="minimap__zone minimap__zone--mid"
-                        data-zone="mid" aria-label="중간 구역 보기"></button>
+                        data-zone="mid" aria-label="중간 구역 보기">
+                    <span class="minimap__zone-label">중간</span>
+                </button>
 
                 <button type="button"
                         class="minimap__zone minimap__zone--rear"
-                        data-zone="rear" aria-label="뒤쪽 구역 보기"></button>
+                        data-zone="rear" aria-label="뒤쪽 구역 보기">
+                    <span class="minimap__zone-label">뒤</span>
+                </button>
+            </div>
+
+            <%-- 범례 --%>
+            <div class="minimap__info">
+                <div class="minimap__info-item">
+                    <span class="minimap__info-icon minimap__info-icon--exit"></span>
+                    <span>비상구</span>
+                </div>
+                <div class="minimap__info-item">
+                    <span class="minimap__info-icon minimap__info-icon--wing"></span>
+                    <span>날개 위치</span>
+                </div>
             </div>
         </div>
     </div>
@@ -65,18 +128,18 @@
                 </c:forEach>
             </div>
 
-                <div id="seat-grid"
-                     class="seat-grid seat-grid--front"
-                     data-ctx="${fn:escapeXml(pageContext.request.contextPath)}"
-                     data-rid="${fn:escapeXml(reservationId)}"
-                     data-sid="${fn:escapeXml(reservationSegmentId)}"
-                     data-pid="${fn:escapeXml(passengerId)}"
-                     data-cabin="${fn:escapeXml(cabinClassCode)}">
-                    <p class="seat-grid__loading">좌석 정보를 불러오는 중...</p>
-                </div>
+            <div id="seat-grid"
+                 class="seat-grid seat-grid--front"
+                 data-ctx="${fn:escapeXml(pageContext.request.contextPath)}"
+                 data-rid="${fn:escapeXml(reservationId)}"
+                 data-sid="${fn:escapeXml(reservationSegmentId)}"
+                 data-pid="${fn:escapeXml(passengerId)}"
+                 data-cabin="${fn:escapeXml(cabinClassCode)}">
+                <p class="seat-grid__loading">좌석 정보를 불러오는 중...</p>
+            </div>
 
 
-                <div class="seat-legend">
+            <div class="seat-legend">
                 <div class="seat-legend__item">
                     <span class="seat-legend__icon seat-legend__icon--available"></span>
                     <span class="seat-legend__label">선택 가능</span>

--- a/src/main/webapp/WEB-INF/views/seat/seat-notices.jspf
+++ b/src/main/webapp/WEB-INF/views/seat/seat-notices.jspf
@@ -2,24 +2,23 @@
 <section class="seat-notices">
     <h3 class="seat-notices__title">유의사항</h3>
     <div class="seat-notices__content">
-        <p>※ 관련 규정에 따라 비상구 좌석 이용이 부적합한 승객의 경우, 해당 좌석 배정이 제한될 수 있습니다.</p>
-        <p>※ 항공기 기종 및 운항 스케줄은 사전 예고 없이 변경될 수 있습니다.</p>
-        <p>※ 항공기 운영 상황에 따라 일부 좌석은 사전 좌석 지정이 제한될 수 있는 점 양해 부탁드립니다.</p>
-        <p>※ 좌석 전면의 격벽 유무는 탑승 후 환불 사유로 인정되지 않으므로, 구매 시 반드시 확인하시기 바랍니다.</p>
-        <p>※ 사전 구매한 좌석은 변경이 불가하며, 변경을 원하실 경우 취소(환불) 후 재구매하셔야 합니다.</p>
+        <p>비상구 좌석은 관련 규정에 따라 이용이 제한될 수 있습니다.</p>
+        <p>항공기 기종 및 운항 스케줄은 사전 예고 없이 변경될 수 있습니다.</p>
+        <p>항공기 운영 상황에 따라 일부 좌석은 사전 지정이 제한될 수 있습니다.</p>
+        <p>좌석 전면 격벽 유무는 탑승 후 환불 사유로 인정되지 않습니다.</p>
+        <p>사전 구매한 좌석 변경 시 취소(환불) 후 재구매가 필요합니다.</p>
     </div>
 
-    <h3 class="seat-notices__title" style="margin-top: 40px;">약관 동의</h3>
+    <div class="seat-notices__divider"></div>
 
+    <h3 class="seat-notices__title seat-notices__title--terms">약관 동의</h3>
     <div class="seat-terms">
         <div class="seat-terms__header-wrapper" id="terms-header">
             <input type="checkbox" id="terms-checkbox" class="terms-hidden-check">
-
             <label class="seat-terms__title" for="terms-checkbox">
-                <span class="color-blue">[필수]</span> 좌석 선택 규정
+                <span class="color-blue">[필수]</span> 좌석 선택 규정 동의
             </label>
-
-            <button type="button" class="seat-terms__toggle-btn" id="terms-toggle">
+            <button type="button" class="seat-terms__toggle-btn" id="terms-toggle" aria-label="약관 내용 보기">
                 <span class="chevron-arrow"></span>
             </button>
         </div>
@@ -27,56 +26,39 @@
         <div class="seat-terms__content" id="terms-content" hidden>
             <ul class="terms-list">
                 <li>
-                    <strong>사전 좌석 선택</strong>
+                    <strong>1. 사전 좌석 선택</strong>
                     <ul>
                         <li>좌석 선택은 항공권 예매 시 또는 예매 완료 후 사전 구매를 통해 이용할 수 있습니다.</li>
                         <li>일부 항공권, 운임 종류 또는 항공편의 경우 사전 좌석 선택이 제한될 수 있습니다.</li>
                     </ul>
                 </li>
-
                 <li>
-                    <strong>좌석 배정 제한</strong>
+                    <strong>2. 좌석 배정 제한</strong>
                     <ul>
-                        <li>비상구 좌석은 관련 법령 및 항공사 규정에 따라 이용이 제한될 수 있으며, 해당 좌석 이용이 부적합하다고 판단되는 승객에게는 배정되지 않을 수 있습니다.</li>
+                        <li>비상구 좌석은 관련 법령 및 항공사 규정에 따라 이용이 제한될 수 있습니다.</li>
                         <li>항공기 운영상 필요에 따라 일부 좌석은 사전 지정이 불가할 수 있습니다.</li>
                     </ul>
                 </li>
-
                 <li>
-                    <strong>항공기 변경 및 좌석 변경</strong>
+                    <strong>3. 항공기 및 좌석 변경</strong>
                     <ul>
-                        <li>항공기 기종 또는 운항 스케줄은 사전 예고 없이 변경될 수 있으며, 이로 인해 사전 구매한 좌석이 변경될 수 있습니다.</li>
-                        <li>항공기 변경 등 불가피한 사유로 좌석이 변경되는 경우, 항공사는 대체 좌석을 배정할 수 있습니다.</li>
+                        <li>항공기 기종 또는 운항 스케줄 변경 시 사전 구매한 좌석이 변경될 수 있습니다.</li>
+                        <li>불가피한 사유로 좌석이 변경되는 경우 항공사는 대체 좌석을 배정합니다.</li>
                     </ul>
                 </li>
-
                 <li>
-                    <strong>좌석 형태 및 편의 사양</strong>
+                    <strong>4. 좌석 형태 및 편의 사양</strong>
                     <ul>
-                        <li>좌석 전면의 격벽 유무, 좌석 간 간격, 창가·통로 여부 등은 항공기 기종에 따라 달라질 수 있습니다.</li>
-                        <li>좌석 형태 또는 편의 사양에 대한 차이는 탑승 후 환불 사유로 인정되지 않습니다.</li>
+                        <li>격벽 유무, 좌석 간격, 창가/통로 여부 등은 기종에 따라 달라질 수 있습니다.</li>
+                        <li>좌석 형태 또는 편의 사양의 차이는 탑승 후 환불 사유로 인정되지 않습니다.</li>
                     </ul>
                 </li>
-
                 <li>
-                    <strong>좌석 변경 및 환불</strong>
+                    <strong>5. 변경 및 환불</strong>
                     <ul>
-                        <li>사전 구매한 좌석은 변경이 불가하며, 변경을 원하는 경우 좌석 구매를 취소(환불)한 후 재구매해야 합니다.</li>
-                        <li>좌석 취소 및 환불은 항공사 및 판매처의 환불 규정에 따라 처리됩니다.</li>
-                    </ul>
-                </li>
-
-                <li>
-                    <strong>현장 배정</strong>
-                    <ul>
-                        <li>사전 좌석을 구매하지 않은 경우, 좌석은 체크인 시 자동 배정될 수 있으며 좌석 위치는 선택이 제한될 수 있습니다.</li>
-                    </ul>
-                </li>
-
-                <li>
-                    <strong>기타</strong>
-                    <ul>
-                        <li>본 규정에 명시되지 않은 사항은 해당 항공사의 좌석 정책 및 운송 약관을 따릅니다.</li>
+                        <li>사전 구매한 좌석은 변경이 불가하며, 취소(환불) 후 재구매해야 합니다.</li>
+                        <li>좌석 취소 및 환불은 항공사 환불 규정에 따라 처리됩니다.</li>
+                        <li>사전 좌석 미구매 시 체크인 때 자동 배정되며 좌석 위치 선택이 제한될 수 있습니다.</li>
                     </ul>
                 </li>
             </ul>

--- a/src/main/webapp/resources/seat/css/base.css
+++ b/src/main/webapp/resources/seat/css/base.css
@@ -186,7 +186,7 @@ body {
 
 /* 왼쪽 미니맵 */
 .minimap-col {
-    flex: 0 0 160px;
+    flex: 0 0 180px;
     align-self: flex-start;
 }
 
@@ -198,7 +198,7 @@ body {
 
     background: linear-gradient(180deg, #ffffff 0%, #f8fafc 100%);
     border-radius: 16px;
-    padding: 20px 16px;
+    padding: 45px 20px 20px;
     box-shadow: 0 4px 20px rgba(0, 0, 0, 0.06);
     border: 1px solid rgba(47, 147, 247, 0.1);
 
@@ -210,12 +210,12 @@ body {
 }
 
 .minimap-col .minimap::before {
-    content: '기내 위치';
+    content: '기내 배치도';
     font-size: 11px;
     font-weight: 600;
-    color: #6b7280;
-    margin-bottom: 10px;
-    letter-spacing: 0.2px;
+    color: #374151;
+    margin-bottom: 12px;
+    letter-spacing: 0.3px;
 }
 
 /* 가운데 좌석 배치도 컬럼 */

--- a/src/main/webapp/resources/seat/css/base.css
+++ b/src/main/webapp/resources/seat/css/base.css
@@ -2,43 +2,63 @@
     /* ===== Seat Theme Colors (공통에 없는 것만) ===== */
 
     /* component.css에서 사용 */
-    --color-primary-seat: #2a74e3;   /* 공통 primary를 seat primary로 alias */
+    --color-primary-seat: var(--color-primary);   /* 공통 primary를 seat primary로 alias */
+    --color-primary-light: #e8f4fd;               /* 연한 파랑 배경 */
+    --color-primary-gradient: linear-gradient(135deg, #2f93f7 0%, #1e7ae0 100%);
     --color-bg-gray: #e9ecef;                     /* 회색 라인/구분용 */
+    --color-bg-soft: #f8fafc;                     /* 부드러운 배경 */
     --color-border-gray: #d0d5dd;                 /* 탭 테두리 등 */
     --color-border-medium: #c7cbd1;               /* 카드 테두리 등 */
 
     /* 텍스트 */
-    /* 공통 muted를 light-gray로 alias */
-    --color-text-light-gray: var(--color-text-muted);
-    --color-text-subtle: var(--color-text-muted);
+    --color-text-light-gray: var(--color-text-muted); /* 공통 muted를 light-gray로 alias */
     --color-seat-text-white: #ffffff;
 
     /* 좌석 상태 */
-    --color-seat-available: #2a74e3; /* 기본 파랑 */
-    --color-seat-selected: #1e5bb8;               /* 선택된 좌석(진한 파랑) */
-    --color-seat-unavailable: #bdbdbd;            /* 불가 좌석(회색) */
+    --color-seat-available: #3b82f6;              /* 선택 가능 - 밝은 파랑 */
+    --color-seat-selected: #1d4ed8;               /* 선택됨 - 진한 파랑 */
+    --color-seat-unavailable: #cbd5e1;            /* 불가 좌석(회색) */
+    --color-seat-hold: #f59e0b;                   /* 예약 대기 - 주황 */
 
     /* 공통에 없음 */
     --radius-xs: 8px;
+    --radius-seat: 8px 8px 4px 4px;               /* 좌석 모양 radius */
 
     --font-family-logo: var(--font-family-primary);
 
     /* 공통엔 xl(24px)까지만 있어서 확장 */
     --font-size-2xl: 26px;
     --font-size-3xl: 28px;  /* 로고/타이틀용 */
+
+    /* 애니메이션 */
+    --transition-fast: 0.15s ease;
+    --transition-normal: 0.25s ease;
+}
+
+/* ==================== Body (좌석 선택 페이지) ==================== */
+body {
+    background: linear-gradient(180deg, #f0f7ff 0%, #f8fafc 50%, #ffffff 100%);
+    min-height: 100vh;
 }
 
 /* ==================== Header ==================== */
 .seat-header {
-    background-color: var(--color-white);
-    border-bottom: 1px solid var(--color-bg-gray);
-    padding: 15px 0;
+    background: linear-gradient(135deg, #ffffff 0%, #f0f7ff 100%);
+    border-bottom: 1px solid rgba(47, 147, 247, 0.15);
+    padding: 18px 0;
+    box-shadow: 0 2px 12px rgba(47, 147, 247, 0.08);
 }
 
 .seat-header__content {
     max-width: 1200px;
     margin: 0 auto;
-    padding: 0 20px;
+    padding: 0 24px;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+}
+
+.seat-header__left {
     display: flex;
     align-items: center;
     gap: var(--spacing-xl);
@@ -51,46 +71,122 @@
 }
 
 .seat-header__logo-icon {
-    width: 61px;
-    height: 42px;
+    width: 52px;
+    height: 36px;
 }
 
 .seat-header__logo-text {
     font-family: var(--font-family-logo);
-    font-size: var(--font-size-3xl);
+    font-size: 24px;
     font-weight: var(--font-weight-bold);
-    color: var(--color-text-tertiary);
+    color: var(--color-primary-seat);
 }
 
 .seat-header__title {
     font-family: var(--font-family-primary);
-    font-size: var(--font-size-2xl);
+    font-size: var(--font-size-xl);
     font-weight: var(--font-weight-bold);
-    color: var(--color-primary-seat);
+    color: var(--color-text-primary);
     margin: 0;
+    padding-left: var(--spacing-xl);
+    border-left: 2px solid rgba(47, 147, 247, 0.3);
+}
+
+/* 예약 단계 표시 */
+.seat-header__steps {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+
+.seat-header__step {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    font-size: 13px;
+    font-weight: 500;
+    color: var(--color-text-muted);
+}
+
+.seat-header__step-number {
+    width: 22px;
+    height: 22px;
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 11px;
+    font-weight: 600;
+    background: #e5e7eb;
+    color: #6b7280;
+}
+
+.seat-header__step--active .seat-header__step-number {
+    background: #3b82f6;
+    color: white;
+}
+
+.seat-header__step--active {
+    color: #3b82f6;
+    font-weight: 600;
+}
+
+.seat-header__step--done .seat-header__step-number {
+    background: #10b981;
+    color: white;
+}
+
+/* CSS 체크마크 */
+.seat-header__step--done .seat-header__step-number::after {
+    content: '';
+    width: 5px;
+    height: 8px;
+    border: solid white;
+    border-width: 0 2px 2px 0;
+    transform: rotate(45deg);
+    margin-bottom: 2px;
+}
+
+.seat-header__step-arrow {
+    color: #d1d5db;
+    font-size: 12px;
+    margin: 0 2px;
+}
+
+/* CSS 화살표 */
+.seat-header__step-arrow::after {
+    content: '';
+    display: inline-block;
+    width: 6px;
+    height: 6px;
+    border-top: 1.5px solid #d1d5db;
+    border-right: 1.5px solid #d1d5db;
+    transform: rotate(45deg);
 }
 
 /* ==================== Container ==================== */
 .seat-container {
-    max-width: 1200px;
+    max-width: 1280px;
     margin: 0 auto;
-    padding: 30px 20px;
+    padding: 24px;
     display: flex;
     flex-direction: column;
-    gap: 30px;
+    gap: 24px;
+    background: var(--color-bg-soft);
+    min-height: calc(100vh - 80px);
 }
 
 /* ==================== Main Content Layout ==================== */
 /* 3컬럼(미니맵 / 좌석배치 / 우측패널) 레이아웃 */
 .seat-content {
     display: flex;
-    gap: 30px;
-    align-items: flex-start; /* 상단 정렬 */
+    gap: 24px;
+    align-items: flex-start;
 }
 
 /* 왼쪽 미니맵 */
 .minimap-col {
-    flex: 0 0 170px; /* 미니맵 영역 폭 */
+    flex: 0 0 160px;
     align-self: flex-start;
 }
 
@@ -98,17 +194,28 @@
 .minimap-col .minimap {
     display: flex;
     flex-direction: column;
+    align-items: center;
 
-    background: var(--color-white);
-    border-radius: var(--radius-md);
-    padding: var(--spacing-xl);
-    box-shadow: var(--shadow-card);
+    background: linear-gradient(180deg, #ffffff 0%, #f8fafc 100%);
+    border-radius: 16px;
+    padding: 20px 16px;
+    box-shadow: 0 4px 20px rgba(0, 0, 0, 0.06);
+    border: 1px solid rgba(47, 147, 247, 0.1);
 
     position: sticky;
     top: 20px;
     height: fit-content;
 
     z-index: 5;
+}
+
+.minimap-col .minimap::before {
+    content: '기내 위치';
+    font-size: 11px;
+    font-weight: 600;
+    color: #6b7280;
+    margin-bottom: 10px;
+    letter-spacing: 0.2px;
 }
 
 /* 가운데 좌석 배치도 컬럼 */
@@ -121,29 +228,27 @@
 .seat-map-container {
     display: flex;
     flex-direction: column;
-    gap: 16px;
+    gap: 20px;
 
-    background: var(--color-white);
-    border-radius: var(--radius-md);
-    padding: 16px;
-    box-shadow: var(--shadow-card);
+    background: linear-gradient(180deg, #ffffff 0%, #fafbfc 100%);
+    border-radius: 20px;
+    padding: 24px;
+    box-shadow: 0 4px 24px rgba(0, 0, 0, 0.06);
+    border: 1px solid rgba(0, 0, 0, 0.04);
 
     align-self: flex-start;
 }
 
+/* 좌석 배치도 상단 안내 - 제거 */
+
 .seat-map-container .seat-grid {
     align-self: center;
-    transform: scale(0.92);
+    transform: scale(0.95);
     transform-origin: top center;
 }
 
-/* 오른쪽 패널 - 좌석 선택 내역 */
+/* 오른쪽 패널 - 좌석 선택 내역 (sticky 위치만) */
 .selection-panel {
-    flex: 0 0 265px;
-    display: flex;
-    flex-direction: column;
-    gap: var(--spacing-xl);
-
     position: sticky;
     top: 20px;
     height: fit-content;

--- a/src/main/webapp/resources/seat/css/component.css
+++ b/src/main/webapp/resources/seat/css/component.css
@@ -43,234 +43,355 @@
 /* ==================== Segment Tabs ==================== */
 .segment-tabs {
     display: flex;
-    gap: var(--spacing-xl);
+    gap: 12px;
+    background: white;
+    padding: 12px 16px;
+    border-radius: 16px;
+    box-shadow: 0 2px 12px rgba(0, 0, 0, 0.04);
 }
 
 .segment-tab {
-    flex: 0 0 auto;
-    background: var(--color-white);
-    border: 1px solid var(--color-border-gray);
-    border-radius: var(--radius-xs);
-    padding: var(--spacing-sm) var(--spacing-lg);
+    flex: 1;
+    max-width: 200px;
+    background: #f8fafc;
+    border: 2px solid transparent;
+    border-radius: 12px;
+    padding: 14px 18px;
     cursor: pointer;
-    transition: all 0.2s;
+    transition: all 0.25s ease;
     font-family: var(--font-family-primary);
+    position: relative;
+    overflow: hidden;
+}
+
+.segment-tab::before {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    height: 3px;
+    background: transparent;
+    transition: background 0.25s ease;
 }
 
 .segment-tab:hover {
-    border-color: var(--color-primary-seat);
+    border-color: rgba(59, 130, 246, 0.3);
+    background: #f0f7ff;
 }
 
 .segment-tab--active {
-    border-color: var(--color-primary-seat);
-    background: var(--color-white);
+    border-color: #3b82f6;
+    background: linear-gradient(180deg, #eff6ff 0%, #dbeafe 100%);
+    box-shadow: 0 4px 12px rgba(59, 130, 246, 0.15);
+}
+
+.segment-tab--active::before {
+    background: linear-gradient(90deg, #3b82f6, #60a5fa);
 }
 
 .segment-tab__route {
-    font-size: var(--font-size-sm);
-    font-weight: var(--font-weight-medium);
-    color: var(--color-text-primary);
-    margin-bottom: 6px;
+    font-size: 14px;
+    font-weight: 700;
+    color: #111827;
+    margin-bottom: 4px;
 }
 
 .segment-tab--active .segment-tab__route {
-    color: var(--color-primary-seat);
+    color: #1d4ed8;
 }
 
 .segment-tab__datetime {
-    font-size: var(--font-size-xs);
-    font-weight: var(--font-weight-medium);
-    color: var(--color-text-light-gray);
+    font-size: 12px;
+    font-weight: 500;
+    color: #64748b;
 }
 
 .segment-tab--active .segment-tab__datetime {
-    color: var(--color-primary-seat);
-}
-
-.segment-tabs {
-    pointer-events: none; /* 클릭/탭 전환 차단 */
-}
-
-.segment-tab {
-    cursor: default;
-}
-
-/* 선택된 탭만 강조는 유지 */
-.segment-tab:not(.segment-tab--active) {
-    opacity: 0.6;
+    color: #3b82f6;
 }
 
 /* ==================== Buttons ==================== */
 .btn {
-    padding: 12px 24px;
+    padding: 14px 28px;
     border: none;
-    border-radius: var(--radius-sm);
+    border-radius: 12px;
     font-family: var(--font-family-primary);
-    font-size: var(--font-size-xl);
-    font-weight: var(--font-weight-bold);
+    font-size: 16px;
+    font-weight: 700;
     cursor: pointer;
-    transition: all 0.2s;
+    transition: all 0.25s ease;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 8px;
 }
 
 .btn--primary {
-    background-color: var(--color-primary-seat);
-    color: var(--color-white);
+    background: linear-gradient(135deg, #3b82f6 0%, #1d4ed8 100%);
+    color: #ffffff;
+    box-shadow: 0 4px 14px rgba(59, 130, 246, 0.35);
 }
 
 .btn--primary:hover {
-    background-color: #1e5bb8;
+    background: linear-gradient(135deg, #60a5fa 0%, #3b82f6 100%);
+    transform: translateY(-2px);
+    box-shadow: 0 6px 20px rgba(59, 130, 246, 0.4);
+}
+
+.btn--primary:active {
+    transform: translateY(0);
 }
 
 .btn--secondary {
-    background-color: #9e9e9e;
-    color: var(--color-white);
+    background: #f1f5f9;
+    color: #64748b;
+    border: 1px solid #e2e8f0;
 }
 
 .btn--secondary:hover {
-    background-color: #757575;
+    background: #e2e8f0;
+    color: #475569;
+}
+
+/* 총 금액 표시 */
+.selection-total {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 14px 16px;
+    background: linear-gradient(135deg, #1e40af 0%, #1d4ed8 100%);
+    border-radius: 12px;
+    margin-top: 8px;
+}
+
+.selection-total__label {
+    font-size: 13px;
+    font-weight: 600;
+    color: rgba(255, 255, 255, 0.8);
+}
+
+.selection-total__price {
+    font-size: 18px;
+    font-weight: 700;
+    color: #ffffff;
+}
+
+/* 액션 버튼 래퍼 */
+.selection-actions {
+    display: flex;
+    gap: 10px;
+    margin-top: 4px;
+}
+
+.selection-actions .btn {
+    flex: 1;
+    padding: 14px 20px;
 }
 
 /* ==================== Seat Legend ==================== */
 .seat-legend {
     display: flex;
-    gap: var(--spacing-xl);
-    padding: var(--spacing-md) 0;
-    border-top: 1px solid var(--color-bg-gray);
+    justify-content: center;
+    gap: 24px;
+    padding: 16px 20px;
+    background: white;
+    border-radius: 12px;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.04);
 }
 
 .seat-legend__item {
     display: flex;
     align-items: center;
-    gap: 8px;
+    gap: 10px;
 }
 
 .seat-legend__icon {
-    width: 40px;
-    height: 30px;
-    border-radius: 4px;
+    width: 32px;
+    height: 28px;
+    border-radius: 6px 6px 4px 4px;
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+    position: relative;
+}
+
+/* 좌석 모양 효과 */
+.seat-legend__icon::before {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: 3px;
+    right: 3px;
+    height: 5px;
+    border-radius: 4px 4px 0 0;
+    background: inherit;
+    filter: brightness(0.9);
 }
 
 .seat-legend__icon--available {
-    background-color: var(--color-seat-available);
+    background: linear-gradient(180deg, #60a5fa 0%, #3b82f6 100%);
+    border: 2px solid #2563eb;
 }
 
 .seat-legend__icon--selected {
-    background-color: #ffa500;
+    background: linear-gradient(180deg, #1d4ed8 0%, #1e40af 100%);
+    border: 2px solid #1e3a8a;
 }
 
 .seat-legend__icon--unavailable {
-    background-color: var(--color-seat-unavailable);
+    background: linear-gradient(180deg, #e2e8f0 0%, #cbd5e1 100%);
+    border: 2px solid #94a3b8;
 }
 
 .seat-legend__icon--hold {
-    background-color: #ffa500;
+    background: linear-gradient(180deg, #fbbf24 0%, #f59e0b 100%);
+    border: 2px solid #d97706;
 }
 
 .seat-legend__label {
-    font-size: var(--font-size-sm);
-    font-weight: var(--font-weight-medium);
-    color: var(--color-text-primary);
+    font-size: 13px;
+    font-weight: 600;
+    color: #475569;
 }
 
 /* ==================== Selection Panel ==================== */
-
-.selection-panel__content {
-    background: var(--color-white);
-    border: 1px solid var(--color-border-medium);
-    border-radius: var(--radius-md);
-    padding: var(--spacing-xl);
+.selection-panel {
+    flex: 0 0 300px;
     display: flex;
     flex-direction: column;
-    gap: var(--spacing-md);
+    gap: 12px;
+}
+
+.selection-panel__content {
+    background: #ffffff;
+    border: 1px solid #e2e8f0;
+    border-radius: 16px;
+    padding: 16px;
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
     flex: 1;
+    box-shadow: 0 4px 16px rgba(0, 0, 0, 0.04);
 }
 
 .selection-panel__title {
-    font-size: var(--font-size-lg);
-    font-weight: var(--font-weight-semibold);
-    color: var(--color-text-primary);
-    margin-bottom: var(--spacing-sm);
+    font-size: 14px;
+    font-weight: 700;
+    color: #111827;
+    margin: 0;
+    padding-bottom: 12px;
+    border-bottom: 1px solid #e5e7eb;
 }
 
 /* ==================== Seat Summary ==================== */
 /* 우측 카드 전체 */
 .seat-summary-card {
-    background: #f3f3f3;
-    border-radius: 12px;
-    padding: 18px;
+    background: #ffffff;
+    border-radius: 16px;
+    padding: 0;
+    border: 1px solid #e2e8f0;
+    overflow: hidden;
 }
 
 /* 카드 헤더: 노선/시간 */
 .seat-summary-card__header {
     display: flex;
     flex-direction: column;
-    gap: 10px;
+    gap: 6px;
+    padding: 16px;
+    background: linear-gradient(135deg, #eff6ff 0%, #dbeafe 100%);
+    border-bottom: 1px solid #bfdbfe;
 }
 
 .seat-summary-card__route {
-    font-size: 21px;
-    font-weight: var(--font-weight-bold);
-    color: var(--color-text-primary);
+    font-size: 15px;
+    font-weight: 700;
+    color: #1e40af;
 }
 
 .seat-summary-card__datetime {
-    font-size: 15px;
-    font-weight: 600;
-    color: var(--color-text-primary);
+    font-size: 12px;
+    font-weight: 500;
+    color: #3b82f6;
 }
 
-/* 점선 구분선 */
+/* 점선 구분선 - 숨김 */
 .seat-summary-card__divider {
-    margin: 14px 0 10px;
-    border-top: 2px dashed rgba(0,0,0,0.25);
+    display: none;
+}
+
+/* 카드 본문 */
+.seat-summary-card__body {
+    padding: 12px 16px 16px;
+    display: flex;
+    flex-direction: column;
+    gap: 0;
 }
 
 /* ==================== Seat Summary (Figma Row Style) ==================== */
-/* 승객 리스트 */
-.seat-summary-card__body {
-    display: flex;
-    flex-direction: column;
-    gap: 18px;
-}
-
 /* 승객 한 줄: 좌(이름/좌석) + 우(버튼/가격) */
 .seat-summary-row {
     display: flex;
     align-items: center;
     justify-content: space-between;
-    gap: 14px;
+    gap: 12px;
+    padding: 12px 0;
+    border-bottom: 1px solid #f1f5f9;
 }
 
-/* 현재 좌석 선택 대상(activePassengerId)이면 살짝 강조 */
+.seat-summary-row:last-child {
+    border-bottom: none;
+    padding-bottom: 0;
+}
+
+.seat-summary-row:first-child {
+    padding-top: 0;
+}
+
+/* 현재 좌석 선택 대상(activePassengerId)이면 강조 */
+.seat-summary-row.is-active {
+    background: linear-gradient(90deg, rgba(59, 130, 246, 0.08) 0%, transparent 100%);
+    margin: 0 -16px;
+    padding: 12px 16px;
+    border-radius: 8px;
+    border-bottom: none;
+}
+
 .seat-summary-row.is-active .seat-summary-row__name {
-    text-decoration: underline;
-    text-underline-offset: 4px;
+    color: #1d4ed8;
 }
 
 /* 좌측: 이름 + 좌석 */
 .seat-summary-row__left {
     display: flex;
     flex-direction: column;
-    gap: 6px;
+    gap: 4px;
     min-width: 0;
 }
 
 .seat-summary-row__name {
-    font-size: 16px;
+    font-size: 14px;
     font-weight: 600;
     line-height: 1.2;
     white-space: nowrap;
+    color: #1e293b;
 }
 
 .seat-summary-row__seat {
-    font-size: 16px;
-    font-weight: 500;
+    font-size: 13px;
+    font-weight: 600;
     line-height: 1.1;
-    min-height: 22px; /* 좌석 선택 전/후 레이아웃 흔들림 방지 */
+    min-height: 18px;
+    color: #3b82f6;
 }
 
 .seat-summary-row__seat.is-empty {
-    opacity: 0; /* 공간 유지 */
+    color: #9ca3af;
+    font-weight: 400;
+    font-size: 12px;
+}
+
+.seat-summary-row__seat.is-empty::after {
+    content: '미선택';
 }
 
 /* 오른쪽 정렬 */
@@ -278,14 +399,17 @@
     display: flex;
     flex-direction: column;
     align-items: flex-end;
-    gap: 8px;
+    gap: 4px;
 }
 
 /* 가격 */
 .seat-summary-row__price {
-    font-size: 16px;
-    font-weight: 500;
-    color: var(--color-text-primary);
+    font-size: 14px;
+    font-weight: 700;
+    color: #1e293b;
+    background: #f1f5f9;
+    padding: 4px 10px;
+    border-radius: 6px;
 }
 
 .seat-summary-row__price.is-hidden {
@@ -294,9 +418,11 @@
 
 /* ==================== Seat Action Card ==================== */
 .seat-action-card {
-    background: #f3f3f3;
-    border-radius: 12px;
-    padding: 14px;
+    background: #ffffff;
+    border-radius: 16px;
+    padding: 0;
+    border: 1px solid #e2e8f0;
+    overflow: hidden;
 }
 
 .seat-action-row {
@@ -304,70 +430,87 @@
     align-items: center;
     justify-content: space-between;
     gap: 12px;
-    padding: 14px 6px;
-    min-height: 76px;
+    padding: 14px 16px;
+    min-height: 60px;
+    transition: background 0.2s ease;
+}
+
+.seat-action-row:hover {
+    background: #f8fafc;
 }
 
 .seat-action-row + .seat-action-row {
-    border-top: 1px dashed rgba(0,0,0,0.12);
+    border-top: 1px solid #f1f5f9;
+}
+
+/* 현재 선택 중인 승객 강조 */
+.seat-action-row.is-active {
+    background: linear-gradient(90deg, #eff6ff 0%, #f8fafc 100%);
 }
 
 .seat-action-row__left {
     display: flex;
     flex-direction: column;
-    gap: 8px;
+    gap: 2px;
     min-width: 0;
 }
 
 .seat-action-row__name {
-    font-size: 16px;
-    font-weight: 800;
+    font-size: 14px;
+    font-weight: 600;
     line-height: 1.2;
     white-space: nowrap;
+    color: #1e293b;
+}
+
+.seat-action-row.is-active .seat-action-row__name {
+    color: #1d4ed8;
+}
+
+.seat-action-row__seat {
+    font-size: 12px;
+    font-weight: 500;
+    color: #64748b;
 }
 
 .seat-action-row__seat.is-empty {
-    opacity: 0; /* 공간은 유지, 텍스트만 숨김 */
+    opacity: 0;
 }
 
 .seat-action-row__right {
     display: flex;
-    flex-direction: column; /* 버튼 위, 가격 아래 */
-    align-items: flex-end;
-    justify-content: center;
+    align-items: center;
     gap: 8px;
-    min-width: 120px;
 }
 
 /* 버튼 기본(파란색) */
 .seat-action-row__btn {
     border: none;
-    background: #2a74e3;
+    background: #3b82f6;
     color: #fff;
-    font-weight: 800;
-    font-size: 13px;
-    padding: 9px 14px;
-    border-radius: 14px;
+    font-weight: 600;
+    font-size: 12px;
+    padding: 8px 14px;
+    border-radius: 8px;
     cursor: pointer;
     white-space: nowrap;
-    min-width: 96px;
+    min-width: 80px;
     text-align: center;
     transition: all 0.15s ease;
 }
 
 .seat-action-row__btn:hover {
-    filter: brightness(0.96);
+    background: #2563eb;
 }
 
 /* ==================== Seat Action Button Active ==================== */
-/* 선택된 승객의 버튼은 회색으로 */
+/* 선택된 승객의 버튼 - 선택 중 표시 */
 .seat-action-row__btn.is-active {
-    background: #9e9e9e;
+    background: #1d4ed8;
 }
 
 .seat-action-row__btn:active {
-    transform: translateY(1px);
-    filter: brightness(0.92);
+    transform: scale(0.98);
 }
 
 .is-hidden {

--- a/src/main/webapp/resources/seat/css/component.css
+++ b/src/main/webapp/resources/seat/css/component.css
@@ -45,18 +45,18 @@
     display: flex;
     gap: 12px;
     background: white;
-    padding: 12px 16px;
+    padding: 14px 16px;
     border-radius: 16px;
     box-shadow: 0 2px 12px rgba(0, 0, 0, 0.04);
 }
 
 .segment-tab {
     flex: 1;
-    max-width: 200px;
+    max-width: 240px;
     background: #f8fafc;
-    border: 2px solid transparent;
+    border: 2px solid #e2e8f0;
     border-radius: 12px;
-    padding: 14px 18px;
+    padding: 16px 20px;
     cursor: pointer;
     transition: all 0.25s ease;
     font-family: var(--font-family-primary);
@@ -75,26 +75,73 @@
     transition: background 0.25s ease;
 }
 
+/* 완료 체크 아이콘 영역 */
+.segment-tab::after {
+    content: '';
+    position: absolute;
+    top: 10px;
+    right: 10px;
+    width: 20px;
+    height: 20px;
+    border-radius: 50%;
+    background: #e2e8f0;
+    transition: all 0.25s ease;
+}
+
+/* 완료된 세그먼트 표시 */
+.segment-tab.is-complete::after {
+    background: #10b981;
+}
+
+.segment-tab.is-complete::before {
+    background: linear-gradient(90deg, #10b981, #34d399);
+}
+
 .segment-tab:hover {
-    border-color: rgba(59, 130, 246, 0.3);
+    border-color: rgba(59, 130, 246, 0.4);
     background: #f0f7ff;
+    transform: translateY(-1px);
 }
 
 .segment-tab--active {
     border-color: #3b82f6;
     background: linear-gradient(180deg, #eff6ff 0%, #dbeafe 100%);
-    box-shadow: 0 4px 12px rgba(59, 130, 246, 0.15);
+    box-shadow: 0 4px 16px rgba(59, 130, 246, 0.2);
 }
 
 .segment-tab--active::before {
     background: linear-gradient(90deg, #3b82f6, #60a5fa);
 }
 
+.segment-tab--active::after {
+    background: #bfdbfe;
+}
+
+.segment-tab--active.is-complete::after {
+    background: #10b981;
+}
+
+.segment-tab__label {
+    font-size: 10px;
+    font-weight: 600;
+    color: #94a3b8;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    margin-bottom: 6px;
+}
+
+.segment-tab--active .segment-tab__label {
+    color: #3b82f6;
+}
+
 .segment-tab__route {
-    font-size: 14px;
+    font-size: 15px;
     font-weight: 700;
     color: #111827;
     margin-bottom: 4px;
+    display: flex;
+    align-items: center;
+    gap: 8px;
 }
 
 .segment-tab--active .segment-tab__route {
@@ -109,6 +156,22 @@
 
 .segment-tab--active .segment-tab__datetime {
     color: #3b82f6;
+}
+
+/* 화살표 아이콘 */
+.segment-tab__route::before {
+    content: '';
+    display: inline-block;
+    width: 16px;
+    height: 16px;
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='%2364748b' stroke-width='2'%3E%3Cpath d='M5 12h14M12 5l7 7-7 7'/%3E%3C/svg%3E");
+    background-size: contain;
+    background-repeat: no-repeat;
+    flex-shrink: 0;
+}
+
+.segment-tab--active .segment-tab__route::before {
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='%233b82f6' stroke-width='2'%3E%3Cpath d='M5 12h14M12 5l7 7-7 7'/%3E%3C/svg%3E");
 }
 
 /* ==================== Buttons ==================== */

--- a/src/main/webapp/resources/seat/css/minimap.css
+++ b/src/main/webapp/resources/seat/css/minimap.css
@@ -2,69 +2,174 @@
 .minimap {
     display: flex;
     flex-direction: column;
-    gap: 10px;
+    gap: 12px;
+    align-items: center;
 }
 
 .minimap__plane {
     position: relative;
-    width: 130px;
-    height: 300px;
-    border: 4px solid #1b3a66;
-    border-radius: 20px;
-    background: #fff7ea;
-    box-shadow: 0 6px 18px rgba(0,0,0,0.08);
-    overflow: hidden;
+    width: 110px;
+    height: 280px;
+    background: linear-gradient(180deg, #f8fafc 0%, #e2e8f0 100%);
+    box-shadow: 0 4px 16px rgba(0, 0, 0, 0.1), inset 0 2px 4px rgba(255, 255, 255, 0.8);
+    overflow: visible;
+
+    /* 비행기 동체 모양 */
+    border-radius: 50px 50px 20px 20px;
+    border: 3px solid #94a3b8;
+}
+
+/* 비행기 코 부분 */
+.minimap__plane::before {
+    content: '';
+    position: absolute;
+    top: -25px;
+    left: 50%;
+    transform: translateX(-50%);
+    width: 40px;
+    height: 30px;
+    background: linear-gradient(180deg, #cbd5e1 0%, #94a3b8 100%);
+    border-radius: 50% 50% 0 0;
+    border: 3px solid #94a3b8;
+    border-bottom: none;
+}
+
+/* 날개 표시 */
+.minimap__plane::after {
+    content: '';
+    position: absolute;
+    top: 45%;
+    left: -20px;
+    right: -20px;
+    height: 8px;
+    background: linear-gradient(90deg, #64748b, #94a3b8, #64748b);
+    border-radius: 4px;
+    transform: translateY(-50%);
 }
 
 .minimap__cockpit {
     position: absolute;
-    top: 10px;
+    top: 16px;
     left: 50%;
     transform: translateX(-50%);
-    width: 56px;
-    height: 20px;
-    border-radius: 10px;
-    background: rgba(27, 58, 102, 0.18);
+    width: 50px;
+    height: 16px;
+    border-radius: 8px;
+    background: linear-gradient(180deg, #60a5fa 0%, #3b82f6 100%);
+    box-shadow: inset 0 2px 4px rgba(255, 255, 255, 0.3);
 }
 
 /* 장식용 좌석 점들 */
 .minimap__seats {
     position: absolute;
-    top: 46px;
-    left: 14px;
-    right: 14px;
-    bottom: 12px;
+    top: 50px;
+    left: 16px;
+    right: 16px;
+    bottom: 20px;
 
     display: grid;
-    grid-template-columns: repeat(5, 1fr);
-    gap: 5px;
+    grid-template-columns: repeat(4, 1fr);
+    gap: 4px;
     align-content: start;
 }
 
 .minimap__seat {
     width: 100%;
-    height: 11px;
-    border-radius: 6px;
-    background: rgba(42, 116, 227, 0.22);
-    border: 2px solid rgba(27, 58, 102, 0.55);
+    height: 10px;
+    border-radius: 3px 3px 2px 2px;
+    background: #cbd5e1;
+    border: 1px solid #94a3b8;
+    transition: all 0.2s ease;
 }
 
 /* 3구역 클릭 오버레이 */
 .minimap__zone {
     position: absolute;
-    left: 0;
-    right: 0;
+    left: 4px;
+    right: 4px;
     border: 0;
     background: transparent;
     cursor: pointer;
+    border-radius: 8px;
+    transition: all 0.2s ease;
 }
 
-.minimap__zone--front { top: 0; height: 33.33%; }
-.minimap__zone--mid   { top: 33.33%; height: 33.33%; }
-.minimap__zone--rear  { top: 66.66%; height: 33.34%; }
+.minimap__zone:hover {
+    background: rgba(59, 130, 246, 0.1);
+}
+
+.minimap__zone--front {
+    top: 8px;
+    height: 30%;
+    border-radius: 40px 40px 8px 8px;
+}
+.minimap__zone--mid {
+    top: calc(8px + 30%);
+    height: 35%;
+}
+.minimap__zone--rear {
+    top: calc(8px + 65%);
+    height: calc(35% - 16px);
+    border-radius: 8px 8px 16px 16px;
+}
 
 .minimap__zone.is-active {
-    background: rgba(42, 116, 227, 0.18);
-    outline: 2px solid rgba(42, 116, 227, 0.55);
-    outline-offset: -2px;
+    background: rgba(59, 130, 246, 0.25);
+    box-shadow: inset 0 0 0 2px #3b82f6;
+}
+
+/* 구역 라벨 */
+.minimap__zone::after {
+    content: '';
+    position: absolute;
+    right: 6px;
+    top: 50%;
+    transform: translateY(-50%);
+    font-size: 9px;
+    font-weight: 600;
+    color: #64748b;
+    opacity: 0;
+    transition: opacity 0.2s ease;
+}
+
+.minimap__zone--front::after { content: '앞'; }
+.minimap__zone--mid::after { content: '중간'; }
+.minimap__zone--rear::after { content: '뒤'; }
+
+.minimap__zone:hover::after,
+.minimap__zone.is-active::after {
+    opacity: 1;
+}
+
+/* 미니맵 하단 범례 */
+.minimap__legend {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    margin-top: 8px;
+    padding-top: 12px;
+    border-top: 1px solid #e2e8f0;
+    width: 100%;
+}
+
+.minimap__legend-item {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    font-size: 10px;
+    color: #64748b;
+}
+
+.minimap__legend-dot {
+    width: 10px;
+    height: 10px;
+    border-radius: 3px;
+}
+
+.minimap__legend-dot--available {
+    background: linear-gradient(180deg, #60a5fa 0%, #3b82f6 100%);
+}
+
+.minimap__legend-dot--selected {
+    background: linear-gradient(180deg, #1d4ed8 0%, #1e40af 100%);
 }

--- a/src/main/webapp/resources/seat/css/minimap.css
+++ b/src/main/webapp/resources/seat/css/minimap.css
@@ -8,78 +8,224 @@
 
 .minimap__plane {
     position: relative;
-    width: 110px;
-    height: 280px;
-    background: linear-gradient(180deg, #f8fafc 0%, #e2e8f0 100%);
-    box-shadow: 0 4px 16px rgba(0, 0, 0, 0.1), inset 0 2px 4px rgba(255, 255, 255, 0.8);
+    width: 100px;
+    height: 320px;
+    background: linear-gradient(180deg, #f1f5f9 0%, #e2e8f0 50%, #f1f5f9 100%);
+    box-shadow:
+            0 4px 20px rgba(0, 0, 0, 0.12),
+            inset 0 0 20px rgba(255, 255, 255, 0.5);
     overflow: visible;
 
     /* 비행기 동체 모양 */
-    border-radius: 50px 50px 20px 20px;
-    border: 3px solid #94a3b8;
+    border-radius: 45px 45px 25px 25px;
+    border: 2px solid #94a3b8;
 }
 
-/* 비행기 코 부분 */
-.minimap__plane::before {
-    content: '';
+/* 비행기 기수 (노즈콘) */
+.minimap__nose {
     position: absolute;
-    top: -25px;
-    left: 50%;
-    transform: translateX(-50%);
-    width: 40px;
-    height: 30px;
-    background: linear-gradient(180deg, #cbd5e1 0%, #94a3b8 100%);
-    border-radius: 50% 50% 0 0;
-    border: 3px solid #94a3b8;
-    border-bottom: none;
-}
-
-/* 날개 표시 */
-.minimap__plane::after {
-    content: '';
-    position: absolute;
-    top: 45%;
-    left: -20px;
-    right: -20px;
-    height: 8px;
-    background: linear-gradient(90deg, #64748b, #94a3b8, #64748b);
-    border-radius: 4px;
-    transform: translateY(-50%);
-}
-
-.minimap__cockpit {
-    position: absolute;
-    top: 16px;
+    top: -35px;
     left: 50%;
     transform: translateX(-50%);
     width: 50px;
-    height: 16px;
-    border-radius: 8px;
-    background: linear-gradient(180deg, #60a5fa 0%, #3b82f6 100%);
-    box-shadow: inset 0 2px 4px rgba(255, 255, 255, 0.3);
+    height: 45px;
+    background: linear-gradient(180deg, #e2e8f0 0%, #cbd5e1 100%);
+    border-radius: 50% 50% 45% 45%;
+    border: 2px solid #94a3b8;
+    border-bottom: none;
+    z-index: 1;
 }
 
-/* 장식용 좌석 점들 */
-.minimap__seats {
+/* 조종석 창문 */
+.minimap__cockpit {
     position: absolute;
-    top: 50px;
-    left: 16px;
-    right: 16px;
-    bottom: 20px;
+    top: -18px;
+    left: 50%;
+    transform: translateX(-50%);
+    width: 30px;
+    height: 14px;
+    border-radius: 50% 50% 40% 40%;
+    background: linear-gradient(180deg, #93c5fd 0%, #3b82f6 100%);
+    box-shadow:
+            inset 0 2px 4px rgba(255, 255, 255, 0.4),
+            0 2px 4px rgba(0, 0, 0, 0.1);
+    z-index: 2;
+}
 
-    display: grid;
-    grid-template-columns: repeat(4, 1fr);
-    gap: 4px;
-    align-content: start;
+/* 꼬리 날개 (수직 안정판) */
+.minimap__tail {
+    position: absolute;
+    bottom: -20px;
+    left: 50%;
+    transform: translateX(-50%);
+    width: 8px;
+    height: 35px;
+    background: linear-gradient(180deg, #94a3b8 0%, #64748b 100%);
+    border-radius: 4px 4px 2px 2px;
+    z-index: 1;
+}
+
+.minimap__tail::before {
+    content: '';
+    position: absolute;
+    top: 5px;
+    left: 50%;
+    transform: translateX(-50%);
+    width: 30px;
+    height: 6px;
+    background: linear-gradient(90deg, #64748b, #94a3b8, #64748b);
+    border-radius: 3px;
+}
+
+/* 주날개 */
+.minimap__wing {
+    position: absolute;
+    top: 42%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    width: 140px;
+    height: 12px;
+    background: linear-gradient(180deg, #64748b 0%, #94a3b8 50%, #64748b 100%);
+    border-radius: 6px;
+    z-index: 3;
+    box-shadow: 0 2px 6px rgba(0, 0, 0, 0.15);
+}
+
+/* 날개 엔진 */
+.minimap__wing::before,
+.minimap__wing::after {
+    content: '';
+    position: absolute;
+    top: 50%;
+    transform: translateY(-50%);
+    width: 16px;
+    height: 8px;
+    background: linear-gradient(180deg, #475569 0%, #64748b 100%);
+    border-radius: 4px;
+}
+
+.minimap__wing::before {
+    left: 15px;
+}
+
+.minimap__wing::after {
+    right: 15px;
+}
+
+/* 날개 라벨 */
+.minimap__wing-label {
+    position: absolute;
+    top: 42%;
+    font-size: 8px;
+    font-weight: 600;
+    color: #64748b;
+    white-space: nowrap;
+    z-index: 4;
+}
+
+.minimap__wing-label--left {
+    right: calc(50% + 75px);
+    transform: translateY(-50%);
+}
+
+.minimap__wing-label--right {
+    left: calc(50% + 75px);
+    transform: translateY(-50%);
+}
+
+/* 비상구 표시 */
+.minimap__exit {
+    position: absolute;
+    width: 100%;
+    display: flex;
+    justify-content: space-between;
+    padding: 0 2px;
+    z-index: 5;
+}
+
+.minimap__exit-marker {
+    width: 14px;
+    height: 6px;
+    background: linear-gradient(180deg, #22c55e 0%, #16a34a 100%);
+    border-radius: 2px;
+    position: relative;
+}
+
+/* 비상구 화살표 */
+.minimap__exit-marker::after {
+    content: '';
+    position: absolute;
+    top: 50%;
+    width: 0;
+    height: 0;
+    border-top: 3px solid transparent;
+    border-bottom: 3px solid transparent;
+    transform: translateY(-50%);
+}
+
+.minimap__exit-marker--left::after {
+    left: -4px;
+    border-right: 4px solid #22c55e;
+}
+
+.minimap__exit-marker--right::after {
+    right: -4px;
+    border-left: 4px solid #22c55e;
+}
+
+.minimap__exit--front {
+    top: 12%;
+}
+
+.minimap__exit--overwing {
+    top: 48%;
+}
+
+.minimap__exit--rear {
+    top: 85%;
+}
+
+/* 좌석 영역 */
+.minimap__cabin {
+    position: absolute;
+    top: 45px;
+    left: 12px;
+    right: 12px;
+    bottom: 25px;
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    overflow: hidden;
+}
+
+/* 좌석 행 */
+.minimap__seat-row {
+    display: flex;
+    justify-content: space-between;
+    gap: 8px;
+    flex: 1;
+    max-height: 8px;
+}
+
+.minimap__seat-group {
+    display: flex;
+    gap: 2px;
+    flex: 1;
 }
 
 .minimap__seat {
-    width: 100%;
-    height: 10px;
-    border-radius: 3px 3px 2px 2px;
+    flex: 1;
+    height: 100%;
+    border-radius: 2px 2px 1px 1px;
     background: #cbd5e1;
     border: 1px solid #94a3b8;
     transition: all 0.2s ease;
+}
+
+/* 통로 표시 */
+.minimap__aisle {
+    width: 6px;
+    flex-shrink: 0;
 }
 
 /* 3구역 클릭 오버레이 */
@@ -92,84 +238,116 @@
     cursor: pointer;
     border-radius: 8px;
     transition: all 0.2s ease;
+    z-index: 10;
 }
 
 .minimap__zone:hover {
-    background: rgba(59, 130, 246, 0.1);
+    background: rgba(59, 130, 246, 0.15);
 }
 
 .minimap__zone--front {
     top: 8px;
-    height: 30%;
+    height: 28%;
     border-radius: 40px 40px 8px 8px;
 }
+
 .minimap__zone--mid {
-    top: calc(8px + 30%);
-    height: 35%;
+    top: calc(8px + 28%);
+    height: 38%;
 }
+
 .minimap__zone--rear {
-    top: calc(8px + 65%);
-    height: calc(35% - 16px);
-    border-radius: 8px 8px 16px 16px;
+    top: calc(8px + 66%);
+    height: calc(34% - 16px);
+    border-radius: 8px 8px 20px 20px;
 }
 
 .minimap__zone.is-active {
-    background: rgba(59, 130, 246, 0.25);
+    background: rgba(59, 130, 246, 0.2);
     box-shadow: inset 0 0 0 2px #3b82f6;
 }
 
 /* 구역 라벨 */
-.minimap__zone::after {
-    content: '';
+.minimap__zone-label {
     position: absolute;
-    right: 6px;
+    left: 50%;
     top: 50%;
-    transform: translateY(-50%);
-    font-size: 9px;
-    font-weight: 600;
+    transform: translate(-50%, -50%);
+    font-size: 10px;
+    font-weight: 700;
     color: #64748b;
-    opacity: 0;
-    transition: opacity 0.2s ease;
+    opacity: 0.7;
+    transition: all 0.2s ease;
+    pointer-events: none;
 }
 
-.minimap__zone--front::after { content: '앞'; }
-.minimap__zone--mid::after { content: '중간'; }
-.minimap__zone--rear::after { content: '뒤'; }
-
-.minimap__zone:hover::after,
-.minimap__zone.is-active::after {
+.minimap__zone:hover .minimap__zone-label,
+.minimap__zone.is-active .minimap__zone-label {
     opacity: 1;
+    color: #3b82f6;
 }
 
-/* 미니맵 하단 범례 */
-.minimap__legend {
+/* 범례 */
+.minimap__info {
     display: flex;
     flex-direction: column;
-    gap: 6px;
-    margin-top: 8px;
+    gap: 8px;
+    width: 100%;
     padding-top: 12px;
     border-top: 1px solid #e2e8f0;
-    width: 100%;
 }
 
-.minimap__legend-item {
+.minimap__info-title {
+    font-size: 10px;
+    font-weight: 600;
+    color: #374151;
+    margin-bottom: 4px;
+}
+
+.minimap__info-item {
     display: flex;
     align-items: center;
-    gap: 6px;
+    gap: 8px;
     font-size: 10px;
     color: #64748b;
 }
 
-.minimap__legend-dot {
-    width: 10px;
-    height: 10px;
-    border-radius: 3px;
+.minimap__info-icon {
+    width: 14px;
+    height: 6px;
+    border-radius: 2px;
+    flex-shrink: 0;
 }
 
-.minimap__legend-dot--available {
-    background: linear-gradient(180deg, #60a5fa 0%, #3b82f6 100%);
+.minimap__info-icon--exit {
+    background: linear-gradient(180deg, #22c55e 0%, #16a34a 100%);
 }
 
-.minimap__legend-dot--selected {
-    background: linear-gradient(180deg, #1d4ed8 0%, #1e40af 100%);
+.minimap__info-icon--wing {
+    background: linear-gradient(180deg, #64748b 0%, #94a3b8 100%);
+    width: 20px;
+}
+
+/* 구역 설명 */
+.minimap__zones-info {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    margin-top: 4px;
+}
+
+.minimap__zones-item {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    font-size: 9px;
+    color: #6b7280;
+}
+
+.minimap__zones-dot {
+    width: 8px;
+    height: 8px;
+    border-radius: 2px;
+    background: rgba(59, 130, 246, 0.2);
+    border: 1px solid #3b82f6;
 }

--- a/src/main/webapp/resources/seat/css/seatgrid.css
+++ b/src/main/webapp/resources/seat/css/seatgrid.css
@@ -4,19 +4,25 @@
     min-height: 400px;
     display: flex;
     flex-direction: column;
-    gap: var(--spacing-sm);
+    gap: 6px;
+    padding: 16px;
+    background: linear-gradient(180deg, #f8fafc 0%, #f1f5f9 100%);
+    border-radius: 16px;
 }
 
 /* 좌석 행 */
 .seat-row {
     display: flex;
     align-items: center;
-    gap: 12px; /* 가운데 통로 간격(기존 8px → 12px) */
+    gap: 8px;
+    justify-content: center;
 }
 
 /* 컬럼 헤더 (A~F) */
 .seat-row--header {
-    margin-bottom: 6px;
+    margin-bottom: 8px;
+    padding-bottom: 8px;
+    border-bottom: 2px dashed #e2e8f0;
 }
 
 /* 좌/우 컬럼 텍스트 묶음(헤더용) */
@@ -27,101 +33,189 @@
 }
 
 .seat-col {
-    width: 63px;
-    height: 24px;
+    width: 56px;
+    height: 28px;
     display: flex;
     align-items: center;
     justify-content: center;
 
     font-family: var(--font-family-primary);
-    font-size: var(--font-size-sm);
-    font-weight: var(--font-weight-semibold);
-    color: var(--color-text-subtle);
+    font-size: 13px;
+    font-weight: 700;
+    color: #64748b;
+    background: #e2e8f0;
+    border-radius: 6px;
 }
 
-/* 가운데 행 번호(통로 중앙) */
+/* 가운데 행 번호(통로 중앙) - 숫자만 표시 */
 .seat-row__number--mid {
-    width: 48px; /* 가운데 번호 폭 */
+    width: 36px;
+    min-width: 36px;
     text-align: center;
     font-family: var(--font-family-primary);
-    font-size: var(--font-size-md);
-    font-weight: var(--font-weight-semibold);
-    color: var(--color-text-subtle);
-    flex: 0 0 auto;
+    font-size: 12px;
+    font-weight: 600;
+    color: #94a3b8;
+    flex: 0 0 36px;
+    background: transparent;
+    padding: 0;
 }
 
 /* (호환용) 예전 클래스가 남아있어도 깨지지 않게 */
 .seat-row__number {
-    width: 63px;
+    width: 56px;
     text-align: center;
     font-family: var(--font-family-primary);
-    font-size: var(--font-size-md);
-    font-weight: var(--font-weight-semibold);
-    color: var(--color-text-subtle);
+    font-size: 13px;
+    font-weight: 700;
+    color: #94a3b8;
 }
 
 /* 좌/우 좌석 묶음 */
 .seat-row__seats {
     display: flex;
-    gap: 8px;
-    flex: 0 0 auto; /* 기존 flex:1 제거 (중앙 배치 위해) */
+    gap: 6px;
+    flex: 0 0 auto;
 }
 
 .seat-row__seats--left,
 .seat-row__seats--right {
     display: flex;
-    gap: 8px;
+    gap: 6px;
     flex: 0 0 auto;
 }
 
-/* 좌석 버튼 기본 */
+/* 좌석 버튼 기본 - 비행기 좌석 모양 */
 .seat-item {
-    width: 63px;
-    height: 51px;
+    width: 56px;
+    height: 52px;
     display: flex;
     align-items: center;
     justify-content: center;
     border: none;
-    border-radius: var(--radius-sm);
+    border-radius: 10px 10px 6px 6px;
     font-family: var(--font-family-primary);
-    font-size: 17px;
-    font-weight: var(--font-weight-semibold);
+    font-size: 14px;
+    font-weight: var(--font-weight-bold);
     cursor: pointer;
-    transition: all 0.2s;
+    transition: all 0.2s cubic-bezier(0.4, 0, 0.2, 1);
+    position: relative;
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+}
+
+/* 좌석 상단 등받이 효과 */
+.seat-item::before {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: 4px;
+    right: 4px;
+    height: 8px;
+    border-radius: 6px 6px 0 0;
+    background: inherit;
+    filter: brightness(0.9);
+}
+
+/* 좌석 팔걸이 효과 */
+.seat-item::after {
+    content: '';
+    position: absolute;
+    bottom: 3px;
+    left: 2px;
+    right: 2px;
+    height: 3px;
+    border-radius: 2px;
+    background: rgba(0, 0, 0, 0.1);
 }
 
 /* 좌석 상태 */
 .seat-item--available {
-    background-color: var(--color-seat-available);
-    color: var(--color-seat-text-white);
+    background: linear-gradient(180deg, #60a5fa 0%, #3b82f6 100%);
+    color: #ffffff;
+    border: 2px solid #2563eb;
 }
 
 .seat-item--available:hover {
-    transform: scale(1.05);
-    box-shadow: 0 2px 8px rgba(42, 116, 227, 0.3);
+    transform: translateY(-3px) scale(1.02);
+    box-shadow: 0 8px 20px rgba(59, 130, 246, 0.4);
+    background: linear-gradient(180deg, #93c5fd 0%, #60a5fa 100%);
+}
+
+.seat-item--available:active {
+    transform: translateY(-1px) scale(1.01);
 }
 
 .seat-item--selected {
-    background-color: var(--color-seat-selected);
-    color: var(--color-seat-text-white);
+    background: linear-gradient(180deg, #1d4ed8 0%, #1e40af 100%);
+    color: #ffffff;
+    border: 2px solid #1e3a8a;
+    box-shadow: 0 4px 12px rgba(29, 78, 216, 0.4), inset 0 1px 0 rgba(255, 255, 255, 0.2);
+}
+
+.seat-item--selected::before {
+    background: #1e40af;
+}
+
+/* 선택됨 체크 아이콘 */
+.seat-item--selected .seat-check {
+    position: absolute;
+    top: -6px;
+    right: -6px;
+    width: 18px;
+    height: 18px;
+    background: #10b981;
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 10px;
+    color: white;
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
 }
 
 .seat-item--hold {
-    background-color: #ffa500;
-    color: var(--color-seat-text-white);
+    background: linear-gradient(180deg, #fbbf24 0%, #f59e0b 100%);
+    color: #ffffff;
+    border: 2px solid #d97706;
     cursor: not-allowed;
+    opacity: 0.85;
 }
 
 .seat-item--unavailable {
-    background-color: var(--color-seat-unavailable);
-    color: var(--color-seat-text-white);
+    background: linear-gradient(180deg, #e2e8f0 0%, #cbd5e1 100%);
+    color: #94a3b8;
+    border: 2px solid #94a3b8;
     cursor: not-allowed;
-    opacity: 0.6;
+}
+
+.seat-item--unavailable::before {
+    background: #cbd5e1;
+}
+
+/* X 표시 */
+.seat-item--unavailable::after {
+    content: '';
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    width: 20px;
+    height: 2px;
+    background: #94a3b8;
+    transform: translate(-50%, -50%) rotate(45deg);
+    border-radius: 0;
+    bottom: auto;
 }
 
 .seat-item--empty {
     background: transparent;
     cursor: default;
+    border: none;
+    box-shadow: none;
+}
+
+.seat-item--empty::before,
+.seat-item--empty::after {
+    display: none;
 }
 
 /* ==================== 좌석 섹션 3개 front/mid/rear ==================== */
@@ -152,4 +246,77 @@
 .seat-grid--rear .seat-row[data-section="rear"] {
     display: flex;
 }
+
+/* ==================== Loading State ==================== */
+.seat-grid__loading {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    padding: 60px 20px;
+    color: #64748b;
+    font-size: 14px;
+    font-weight: 500;
+}
+
+.seat-grid__loading::before {
+    content: '';
+    width: 40px;
+    height: 40px;
+    border: 3px solid #e2e8f0;
+    border-top-color: #3b82f6;
+    border-radius: 50%;
+    animation: spin 1s linear infinite;
+    margin-bottom: 16px;
+}
+
+@keyframes spin {
+    to { transform: rotate(360deg); }
+}
+
+/* ==================== Empty State ==================== */
+.selected-summary__empty {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 20px 16px;
+    text-align: center;
+    background: #f9fafb;
+    border-radius: 8px;
+    border: 1px dashed #e5e7eb;
+}
+
+.selected-summary__empty p {
+    color: #9ca3af;
+    font-size: 13px;
+    font-weight: 400;
+    margin: 0;
+}
+
+/* ==================== Animations ==================== */
+@keyframes fadeInUp {
+    from {
+        opacity: 0;
+        transform: translateY(10px);
+    }
+    to {
+        opacity: 1;
+        transform: translateY(0);
+    }
+}
+
+.seat-row {
+    animation: fadeInUp 0.3s ease forwards;
+}
+
+.seat-row:nth-child(1) { animation-delay: 0.02s; }
+.seat-row:nth-child(2) { animation-delay: 0.04s; }
+.seat-row:nth-child(3) { animation-delay: 0.06s; }
+.seat-row:nth-child(4) { animation-delay: 0.08s; }
+.seat-row:nth-child(5) { animation-delay: 0.10s; }
+.seat-row:nth-child(6) { animation-delay: 0.12s; }
+.seat-row:nth-child(7) { animation-delay: 0.14s; }
+.seat-row:nth-child(8) { animation-delay: 0.16s; }
+.seat-row:nth-child(9) { animation-delay: 0.18s; }
+.seat-row:nth-child(10) { animation-delay: 0.20s; }
 

--- a/src/main/webapp/resources/seat/css/toggle.css
+++ b/src/main/webapp/resources/seat/css/toggle.css
@@ -1,88 +1,128 @@
-/* ==================== Notices + Terms (Scoped) ==================== */
-/* JSP 기준: <section class="seat-notices"> 안에서만 적용되게 스코프 걸어 충돌 방지 */
+/* ==================== Notices + Terms ==================== */
 
 /* ---------- Notices Section ---------- */
 .seat-notices {
     display: flex;
     flex-direction: column;
-    gap: 18px;
-    margin-top: 28px;
+    gap: 20px;
+    margin-top: 0;
+    padding: 24px;
+    background: #ffffff;
+    border-radius: 16px;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.04);
+    border: 1px solid #e5e7eb;
 }
 
 .seat-notices__title {
     font-family: var(--font-family-primary);
-    font-size: var(--font-size-2xl);
-    font-weight: var(--font-weight-semibold);
-    color: var(--color-text-primary);
+    font-size: 15px;
+    font-weight: 700;
+    color: #111827;
     margin: 0;
 }
 
-/* 유의사항 컨텐츠 박스 (스크린샷처럼 카드 느낌) */
+/* 유의사항 컨텐츠 박스 */
 .seat-notices__content {
-    background: var(--color-white);
-    border: 1px solid #eee;
-    border-radius: 12px;
-    padding: 18px 22px;
+    background: #f9fafb;
+    border: 1px solid #e5e7eb;
+    border-radius: 8px;
+    padding: 16px 20px;
 }
 
-/* 지금 JSP가 p로 되어 있으니, p를 "불릿처럼" 보이게 보정 */
 .seat-notices__content p {
     position: relative;
     margin: 0;
-    padding-left: 14px;
+    padding-left: 12px;
     font-family: var(--font-family-primary);
-    font-size: var(--font-size-md);
-    font-weight: var(--font-weight-medium);
-    color: var(--color-text-primary);
-    line-height: 22px;
+    font-size: 13px;
+    font-weight: 400;
+    color: #6b7280;
+    line-height: 1.6;
 }
 
-/* 문장 사이 간격 */
 .seat-notices__content p + p {
     margin-top: 8px;
 }
 
-/* 앞에 점/표시 (※ 유지하면서도 리스트 감성) */
 .seat-notices__content p::before {
     content: "•";
     position: absolute;
     left: 0;
     top: 0;
-    color: #999;
+    color: #9ca3af;
 }
 
-/* ---------- Terms Section (Accordion + Checkbox) ---------- */
+/* ---------- 구분선 ---------- */
+.seat-notices__divider {
+    height: 1px;
+    background: #e5e7eb;
+    margin: 4px 0;
+}
+
+/* ---------- 약관 동의 제목 ---------- */
+.seat-notices__title--terms {
+    margin-top: 0;
+}
+
+/* ---------- Terms Section ---------- */
 .seat-notices .seat-terms {
-    border: 1px solid #eee;
-    border-radius: 12px;
+    border: 1px solid #e5e7eb;
+    border-radius: 8px;
     overflow: hidden;
     background: #fff;
 }
 
-/* 헤더(체크박스 + 타이틀 + 화살표) */
+/* 헤더 */
 .seat-notices .seat-terms__header-wrapper {
     display: flex;
     align-items: center;
     gap: 12px;
-    padding: 18px 22px;
+    padding: 14px 16px;
     background: #fff;
-    cursor: pointer; /* 헤더 전체 클릭 가능한 느낌 */
+    cursor: pointer;
     user-select: none;
-    transition: background-color 0.2s;
+    transition: background-color 0.15s;
 }
 
 .seat-notices .seat-terms__header-wrapper:hover {
-    background-color: rgba(0, 0, 0, 0.02);
+    background: #f9fafb;
 }
 
-/* 체크박스: 기본 체크박스 스타일 활용 (최소 침투) */
+/* 체크박스 */
 .seat-notices .terms-hidden-check {
-    width: 22px;
-    height: 22px;
+    appearance: none;
+    -webkit-appearance: none;
+    width: 18px;
+    height: 18px;
     margin: 0;
     cursor: pointer;
-    accent-color: var(--color-primary-seat, #2a74e3);
     flex: 0 0 auto;
+    border: 1.5px solid #d1d5db;
+    border-radius: 4px;
+    background: #ffffff;
+    transition: all 0.15s ease;
+    position: relative;
+}
+
+.seat-notices .terms-hidden-check:hover {
+    border-color: #3b82f6;
+}
+
+.seat-notices .terms-hidden-check:checked {
+    background: #3b82f6;
+    border-color: #3b82f6;
+}
+
+.seat-notices .terms-hidden-check:checked::after {
+    content: '';
+    position: absolute;
+    top: 2px;
+    left: 5px;
+    width: 5px;
+    height: 9px;
+    border: solid white;
+    border-width: 0 2px 2px 0;
+    transform: rotate(45deg);
 }
 
 /* 제목 라벨 */
@@ -91,24 +131,26 @@
     align-items: center;
     gap: 6px;
     font-family: var(--font-family-primary);
-    font-size: 16px;
-    font-weight: 700;
-    color: #2c2c2c;
+    font-size: 14px;
+    font-weight: 500;
+    color: #374151;
     margin: 0;
     cursor: pointer;
-    line-height: 1.2;
+    line-height: 1.3;
+    flex: 1;
 }
 
-/* [필수] 강조 */
+/* [필수] */
 .seat-notices .seat-terms__title .color-blue {
-    color: var(--color-primary-seat, #2a74e3);
+    color: #3b82f6;
+    font-weight: 600;
 }
 
-/* 오른쪽 토글 버튼 */
+/* 토글 버튼 */
 .seat-notices .seat-terms__toggle-btn {
     margin-left: auto;
-    width: 40px;
-    height: 40px;
+    width: 28px;
+    height: 28px;
     border: none;
     background: transparent;
     cursor: pointer;
@@ -118,34 +160,34 @@
     padding: 0;
 }
 
-/* chevron (span.chevron-arrow) */
+/* chevron */
 .seat-notices .chevron-arrow {
     display: inline-block;
-    width: 10px;
-    height: 10px;
-    border-right: 2px solid #9b9b9b;
-    border-bottom: 2px solid #9b9b9b;
+    width: 7px;
+    height: 7px;
+    border-right: 1.5px solid #9ca3af;
+    border-bottom: 1.5px solid #9ca3af;
     transform: rotate(45deg);
-    transition: transform 0.25s ease;
+    transition: transform 0.2s ease;
 }
 
 /* content 영역 */
 .seat-notices .seat-terms__content {
-    padding: 0 22px 20px 58px; /* 체크박스 시작선 맞추기 */
-    background: #fff;
+    padding: 16px 16px 16px 46px;
+    background: #f9fafb;
+    border-top: 1px solid #e5e7eb;
     font-family: var(--font-family-primary);
-    font-size: 14px;
-    font-weight: var(--font-weight-medium);
-    color: #666;
-    line-height: 1.7;
+    font-size: 13px;
+    font-weight: 400;
+    color: #6b7280;
+    line-height: 1.6;
 }
 
-/* hidden 속성일 때 자연스럽게 (JS로 hidden 토글할 예정) */
 .seat-notices .seat-terms__content[hidden] {
     display: none !important;
 }
 
-/* 리스트 스타일 */
+/* 리스트 */
 .seat-notices .terms-list {
     list-style: none;
     margin: 0;
@@ -153,39 +195,45 @@
 }
 
 .seat-notices .terms-list > li + li {
-    margin-top: 14px;
+    margin-top: 16px;
+    padding-top: 16px;
+    border-top: 1px solid #e5e7eb;
 }
 
 .seat-notices .terms-list strong {
     display: block;
-    font-weight: 700;
-    color: #333;
-    margin-bottom: 6px;
+    font-weight: 600;
+    font-size: 13px;
+    color: #374151;
+    margin-bottom: 8px;
 }
 
 /* 내부 ul */
 .seat-notices .terms-list ul {
     margin: 0;
-    padding-left: 18px;
+    padding-left: 16px;
+    list-style: disc;
 }
 
 .seat-notices .terms-list ul li {
-    list-style: disc;
-    margin: 0 0 6px 0;
+    margin: 0 0 4px 0;
+    font-size: 12px;
+    color: #6b7280;
 }
 
-/* 마지막 li 간격 정리 */
+.seat-notices .terms-list ul li::marker {
+    color: #d1d5db;
+}
+
 .seat-notices .terms-list ul li:last-child {
     margin-bottom: 0;
 }
 
-/* ---------- Expanded State (JS에서 header에 클래스 토글 추천) ---------- */
-/* JS에서 #terms-header(좋음) 또는 .seat-terms__header-wrapper에 이 클래스 붙이면 됨 */
+/* Expanded State */
 .seat-notices .seat-terms__header-wrapper.seat-terms__header--expanded .chevron-arrow {
     transform: rotate(-135deg);
 }
 
-/* 체크박스 체크 시 약간 강조 (선택사항) */
 .seat-notices .terms-hidden-check:checked + .seat-terms__title {
-    color: var(--color-primary-seat, #2a74e3);
+    color: #1f2937;
 }

--- a/src/main/webapp/resources/seat/js/seat-confirm.js
+++ b/src/main/webapp/resources/seat/js/seat-confirm.js
@@ -6,29 +6,103 @@ window.SeatConfirm = (() => {
             return dom.termsCheckbox ? !!dom.termsCheckbox.checked : true;
         }
 
-        function isAllPassengersPicked() {
+        // 현재 세그먼트의 모든 승객이 좌석 선택했는지 확인
+        function isCurrentSegmentComplete() {
             if (!state.passengers.length) return false;
-            return state.passengers.every(
-                (p) => !!state.selectedSeatsByPassenger[p.passengerId]
-            );
+            const segId = state.activeSegmentId;
+            const seats = state.selectedSeatsBySegment[segId] || {};
+            return state.passengers.every((p) => !!seats[p.passengerId]);
+        }
+
+        // 모든 세그먼트의 모든 승객이 좌석 선택했는지 확인
+        function isAllSegmentsComplete() {
+            if (!state.passengers.length) return false;
+            if (!state.segments.length) return false;
+
+            return state.segments.every((seg) => {
+                const seats = state.selectedSeatsBySegment[seg.segmentId] || {};
+                return state.passengers.every((p) => !!seats[p.passengerId]);
+            });
+        }
+
+        // 미완료 세그먼트 찾기
+        function findIncompleteSegment() {
+            for (const seg of state.segments) {
+                const seats = state.selectedSeatsBySegment[seg.segmentId] || {};
+                const isComplete = state.passengers.every((p) => !!seats[p.passengerId]);
+                if (!isComplete) {
+                    return seg;
+                }
+            }
+            return null;
+        }
+
+        function scrollToTermsAndHighlight() {
+            const termsSection = document.querySelector(".seat-notices");
+            const termsCheckbox = document.getElementById("terms-checkbox");
+            const termsWrapper = document.querySelector(".seat-terms__header-wrapper");
+
+            if (termsSection) {
+                setTimeout(() => {
+                    termsSection.scrollIntoView({ behavior: "smooth", block: "center" });
+
+                    if (termsWrapper) {
+                        termsWrapper.style.transition = "box-shadow 0.3s ease";
+                        termsWrapper.style.boxShadow = "0 0 0 3px rgba(239, 68, 68, 0.5)";
+                        termsWrapper.style.borderRadius = "8px";
+
+                        setTimeout(() => {
+                            termsWrapper.style.boxShadow = "";
+                        }, 2000);
+                    }
+
+                    if (termsCheckbox) {
+                        termsCheckbox.focus();
+                    }
+                }, 100);
+            }
+        }
+
+        // 세그먼트 탭으로 전환
+        function switchToSegment(segmentId) {
+            const tab = document.querySelector(`#segment-tabs .segment-tab[data-segment-id="${segmentId}"]`);
+            if (tab) {
+                tab.click();
+            }
         }
 
         function sync() {
         }
 
         function bindConfirmClick() {
-            dom.btnConfirm?.addEventListener("click", (e) => {
+            dom.btnConfirm?.addEventListener("click", async (e) => {
                 e.preventDefault();
 
-                // 좌석 선택 확인
-                if (!isAllPassengersPicked()) {
-                    alert("좌석을 선택해주세요.");
+                // 모든 세그먼트 좌석 선택 확인
+                if (!isAllSegmentsComplete()) {
+                    const incompleteSeg = findIncompleteSegment();
+
+                    if (incompleteSeg) {
+                        const segName = `${incompleteSeg.dep} → ${incompleteSeg.arr}`;
+
+                        Swal.warning(
+                            `${segName} 구간의 모든 승객 좌석을 선택해주세요.`,
+                            "좌석 미선택"
+                        ).then(() => {
+                            // 미완료 세그먼트로 전환
+                            switchToSegment(incompleteSeg.segmentId);
+                        });
+                    } else {
+                        Swal.warning("모든 구간의 좌석을 선택해주세요.", "좌석 미선택");
+                    }
                     return;
                 }
 
                 // 약관 동의 확인
                 if (!isAgreed()) {
-                    alert("약관에 동의해주세요.");
+                    Swal.warning("좌석 선택 규정에 동의해주세요.", "약관 동의 필요").then(() => {
+                        scrollToTermsAndHighlight();
+                    });
                     return;
                 }
 
@@ -38,7 +112,6 @@ window.SeatConfirm = (() => {
         }
 
         function bindTermsUI() {
-            // 약관 토글 UI만 유지
             if (dom.termsToggle && dom.termsContent) {
                 dom.termsToggle.addEventListener("click", (e) => {
                     e.preventDefault();

--- a/src/main/webapp/resources/seat/js/seat-events.js
+++ b/src/main/webapp/resources/seat/js/seat-events.js
@@ -2,10 +2,59 @@ window.SeatEvents = (() => {
     function bind(app, renderer) {
         const { dom, ctx, state } = app;
 
+        bindSegmentTabs();
         bindActionSeatSelect();
         bindSeatGridClick();
         bindCancel();
         bindMinimapZone();
+
+        // 세그먼트 탭 전환 (가는편/오는편)
+        function bindSegmentTabs() {
+            const tabsEl = dom.segmentTabsEl;
+            if (!tabsEl) return;
+
+            // 초기 완료 상태 표시
+            updateAllSegmentTabsStatus();
+
+            tabsEl.addEventListener("click", async (e) => {
+                const tab = e.target.closest(".segment-tab");
+                if (!tab) return;
+
+                const newSegmentId = tab.dataset.segmentId;
+                if (!newSegmentId || newSegmentId === state.activeSegmentId) return;
+
+                // 탭 UI 전환
+                tabsEl.querySelectorAll(".segment-tab").forEach((t) => {
+                    t.classList.toggle("segment-tab--active", t.dataset.segmentId === newSegmentId);
+                });
+
+                // 상태 업데이트
+                state.activeSegmentId = newSegmentId;
+                ctx.segmentId = newSegmentId;
+
+                // 첫 번째 승객으로 리셋
+                state.activePassengerId =
+                    (state.passengers[0] && state.passengers[0].passengerId) || ctx.defaultPassengerId;
+
+                // 좌석 정보 다시 로드
+                await renderer.refreshAndRender().catch(console.error);
+
+                // 완료 상태 업데이트
+                updateAllSegmentTabsStatus();
+            });
+        }
+
+        // 모든 세그먼트 탭 완료 상태 업데이트
+        function updateAllSegmentTabsStatus() {
+            const tabs = document.querySelectorAll("#segment-tabs .segment-tab");
+            tabs.forEach((tab) => {
+                const segId = tab.dataset.segmentId;
+                const seats = state.selectedSeatsBySegment[segId] || {};
+                const isComplete = state.passengers.length > 0 &&
+                    state.passengers.every((p) => !!seats[p.passengerId]);
+                tab.classList.toggle("is-complete", isComplete);
+            });
+        }
 
         // 오른쪽 액션 카드 버튼으로 activePassengerId 변경
         function bindActionSeatSelect() {
@@ -21,7 +70,7 @@ window.SeatEvents = (() => {
             });
         }
 
-        // 좌석 클릭 → HOLD/RELEASE
+        // 좌석 클릭 → HOLD/RELEASE (Optimistic UI Update)
         function bindSeatGridClick() {
             dom.seatGridEl.addEventListener("click", async (e) => {
                 const btn = e.target.closest("button.seat-item");
@@ -31,72 +80,130 @@ window.SeatEvents = (() => {
                 if (!seatNo) return;
 
                 const pid = state.activePassengerId;
-                const currentSeatNo = state.selectedSeatsByPassenger[pid] || null;
+                const segId = state.activeSegmentId;
+                const currentSeats = state.selectedSeatsBySegment[segId] || {};
+                const currentSeatNo = currentSeats[pid] || null;
 
                 // 동일 화면 중복 선택 방지
-                const occupiedByOther = Object.entries(state.selectedSeatsByPassenger).some(
+                const occupiedByOther = Object.entries(currentSeats).some(
                     ([otherPid, s]) => otherPid !== String(pid) && s === seatNo
                 );
                 if (occupiedByOther) {
-                    alert("다른 승객이 이미 선택한 좌석입니다.");
+                    Swal.warning("다른 승객이 이미 선택한 좌석입니다.", "좌석 선택 불가");
                     return;
                 }
 
                 // disabled 좌석은 클릭 무시 (현재 선택좌석 해제만 허용)
                 if (btn.disabled && !(currentSeatNo && seatNo === currentSeatNo)) return;
 
-                try {
-                    state.isHolding = true;
+                state.isHolding = true;
 
-                    if (currentSeatNo === seatNo) {
-                        await SeatAPI.releaseHold(
-                            ctx.base,
-                            ctx.reservationId,
-                            ctx.segmentId,
-                            pid
-                        );
+                // 같은 좌석 재클릭 → 해제
+                if (currentSeatNo === seatNo) {
+                    // 1. 즉시 UI 업데이트
+                    SeatGrid.updateSeatUI(dom.seatGridEl, seatNo, "AVAILABLE");
+                    delete state.selectedSeatsBySegment[segId][pid];
+                    updateSummaryUI();
 
-                        delete state.selectedSeatsByPassenger[pid];
-                        await renderer.refreshAndRender();
-                        return;
-                    } else {
-                        if (currentSeatNo) {
-                            await SeatAPI.releaseHold(
-                                ctx.base,
-                                ctx.reservationId,
-                                ctx.segmentId,
-                                pid
-                            );
-                        }
-                        await SeatAPI.holdSeat(
-                            ctx.base,
-                            ctx.reservationId,
-                            ctx.segmentId, {
-                            passengerId: pid,
-                            seatNo,
-                        });
-
-                        state.selectedSeatsByPassenger[pid] = seatNo;
-                        await renderer.refreshAndRender();
+                    // 2. 백그라운드 API 호출
+                    try {
+                        await SeatAPI.releaseHold(ctx.base, ctx.reservationId, segId, pid);
+                    } catch (err) {
+                        // 실패 시 롤백
+                        state.selectedSeatsBySegment[segId][pid] = seatNo;
+                        SeatGrid.updateSeatUI(dom.seatGridEl, seatNo, "HOLD");
+                        updateSummaryUI();
+                        Swal.error("좌석 해제에 실패했습니다.", "오류");
+                    } finally {
+                        state.isHolding = false;
                     }
+                    return;
+                }
+
+                // 새 좌석 선택
+                // 1. 즉시 UI 업데이트
+                if (currentSeatNo) {
+                    SeatGrid.updateSeatUI(dom.seatGridEl, currentSeatNo, "AVAILABLE");
+                }
+                SeatGrid.updateSeatUI(dom.seatGridEl, seatNo, "HOLD");
+
+                if (!state.selectedSeatsBySegment[segId]) {
+                    state.selectedSeatsBySegment[segId] = {};
+                }
+                state.selectedSeatsBySegment[segId][pid] = seatNo;
+                updateSummaryUI();
+
+                // 2. 백그라운드 API 호출
+                try {
+                    if (currentSeatNo) {
+                        await SeatAPI.releaseHold(ctx.base, ctx.reservationId, segId, pid);
+                    }
+                    await SeatAPI.holdSeat(ctx.base, ctx.reservationId, segId, {
+                        passengerId: pid,
+                        seatNo,
+                    });
                 } catch (err) {
-                    alert(`좌석 선택에 실패했습니다. 다시 시도해주세요.`);
-                    await renderer.refreshAndRender().catch(() => {});
+                    // 실패 시 롤백
+                    SeatGrid.updateSeatUI(dom.seatGridEl, seatNo, "AVAILABLE");
+                    if (currentSeatNo) {
+                        state.selectedSeatsBySegment[segId][pid] = currentSeatNo;
+                        SeatGrid.updateSeatUI(dom.seatGridEl, currentSeatNo, "HOLD");
+                    } else {
+                        delete state.selectedSeatsBySegment[segId][pid];
+                    }
+                    updateSummaryUI();
+                    Swal.error("좌석 선택에 실패했습니다. 다시 시도해주세요.", "오류");
                 } finally {
                     state.isHolding = false;
                 }
             });
+
+            // 우측 패널 요약 업데이트 (전체 렌더링 없이)
+            function updateSummaryUI() {
+                const segInfo = getActiveSegmentInfo();
+                const segId = state.activeSegmentId;
+
+                SeatGrid.renderSelectedSummary(dom.summaryEl, {
+                    passengers: state.passengers,
+                    activePassengerId: state.activePassengerId,
+                    selectedSeatsByPassenger: state.selectedSeatsBySegment[segId] || {},
+                    segment: segInfo,
+                });
+                SeatGrid.renderSeatAction(dom.actionEl, {
+                    passengers: state.passengers,
+                    activePassengerId: state.activePassengerId,
+                    selectedSeatsByPassenger: state.selectedSeatsBySegment[segId] || {},
+                    segment: segInfo,
+                });
+
+                // 세그먼트 탭 완료 상태 업데이트
+                updateAllSegmentTabsStatus();
+            }
+
+            function getActiveSegmentInfo() {
+                const activeSegBtn = document.querySelector("#segment-tabs .segment-tab--active");
+                if (!activeSegBtn) return { routeText: "", dateTimeText: "" };
+                const dep = activeSegBtn.dataset.dep || "";
+                const arr = activeSegBtn.dataset.arr || "";
+                const depTimeText = activeSegBtn.dataset.deptime || "";
+                return {
+                    routeText: dep && arr ? `${dep} → ${arr}` : "",
+                    dateTimeText: depTimeText,
+                };
+            }
         }
 
-        // 취소: HOLD 풀고 닫기
+        // 취소: 모든 세그먼트의 HOLD 풀고 닫기
         function bindCancel() {
             dom.btnCancel?.addEventListener("click", async () => {
-                const pids = Object.keys(state.selectedSeatsByPassenger);
-
-                for (const pid of pids) {
-                    try {
-                        await SeatAPI.releaseHold(ctx.base, ctx.reservationId, ctx.segmentId, pid);
-                    } catch (e) {}
+                // 모든 세그먼트의 선택된 좌석 해제
+                for (const segId of Object.keys(state.selectedSeatsBySegment)) {
+                    const seats = state.selectedSeatsBySegment[segId];
+                    for (const pid of Object.keys(seats)) {
+                        try {
+                            await SeatAPI.releaseHold(ctx.base, ctx.reservationId, segId, pid);
+                        } catch (e) {}
+                    }
                 }
 
                 window.opener ? window.close() : history.back();

--- a/src/main/webapp/resources/seat/js/seat-grid.js
+++ b/src/main/webapp/resources/seat/js/seat-grid.js
@@ -267,5 +267,46 @@
      `;
     }
 
-    global.SeatGrid = { renderSeatGrid, renderSelectedSummary, renderSeatAction };
+    // =========================
+    // 개별 좌석 UI 업데이트 (전체 렌더링 없이)
+    // =========================
+    function updateSeatUI(seatGridEl, seatNo, status) {
+        if (!seatGridEl || !seatNo) return;
+
+        const btn = seatGridEl.querySelector(`button.seat-item[data-seat-no="${seatNo}"]`);
+        if (!btn) return;
+
+        // 기존 상태 클래스 제거
+        btn.classList.remove(
+            "seat-item--available",
+            "seat-item--hold",
+            "seat-item--selected",
+            "seat-item--unavailable"
+        );
+        btn.disabled = false;
+
+        // 클릭 애니메이션 효과
+        btn.style.transform = "scale(0.9)";
+        requestAnimationFrame(() => {
+            btn.style.transition = "transform 0.15s ease";
+            btn.style.transform = "";
+        });
+
+        // 새 상태 적용
+        if (status === "HOLD" || status === "SELECTED") {
+            btn.classList.add("seat-item--hold");
+        } else if (status === "AVAILABLE") {
+            btn.classList.add("seat-item--available");
+        } else {
+            btn.classList.add("seat-item--unavailable");
+            btn.disabled = true;
+        }
+    }
+
+    global.SeatGrid = {
+        renderSeatGrid,
+        renderSelectedSummary,
+        renderSeatAction,
+        updateSeatUI
+    };
 })(window);

--- a/src/main/webapp/resources/seat/js/seat-render.js
+++ b/src/main/webapp/resources/seat/js/seat-render.js
@@ -22,7 +22,8 @@ window.SeatRenderer = (() => {
         }
 
         async function refreshAndRender() {
-            const seats = await SeatAPI.fetchSeatMap(ctx.base, ctx.reservationId, ctx.segmentId);
+            const segId = state.activeSegmentId;
+            const seats = await SeatAPI.fetchSeatMap(ctx.base, ctx.reservationId, segId);
 
             // 서버에서 이미 AVAILABLE로 바뀐 좌석은 로컬 선택에서도 제거
             const seatStatusBySeatNo = new Map();
@@ -32,16 +33,14 @@ window.SeatRenderer = (() => {
                 if (seatNo) seatStatusBySeatNo.set(seatNo, st);
             });
 
-            Object.entries(state.selectedSeatsByPassenger).forEach(([pid, seatNo]) => {
+            const currentSegmentSeats = state.selectedSeatsBySegment[segId] || {};
+            Object.entries(currentSegmentSeats).forEach(([pid, seatNo]) => {
                 const st = seatStatusBySeatNo.get(String(seatNo)) || "AVAILABLE";
                 // 서버가 AVAILABLE로 보여주면(만료/해제) 로컬도 제거
                 if (st === "AVAILABLE") {
-                    delete state.selectedSeatsByPassenger[pid];
+                    delete state.selectedSeatsBySegment[segId][pid];
                 }
             });
-
-            const activeSeatNo =
-                state.selectedSeatsByPassenger[String(state.activePassengerId)] || null;
 
             SeatGrid.renderSeatGrid(dom.seatGridEl, seats, state.activePassengerId, ctx.cabinClassCode);
 
@@ -50,14 +49,14 @@ window.SeatRenderer = (() => {
             SeatGrid.renderSelectedSummary(dom.summaryEl, {
                 passengers: state.passengers,
                 activePassengerId: state.activePassengerId,
-                selectedSeatsByPassenger: state.selectedSeatsByPassenger,
+                selectedSeatsByPassenger: state.selectedSeatsBySegment[segId] || {},
                 segment: segInfo,
             });
 
             SeatGrid.renderSeatAction(dom.actionEl, {
                 passengers: state.passengers,
                 activePassengerId: state.activePassengerId,
-                selectedSeatsByPassenger: state.selectedSeatsByPassenger,
+                selectedSeatsByPassenger: state.selectedSeatsBySegment[segId] || {},
                 segment: segInfo,
             });
 

--- a/src/main/webapp/resources/seat/js/seat-state.js
+++ b/src/main/webapp/resources/seat/js/seat-state.js
@@ -7,6 +7,7 @@ window.SeatState = (() => {
             seatGridEl,
             summaryEl: document.getElementById("selected-summary"),
             actionEl: document.getElementById("seat-action"),
+            segmentTabsEl: document.getElementById("segment-tabs"),
 
             termsToggle: document.getElementById("terms-toggle"),
             termsContent: document.getElementById("terms-content"),
@@ -26,13 +27,42 @@ window.SeatState = (() => {
             cabinClassCode: seatGridEl.dataset.cabin || null,
         };
 
+        // 세그먼트 목록 수집
+        const segments = [];
+        document.querySelectorAll("#segment-tabs .segment-tab").forEach((tab) => {
+            segments.push({
+                segmentId: tab.dataset.segmentId,
+                dep: tab.dataset.dep,
+                arr: tab.dataset.arr,
+                deptime: tab.dataset.deptime,
+            });
+        });
+
         const state = {
             isHolding: false,
             activePassengerId: "",
-            selectedSeatsByPassenger: {}, // { passengerId: seatNo }
-            passengers: [], // [{ passengerId, name }]
+            activeSegmentId: ctx.segmentId,
+            segments: segments,
+
+            // 세그먼트별 선택 좌석 저장 { segmentId: { passengerId: seatNo } }
+            selectedSeatsBySegment: {},
+
+            // 현재 세그먼트의 선택 좌석 (편의용 getter/setter)
+            get selectedSeatsByPassenger() {
+                return this.selectedSeatsBySegment[this.activeSegmentId] || {};
+            },
+            set selectedSeatsByPassenger(val) {
+                this.selectedSeatsBySegment[this.activeSegmentId] = val;
+            },
+
+            passengers: [],
             passengerNameById: {},
         };
+
+        // 각 세그먼트 초기화
+        segments.forEach((seg) => {
+            state.selectedSeatsBySegment[seg.segmentId] = {};
+        });
 
         // 승객 목록
         document.querySelectorAll("#passenger-source .passenger-source").forEach((el) => {


### PR DESCRIPTION
## 📌 PR 설명
  좌석 선택 페이지의 사용자 경험(UX)을 전반적으로 개선했습니다.
  Optimistic UI 적용으로 즉각적인 피드백 제공, 왕복 항공편 좌석 선택 플로우 개선, 미니맵 UI 리디자인을 포함합니다<br>

## ✅ 완료한 기능 명세

- 좌석 선택 시 Optimistic UI 적용 - 즉시 UI 반영 후 백그라운드 API 호출
  - 브라우저 기본 alert()을 SweetAlert2 커스텀 알림으로 교체
  - 왕복 항공편 세그먼트 탭 전환 기능 구현 (가는편/오는편)
  - 좌석 선택 후 재진입 시 기존 선택 좌석 복원 로직 추가
  -  미니맵 비행기 형태 리디자인 (비상구, 날개 표시)
  -  약관 미동의 시 스크롤 이동 및 하이라이트 효과


<br>

### 🔗 관련 이슈
Closes #226 

<br>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Multi-segment seat selection with per-segment validation and optimistic hold/release behavior
  * Passport toggle and wheel-style date picker for passenger inputs
  * Step progress indicator for the booking flow and unified seat selection card

* **UI/Design Improvements**
  * Full visual redesign: new color tokens, gradients, spacing, and updated seat/minimap visuals
  * Interactive minimap with zone controls and enhanced seat state feedback
  * Reworked notices/terms layout and improved Swal-based user notifications
<!-- end of auto-generated comment: release notes by coderabbit.ai -->