### PR TITLE
[FLYW-197] 에러 페이지 작성

### DIFF
--- a/src/main/java/com/flyway/template/controller/ErrorController.java
+++ b/src/main/java/com/flyway/template/controller/ErrorController.java
@@ -1,0 +1,55 @@
+package com.flyway.template.controller;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+import javax.servlet.RequestDispatcher;
+import javax.servlet.http.HttpServletRequest;
+
+@Slf4j
+@Controller
+@RequestMapping("/error")
+public class ErrorController {
+
+	@GetMapping
+	public String handleError(HttpServletRequest request) {
+		Object status = request.getAttribute(RequestDispatcher.ERROR_STATUS_CODE);
+		String requestUri = (String) request.getAttribute(RequestDispatcher.ERROR_REQUEST_URI);
+
+		if (status != null) {
+			int statusCode = Integer.parseInt(status.toString());
+
+			// 운영 환경 로깅
+			if (statusCode == 404) {
+				log.warn("[404] 페이지 없음: {}", requestUri);
+				return "error/404";
+			} else if (statusCode == 403) {
+				log.warn("[403] 접근 거부: {}", requestUri);
+				return "error/403";
+			} else if (statusCode >= 500) {
+				Object exception = request.getAttribute(RequestDispatcher.ERROR_EXCEPTION);
+				log.error("[{}] 서버 오류: {} - {}", statusCode, requestUri, exception);
+				return "error/500";
+			}
+		}
+
+		return "error/500";
+	}
+
+	@GetMapping("/403")
+	public String forbidden() {
+		return "error/403";
+	}
+
+	@GetMapping("/404")
+	public String notFound() {
+		return "error/404";
+	}
+
+	@GetMapping("/500")
+	public String serverError() {
+		return "error/500";
+	}
+}

--- a/src/main/webapp/WEB-INF/views/error/403.jsp
+++ b/src/main/webapp/WEB-INF/views/error/403.jsp
@@ -1,0 +1,171 @@
+<%@ page contentType="text/html; charset=UTF-8" pageEncoding="UTF-8" isErrorPage="true" %>
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>접근 권한이 없습니다 - Flyway</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Pretendard:wght@400;500;600;700;800;900&display=swap" rel="stylesheet">
+    <style>
+        * {
+            font-family: 'Pretendard', -apple-system, BlinkMacSystemFont, system-ui, sans-serif;
+        }
+
+        body {
+            background: linear-gradient(135deg, #fef3c7 0%, #fef9c3 50%, #fffbeb 100%);
+            min-height: 100vh;
+            overflow: hidden;
+        }
+
+        /* 경고 테이프 패턴 */
+        .warning-tape {
+            position: absolute;
+            width: 200%;
+            height: 30px;
+            background: repeating-linear-gradient(
+                45deg,
+                #fbbf24,
+                #fbbf24 20px,
+                #1f2937 20px,
+                #1f2937 40px
+            );
+            opacity: 0.3;
+        }
+
+        .tape-top {
+            top: 10%;
+            left: -50%;
+            transform: rotate(-5deg);
+            animation: tape-scroll 20s linear infinite;
+        }
+
+        .tape-bottom {
+            bottom: 15%;
+            left: -50%;
+            transform: rotate(3deg);
+            animation: tape-scroll 25s linear infinite reverse;
+        }
+
+        @keyframes tape-scroll {
+            from { transform: translateX(0) rotate(-5deg); }
+            to { transform: translateX(50%) rotate(-5deg); }
+        }
+
+        /* 자물쇠 흔들기 */
+        .lock-shake {
+            animation: shake 0.5s ease-in-out infinite;
+        }
+
+        @keyframes shake {
+            0%, 100% { transform: rotate(0deg); }
+            25% { transform: rotate(-5deg); }
+            75% { transform: rotate(5deg); }
+        }
+
+        /* 방패 효과 */
+        .shield-pulse {
+            animation: pulse-ring 2s ease-out infinite;
+        }
+
+        @keyframes pulse-ring {
+            0% { box-shadow: 0 0 0 0 rgba(251, 191, 36, 0.4); }
+            70% { box-shadow: 0 0 0 20px rgba(251, 191, 36, 0); }
+            100% { box-shadow: 0 0 0 0 rgba(251, 191, 36, 0); }
+        }
+
+        .btn-primary {
+            background: linear-gradient(135deg, #f59e0b 0%, #d97706 100%);
+            box-shadow: 0 4px 15px rgba(245, 158, 11, 0.4);
+            transition: all 0.3s ease;
+        }
+
+        .btn-primary:hover {
+            transform: translateY(-2px);
+            box-shadow: 0 6px 25px rgba(245, 158, 11, 0.5);
+        }
+
+        .btn-secondary {
+            background: white;
+            border: 2px solid #fcd34d;
+            transition: all 0.3s ease;
+        }
+
+        .btn-secondary:hover {
+            border-color: #f59e0b;
+            background: #fffbeb;
+        }
+    </style>
+</head>
+<body class="flex items-center justify-center p-4">
+    <!-- 경고 테이프 -->
+    <div class="warning-tape tape-top"></div>
+    <div class="warning-tape tape-bottom"></div>
+
+    <div class="text-center z-10 max-w-lg mx-auto">
+        <!-- 로고 -->
+        <a href="${pageContext.request.contextPath}/" class="inline-block mb-8">
+            <img src="${pageContext.request.contextPath}/resources/common/img/logo.svg"
+                 alt="Flyway" class="h-10 mx-auto">
+        </a>
+
+        <!-- 일러스트 -->
+        <div class="relative mb-8">
+            <!-- 방패 + 자물쇠 -->
+            <div class="w-32 h-32 mx-auto bg-gradient-to-br from-amber-400 to-amber-500 rounded-full
+                        flex items-center justify-center shield-pulse">
+                <svg class="w-16 h-16 text-white lock-shake" fill="currentColor" viewBox="0 0 24 24">
+                    <path d="M12 1L3 5v6c0 5.55 3.84 10.74 9 12 5.16-1.26 9-6.45 9-12V5l-9-4zm0 10.99h7c-.53 4.12-3.28 7.79-7 8.94V12H5V6.3l7-3.11v8.8z"/>
+                    <path d="M11 7h2v2h-2zm0 4h2v4h-2z"/>
+                </svg>
+            </div>
+
+            <!-- 경고 아이콘 -->
+            <div class="absolute -top-1 -right-1 w-10 h-10 bg-red-500 rounded-full flex items-center justify-center
+                        border-4 border-white shadow-lg">
+                <svg class="w-5 h-5 text-white" fill="currentColor" viewBox="0 0 20 20">
+                    <path fill-rule="evenodd" d="M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z" clip-rule="evenodd"/>
+                </svg>
+            </div>
+        </div>
+
+        <!-- 에러 코드 -->
+        <div class="mb-4">
+            <span class="text-8xl font-black text-transparent bg-clip-text bg-gradient-to-r from-amber-500 to-orange-500">
+                403
+            </span>
+        </div>
+
+        <!-- 메시지 -->
+        <h1 class="text-2xl font-bold text-gray-800 mb-3">
+            탑승이 거부되었습니다
+        </h1>
+        <p class="text-gray-500 mb-8 leading-relaxed">
+            이 페이지에 접근할 권한이 없습니다.<br>
+            로그인이 필요하거나 접근이 제한된 구역입니다.
+        </p>
+
+        <!-- 버튼 -->
+        <div class="flex flex-col sm:flex-row gap-3 justify-center">
+            <a href="${pageContext.request.contextPath}/login"
+               class="btn-primary px-8 py-3 rounded-full text-white font-semibold inline-flex items-center justify-center gap-2">
+                <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                          d="M11 16l-4-4m0 0l4-4m-4 4h14m-5 4v1a3 3 0 01-3 3H6a3 3 0 01-3-3V7a3 3 0 013-3h7a3 3 0 013 3v1"/>
+                </svg>
+                로그인하기
+            </a>
+            <a href="${pageContext.request.contextPath}/"
+               class="btn-secondary px-8 py-3 rounded-full text-gray-600 font-semibold inline-flex items-center justify-center gap-2">
+                <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                          d="M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-6 0a1 1 0 001-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 001 1m-6 0h6"/>
+                </svg>
+                홈으로 가기
+            </a>
+        </div>
+    </div>
+</body>
+</html>

--- a/src/main/webapp/WEB-INF/views/error/404.jsp
+++ b/src/main/webapp/WEB-INF/views/error/404.jsp
@@ -1,0 +1,194 @@
+<%@ page contentType="text/html; charset=UTF-8" pageEncoding="UTF-8" isErrorPage="true" %>
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>페이지를 찾을 수 없습니다 - Flyway</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Pretendard:wght@400;500;600;700;800;900&display=swap" rel="stylesheet">
+    <style>
+        * {
+            font-family: 'Pretendard', -apple-system, BlinkMacSystemFont, system-ui, sans-serif;
+        }
+
+        body {
+            background: linear-gradient(135deg, #dbeafe 0%, #eff6ff 50%, #f0f9ff 100%);
+            min-height: 100vh;
+            overflow: hidden;
+        }
+
+        /* 구름 애니메이션 */
+        .cloud {
+            position: absolute;
+            background: white;
+            border-radius: 100px;
+            opacity: 0.8;
+            animation: float-cloud 20s linear infinite;
+        }
+
+        .cloud::before, .cloud::after {
+            content: '';
+            position: absolute;
+            background: white;
+            border-radius: 50%;
+        }
+
+        .cloud-1 {
+            width: 120px;
+            height: 40px;
+            top: 15%;
+            left: -150px;
+            animation-duration: 25s;
+        }
+        .cloud-1::before { width: 50px; height: 50px; top: -25px; left: 15px; }
+        .cloud-1::after { width: 70px; height: 70px; top: -35px; left: 45px; }
+
+        .cloud-2 {
+            width: 100px;
+            height: 35px;
+            top: 30%;
+            left: -120px;
+            animation-duration: 30s;
+            animation-delay: 5s;
+        }
+        .cloud-2::before { width: 45px; height: 45px; top: -22px; left: 12px; }
+        .cloud-2::after { width: 60px; height: 60px; top: -30px; left: 38px; }
+
+        .cloud-3 {
+            width: 80px;
+            height: 30px;
+            top: 60%;
+            left: -100px;
+            animation-duration: 22s;
+            animation-delay: 10s;
+        }
+        .cloud-3::before { width: 35px; height: 35px; top: -18px; left: 10px; }
+        .cloud-3::after { width: 50px; height: 50px; top: -25px; left: 30px; }
+
+        @keyframes float-cloud {
+            from { transform: translateX(0); }
+            to { transform: translateX(calc(100vw + 200px)); }
+        }
+
+        /* 비행기 애니메이션 - 길 잃은 느낌 */
+        .plane-lost {
+            animation: plane-wander 8s ease-in-out infinite;
+        }
+
+        @keyframes plane-wander {
+            0% { transform: translate(0, 0) rotate(-15deg); }
+            25% { transform: translate(20px, -30px) rotate(5deg); }
+            50% { transform: translate(-10px, 10px) rotate(-25deg); }
+            75% { transform: translate(30px, 20px) rotate(10deg); }
+            100% { transform: translate(0, 0) rotate(-15deg); }
+        }
+
+        /* 물음표 떠다니기 */
+        .question-float {
+            animation: question-bounce 2s ease-in-out infinite;
+        }
+
+        @keyframes question-bounce {
+            0%, 100% { transform: translateY(0); }
+            50% { transform: translateY(-10px); }
+        }
+
+        /* 버튼 호버 효과 */
+        .btn-primary {
+            background: linear-gradient(135deg, #3b82f6 0%, #2563eb 100%);
+            box-shadow: 0 4px 15px rgba(59, 130, 246, 0.4);
+            transition: all 0.3s ease;
+        }
+
+        .btn-primary:hover {
+            transform: translateY(-2px);
+            box-shadow: 0 6px 25px rgba(59, 130, 246, 0.5);
+        }
+
+        .btn-secondary {
+            background: white;
+            border: 2px solid #e2e8f0;
+            transition: all 0.3s ease;
+        }
+
+        .btn-secondary:hover {
+            border-color: #3b82f6;
+            background: #f0f9ff;
+        }
+    </style>
+</head>
+<body class="flex items-center justify-center p-4">
+    <!-- 구름들 -->
+    <div class="cloud cloud-1"></div>
+    <div class="cloud cloud-2"></div>
+    <div class="cloud cloud-3"></div>
+
+    <div class="text-center z-10 max-w-lg mx-auto">
+        <!-- 로고 -->
+        <a href="${pageContext.request.contextPath}/" class="inline-block mb-8">
+            <img src="${pageContext.request.contextPath}/resources/common/img/logo.svg"
+                 alt="Flyway" class="h-10 mx-auto">
+        </a>
+
+        <!-- 일러스트 -->
+        <div class="relative mb-8">
+            <!-- 비행기 SVG -->
+            <svg class="plane-lost w-32 h-32 mx-auto text-blue-500" viewBox="0 0 100 100" fill="none" xmlns="http://www.w3.org/2000/svg">
+                <path d="M85 45L55 35L50 10L45 35L15 45L45 50L40 90L50 70L60 90L55 50L85 45Z"
+                      fill="currentColor" opacity="0.9"/>
+                <circle cx="50" cy="42" r="3" fill="white"/>
+            </svg>
+
+            <!-- 물음표들 -->
+            <div class="absolute -top-2 -right-4 question-float" style="animation-delay: 0s;">
+                <span class="text-3xl font-bold text-blue-400">?</span>
+            </div>
+            <div class="absolute top-8 -left-2 question-float" style="animation-delay: 0.5s;">
+                <span class="text-2xl font-bold text-blue-300">?</span>
+            </div>
+            <div class="absolute -bottom-2 right-4 question-float" style="animation-delay: 1s;">
+                <span class="text-xl font-bold text-blue-200">?</span>
+            </div>
+        </div>
+
+        <!-- 에러 코드 -->
+        <div class="mb-4">
+            <span class="text-8xl font-black text-transparent bg-clip-text bg-gradient-to-r from-blue-500 to-blue-600">
+                404
+            </span>
+        </div>
+
+        <!-- 메시지 -->
+        <h1 class="text-2xl font-bold text-gray-800 mb-3">
+            목적지를 찾을 수 없어요
+        </h1>
+        <p class="text-gray-500 mb-8 leading-relaxed">
+            요청하신 페이지가 이동했거나 존재하지 않습니다.<br>
+            주소를 다시 확인해 주세요.
+        </p>
+
+        <!-- 버튼 -->
+        <div class="flex flex-col sm:flex-row gap-3 justify-center">
+            <a href="${pageContext.request.contextPath}/"
+               class="btn-primary px-8 py-3 rounded-full text-white font-semibold inline-flex items-center justify-center gap-2">
+                <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                          d="M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-6 0a1 1 0 001-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 001 1m-6 0h6"/>
+                </svg>
+                홈으로 돌아가기
+            </a>
+            <button onclick="history.back()"
+                    class="btn-secondary px-8 py-3 rounded-full text-gray-600 font-semibold inline-flex items-center justify-center gap-2">
+                <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                          d="M10 19l-7-7m0 0l7-7m-7 7h18"/>
+                </svg>
+                이전 페이지
+            </button>
+        </div>
+    </div>
+</body>
+</html>

--- a/src/main/webapp/WEB-INF/views/error/500.jsp
+++ b/src/main/webapp/WEB-INF/views/error/500.jsp
@@ -1,0 +1,200 @@
+<%@ page contentType="text/html; charset=UTF-8" pageEncoding="UTF-8" isErrorPage="true" %>
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>서버 오류가 발생했습니다 - Flyway</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Pretendard:wght@400;500;600;700;800;900&display=swap" rel="stylesheet">
+    <style>
+        * {
+            font-family: 'Pretendard', -apple-system, BlinkMacSystemFont, system-ui, sans-serif;
+        }
+
+        body {
+            background: linear-gradient(135deg, #fee2e2 0%, #fef2f2 50%, #fff5f5 100%);
+            min-height: 100vh;
+            overflow: hidden;
+        }
+
+        /* 연기 애니메이션 */
+        .smoke {
+            position: absolute;
+            width: 20px;
+            height: 20px;
+            background: rgba(156, 163, 175, 0.6);
+            border-radius: 50%;
+            animation: smoke-rise 3s ease-out infinite;
+        }
+
+        .smoke-1 { left: 45%; animation-delay: 0s; }
+        .smoke-2 { left: 48%; animation-delay: 0.5s; }
+        .smoke-3 { left: 51%; animation-delay: 1s; }
+        .smoke-4 { left: 54%; animation-delay: 1.5s; }
+
+        @keyframes smoke-rise {
+            0% {
+                opacity: 0.8;
+                transform: translateY(0) scale(1);
+            }
+            100% {
+                opacity: 0;
+                transform: translateY(-100px) scale(2);
+            }
+        }
+
+        /* 비행기 추락 효과 */
+        .plane-crash {
+            animation: plane-fall 4s ease-in-out infinite;
+        }
+
+        @keyframes plane-fall {
+            0% { transform: rotate(0deg) translateY(0); }
+            25% { transform: rotate(15deg) translateY(5px); }
+            50% { transform: rotate(-10deg) translateY(-5px); }
+            75% { transform: rotate(20deg) translateY(10px); }
+            100% { transform: rotate(0deg) translateY(0); }
+        }
+
+        /* 경고등 깜빡임 */
+        .warning-blink {
+            animation: blink-warning 1s ease-in-out infinite;
+        }
+
+        @keyframes blink-warning {
+            0%, 100% { opacity: 1; }
+            50% { opacity: 0.3; }
+        }
+
+        /* 기어 회전 */
+        .gear-spin {
+            animation: gear-rotate 4s linear infinite;
+        }
+
+        .gear-spin-reverse {
+            animation: gear-rotate 4s linear infinite reverse;
+        }
+
+        @keyframes gear-rotate {
+            from { transform: rotate(0deg); }
+            to { transform: rotate(360deg); }
+        }
+
+        .btn-primary {
+            background: linear-gradient(135deg, #ef4444 0%, #dc2626 100%);
+            box-shadow: 0 4px 15px rgba(239, 68, 68, 0.4);
+            transition: all 0.3s ease;
+        }
+
+        .btn-primary:hover {
+            transform: translateY(-2px);
+            box-shadow: 0 6px 25px rgba(239, 68, 68, 0.5);
+        }
+
+        .btn-secondary {
+            background: white;
+            border: 2px solid #fca5a5;
+            transition: all 0.3s ease;
+        }
+
+        .btn-secondary:hover {
+            border-color: #ef4444;
+            background: #fef2f2;
+        }
+    </style>
+</head>
+<body class="flex items-center justify-center p-4">
+    <!-- 연기 효과 -->
+    <div class="smoke smoke-1"></div>
+    <div class="smoke smoke-2"></div>
+    <div class="smoke smoke-3"></div>
+    <div class="smoke smoke-4"></div>
+
+    <div class="text-center z-10 max-w-lg mx-auto">
+        <!-- 로고 -->
+        <a href="${pageContext.request.contextPath}/" class="inline-block mb-8">
+            <img src="${pageContext.request.contextPath}/resources/common/img/logo.svg"
+                 alt="Flyway" class="h-10 mx-auto">
+        </a>
+
+        <!-- 일러스트 -->
+        <div class="relative mb-8">
+            <!-- 고장난 비행기 -->
+            <div class="relative inline-block">
+                <svg class="plane-crash w-28 h-28 text-red-500" viewBox="0 0 100 100" fill="none" xmlns="http://www.w3.org/2000/svg">
+                    <path d="M85 45L55 35L50 10L45 35L15 45L45 50L40 90L50 70L60 90L55 50L85 45Z"
+                          fill="currentColor" opacity="0.9"/>
+                    <circle cx="50" cy="42" r="3" fill="white"/>
+                </svg>
+
+                <!-- 기어 아이콘들 -->
+                <div class="absolute -bottom-2 -left-4">
+                    <svg class="gear-spin w-8 h-8 text-gray-400" fill="currentColor" viewBox="0 0 20 20">
+                        <path fill-rule="evenodd" d="M11.49 3.17c-.38-1.56-2.6-1.56-2.98 0a1.532 1.532 0 01-2.286.948c-1.372-.836-2.942.734-2.106 2.106.54.886.061 2.042-.947 2.287-1.561.379-1.561 2.6 0 2.978a1.532 1.532 0 01.947 2.287c-.836 1.372.734 2.942 2.106 2.106a1.532 1.532 0 012.287.947c.379 1.561 2.6 1.561 2.978 0a1.533 1.533 0 012.287-.947c1.372.836 2.942-.734 2.106-2.106a1.533 1.533 0 01.947-2.287c1.561-.379 1.561-2.6 0-2.978a1.532 1.532 0 01-.947-2.287c.836-1.372-.734-2.942-2.106-2.106a1.532 1.532 0 01-2.287-.947zM10 13a3 3 0 100-6 3 3 0 000 6z" clip-rule="evenodd"/>
+                    </svg>
+                </div>
+                <div class="absolute -top-2 -right-4">
+                    <svg class="gear-spin-reverse w-6 h-6 text-gray-300" fill="currentColor" viewBox="0 0 20 20">
+                        <path fill-rule="evenodd" d="M11.49 3.17c-.38-1.56-2.6-1.56-2.98 0a1.532 1.532 0 01-2.286.948c-1.372-.836-2.942.734-2.106 2.106.54.886.061 2.042-.947 2.287-1.561.379-1.561 2.6 0 2.978a1.532 1.532 0 01.947 2.287c-.836 1.372.734 2.942 2.106 2.106a1.532 1.532 0 012.287.947c.379 1.561 2.6 1.561 2.978 0a1.533 1.533 0 012.287-.947c1.372.836 2.942-.734 2.106-2.106a1.533 1.533 0 01.947-2.287c1.561-.379 1.561-2.6 0-2.978a1.532 1.532 0 01-.947-2.287c.836-1.372-.734-2.942-2.106-2.106a1.532 1.532 0 01-2.287-.947zM10 13a3 3 0 100-6 3 3 0 000 6z" clip-rule="evenodd"/>
+                    </svg>
+                </div>
+            </div>
+
+            <!-- 경고 아이콘 -->
+            <div class="absolute -top-2 left-1/2 transform -translate-x-1/2 -translate-y-full">
+                <div class="warning-blink w-12 h-12 bg-red-500 rounded-full flex items-center justify-center shadow-lg">
+                    <svg class="w-7 h-7 text-white" fill="currentColor" viewBox="0 0 20 20">
+                        <path fill-rule="evenodd" d="M8.257 3.099c.765-1.36 2.722-1.36 3.486 0l5.58 9.92c.75 1.334-.213 2.98-1.742 2.98H4.42c-1.53 0-2.493-1.646-1.743-2.98l5.58-9.92zM11 13a1 1 0 11-2 0 1 1 0 012 0zm-1-8a1 1 0 00-1 1v3a1 1 0 002 0V6a1 1 0 00-1-1z" clip-rule="evenodd"/>
+                    </svg>
+                </div>
+            </div>
+        </div>
+
+        <!-- 에러 코드 -->
+        <div class="mb-4">
+            <span class="text-8xl font-black text-transparent bg-clip-text bg-gradient-to-r from-red-500 to-red-600">
+                500
+            </span>
+        </div>
+
+        <!-- 메시지 -->
+        <h1 class="text-2xl font-bold text-gray-800 mb-3">
+            기술적 결함이 발생했습니다
+        </h1>
+        <p class="text-gray-500 mb-8 leading-relaxed">
+            서버에 문제가 발생하여 요청을 처리할 수 없습니다.<br>
+            잠시 후 다시 시도해 주세요.
+        </p>
+
+        <!-- 버튼 -->
+        <div class="flex flex-col sm:flex-row gap-3 justify-center">
+            <button onclick="location.reload()"
+                    class="btn-primary px-8 py-3 rounded-full text-white font-semibold inline-flex items-center justify-center gap-2">
+                <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                          d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"/>
+                </svg>
+                다시 시도
+            </button>
+            <a href="${pageContext.request.contextPath}/"
+               class="btn-secondary px-8 py-3 rounded-full text-gray-600 font-semibold inline-flex items-center justify-center gap-2">
+                <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                          d="M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-6 0a1 1 0 001-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 001 1m-6 0h6"/>
+                </svg>
+                홈으로 가기
+            </a>
+        </div>
+
+        <!-- 추가 도움 -->
+        <p class="mt-8 text-sm text-gray-400">
+            문제가 계속되면
+            <a href="mailto:support@flyway.io" class="text-red-500 hover:underline">support@flyway.io</a>
+            로 문의해 주세요.
+        </p>
+    </div>
+</body>
+</html>

--- a/src/main/webapp/WEB-INF/views/home.jsp
+++ b/src/main/webapp/WEB-INF/views/home.jsp
@@ -24,7 +24,7 @@
     <!-- 비디오 컨테이너 (overflow: hidden) -->
     <div class="hero-video-container">
         <video autoplay loop muted playsinline class="hero-video">
-            <source src="https://assets.mixkit.co/videos/preview/mixkit-flying-over-the-clouds-at-sunset-24422-large.mp4" type="video/mp4" />
+            <source src="https://flyway-static-files.s3.ap-northeast-2.amazonaws.com/857251-hd_1620_1080_25fps.mp4" type="video/mp4" />
         </video>
         <div class="hero-overlay"></div>
     </div>

--- a/src/main/webapp/WEB-INF/web.xml
+++ b/src/main/webapp/WEB-INF/web.xml
@@ -64,15 +64,19 @@
 
     <!-- Error Pages -->
     <error-page>
+        <error-code>400</error-code>
+        <location>/error</location>
+    </error-page>
+    <error-page>
         <error-code>403</error-code>
-        <location>/WEB-INF/views/error/403.jsp</location>
+        <location>/error</location>
     </error-page>
     <error-page>
         <error-code>404</error-code>
-        <location>/WEB-INF/views/error/404.jsp</location>
+        <location>/error</location>
     </error-page>
     <error-page>
         <error-code>500</error-code>
-        <location>/WEB-INF/views/error/500.jsp</location>
+        <location>/error</location>
     </error-page>
 </web-app>

--- a/src/main/webapp/WEB-INF/web.xml
+++ b/src/main/webapp/WEB-INF/web.xml
@@ -61,4 +61,18 @@
         <filter-name>springSecurityFilterChain</filter-name>
         <url-pattern>/*</url-pattern>
     </filter-mapping>
+
+    <!-- Error Pages -->
+    <error-page>
+        <error-code>403</error-code>
+        <location>/WEB-INF/views/error/403.jsp</location>
+    </error-page>
+    <error-page>
+        <error-code>404</error-code>
+        <location>/WEB-INF/views/error/404.jsp</location>
+    </error-page>
+    <error-page>
+        <error-code>500</error-code>
+        <location>/WEB-INF/views/error/500.jsp</location>
+    </error-page>
 </web-app>


### PR DESCRIPTION
## 📌 PR 설명
403, 404, 500 에러페이지 구현

  Flyway 브랜드 아이덴티티에 맞는 커스텀 에러 페이지를 추가했습니다.
  - 항공 테마 일러스트 및 애니메이션
  - 각 에러 상황에 맞는 메시지와 색상
  - 운영 환경 대비 에러 로깅 기능
<br>

## ✅ 완료한 기능 명세

- [x] 403, 404, 500 에러 페이지 구현


<br>

## 📸 스크린샷
### 404
<img width="501" height="450" alt="스크린샷 2026-02-02 오후 5 35 24" src="https://github.com/user-attachments/assets/bd17e302-f091-4c49-86ab-b0d2dd69ce73" />

### 403
<img width="487" height="450" alt="스크린샷 2026-02-02 오후 5 43 04" src="https://github.com/user-attachments/assets/e4a2e6cf-92de-4b74-82b4-9869301a0ed5" />

### 500
<img width="464" height="450" alt="스크린샷 2026-02-02 오후 5 43 13" src="https://github.com/user-attachments/assets/2ceead65-3e63-43d9-b3a6-50097570898e" />



<br>

## 💭 고민과 해결과정
1. 에러 페이지 처리 방식 선택

  - 방법 1: web.xml에 JSP 직접 등록 (단순)
  - 방법 2: ErrorController를 통한 처리 (확장성)
  - 결정: 운영 환경에서 에러 로깅이 필요하므로 ErrorController 방식 채택


### 🔗 관련 이슈
Closes #230 

<br>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added custom animated error pages for 400/403/404/500 with Korean-language messaging and contextual actions (login, home, back, reload).
  * Centralized error routing to present the themed error views consistently.
* **Chores**
  * Updated home page background video source to a new hosted asset.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->