### PR TITLE
[FLYW-192] 좌석 미선택 오류 수정 

### DIFF
--- a/src/main/webapp/WEB-INF/views/reservations/booking.jsp
+++ b/src/main/webapp/WEB-INF/views/reservations/booking.jsp
@@ -796,39 +796,66 @@
     }
 
     // 결제 페이지 이동
-    function goPayment() {
+    async function goPayment() {
         if (!passengerSaved) {
             Swal.warning('탑승자 정보를 먼저 저장해주세요.', '정보 미입력');
             return;
         }
 
-        // 좌석 선택 여부 체크
-        const incompleteSegment = segments.find(seg => seg.seatCount < passengerCount);
+        try {
+            // 서버에서 최신 좌석 선택 정보 조회
+            const res = await fetchWithRefresh('/reservations/' + reservationId + '/seats/info');
+            const data = await res.json();
 
-        if (incompleteSegment) {
-            const segmentLabel = incompleteSegment.segmentOrder === 1 ? '가는편' : '오는편';
-            const routeText = incompleteSegment.depCity + ' → ' + incompleteSegment.arrCity;
+            if (!data.success) {
+                Swal.error(data.message || '좌석 정보를 불러오지 못했습니다.', '오류');
+                return;
+            }
 
-            Swal.fire({
-                icon: 'warning',
-                title: '좌석 미선택',
-                html: '<b>' + segmentLabel + '</b> (' + routeText + ')<br>모든 승객의 좌석을 선택해주세요.',
-                confirmButtonText: '좌석 선택하기',
-                confirmButtonColor: '#1f6feb',
-                showCancelButton: true,
-                cancelButtonText: '취소',
-                cancelButtonColor: '#64748b'
-            }).then((result) => {
-                if (result.isConfirmed) {
-                    openSeatPopup(incompleteSegment.segmentId);
-                }
-            });
-            return;
+            // 최신 seatCount 기준으로 검증
+            const latestSegments = data.segments || [];
+            const incomplete = latestSegments.find(seg => (seg.passengerSeats?.length || 0) < passengerCount);
+
+            if (incomplete) {
+                const segmentLabel = incomplete.segmentOrder === 1 ? '가는편' : '오는편';
+                const routeText = (incomplete.depCity && incomplete.arrCity)
+                    ? (incomplete.depCity + ' → ' + incomplete.arrCity)
+                    : '';
+
+                Swal.fire({
+                    icon: 'warning',
+                    title: '좌석 미선택',
+                    html: '<b>' + segmentLabel + '</b>' + (routeText ? ' (' + routeText + ')' : '') +
+                        '<br>모든 승객의 좌석을 선택해주세요.',
+                    confirmButtonText: '좌석 선택하기',
+                    confirmButtonColor: '#1f6feb',
+                    showCancelButton: true,
+                    cancelButtonText: '취소',
+                    cancelButtonColor: '#64748b'
+                }).then((result) => {
+                    if (result.isConfirmed) {
+                        // API가 seg.segmentId를 내려주면 그걸 사용, 없으면 booking.jsp의 segments에서 매핑
+                        const segId = incomplete.segmentId || incomplete.reservationSegmentId;
+                        if (segId) openSeatPopup(segId);
+                        else {
+                            // fallback: booking.jsp의 segments 배열에서 segmentOrder로 찾아서 오픈
+                            const localSeg = segments.find(s => s.segmentOrder === incomplete.segmentOrder);
+                            if (localSeg) openSeatPopup(localSeg.segmentId);
+                        }
+                    }
+                });
+                return;
+            }
+
+            // 좌석 선택 OK → 결제 페이지로 이동
+            location.href = '/payments/' + reservationId;
+
+        } catch (err) {
+            console.error('goPayment seat check failed', err);
+            Swal.error('좌석 검증 중 오류가 발생했습니다.', '오류');
         }
-
-        // 결제 페이지로 이동 (PaymentController)
-        location.href = '/payments/' + reservationId;
     }
+
 
     function getLocalISODate() {
         const now = new Date();

--- a/src/main/webapp/WEB-INF/views/reservations/booking.jsp
+++ b/src/main/webapp/WEB-INF/views/reservations/booking.jsp
@@ -822,11 +822,11 @@
                     ? (incomplete.depCity + ' → ' + incomplete.arrCity)
                     : '';
 
+                const detail = segmentLabel + (routeText ? ' (' + routeText + ')' : '');
                 Swal.fire({
                     icon: 'warning',
                     title: '좌석 미선택',
-                    html: '<b>' + segmentLabel + '</b>' + (routeText ? ' (' + routeText + ')' : '') +
-                        '<br>모든 승객의 좌석을 선택해주세요.',
+                    text: detail + '\n 모든 승객의 좌석을 선택해주세요.',
                     confirmButtonText: '좌석 선택하기',
                     confirmButtonColor: '#1f6feb',
                     showCancelButton: true,
@@ -1282,6 +1282,7 @@
                 const minExpiry = new Date();
                 minExpiry.setMonth(minExpiry.getMonth() + 6);
                 if (new Date(passportExpiry) < minExpiry) {
+
                     const confirmResult = await Swal.fire({
                         icon: 'warning',
                         title: '여권 만료일 확인',

--- a/src/main/webapp/resources/seat/css/base.css
+++ b/src/main/webapp/resources/seat/css/base.css
@@ -16,7 +16,7 @@
 
     /* 좌석 상태 */
     --color-seat-available: #3b82f6;              /* 선택 가능 - 밝은 파랑 */
-    --color-seat-selected: #1d4ed8;               /* 선택됨 - 진한 파랑 */
+    --color-seat-selected: #f59e0b;               /* 선택됨 - 주황 */
     --color-seat-unavailable: #cbd5e1;            /* 불가 좌석(회색) */
     --color-seat-hold: #f59e0b;                   /* 예약 대기 - 주황 */
 

--- a/src/main/webapp/resources/seat/css/component.css
+++ b/src/main/webapp/resources/seat/css/component.css
@@ -296,8 +296,8 @@
 }
 
 .seat-legend__icon--selected {
-    background: linear-gradient(180deg, #1d4ed8 0%, #1e40af 100%);
-    border: 2px solid #1e3a8a;
+    background: linear-gradient(180deg, #fbbf24 0%, #f59e0b 100%);
+    border: 2px solid #d97706;
 }
 
 .seat-legend__icon--unavailable {

--- a/src/main/webapp/resources/seat/css/seatgrid.css
+++ b/src/main/webapp/resources/seat/css/seatgrid.css
@@ -146,9 +146,9 @@
 }
 
 .seat-item--selected {
-    background: linear-gradient(180deg, #1d4ed8 0%, #1e40af 100%);
+    background: linear-gradient(180deg, #fbbf24 0%, #f59e0b 100%);
     color: #ffffff;
-    border: 2px solid #1e3a8a;
+    border: 2px solid #d97706;
     box-shadow: 0 4px 12px rgba(29, 78, 216, 0.4), inset 0 1px 0 rgba(255, 255, 255, 0.2);
 }
 

--- a/src/main/webapp/resources/seat/js/seat-events.js
+++ b/src/main/webapp/resources/seat/js/seat-events.js
@@ -115,17 +115,56 @@ window.SeatEvents = (() => {
                         }
                         updateSummaryUI();
 
-                        // 서버 해제
+                        // api 호출
+                        let releasedPrevOnServer = false;
+
                         try {
-                            await SeatAPI.releaseHold(ctx.base, ctx.reservationId, segId, pid);
+                            // 중복 HOLD 방지 기존 HOLD가 있으면 먼저 해제
+                            try {
+                                await SeatAPI.releaseHold(ctx.base, ctx.reservationId, segId, pid);
+                                releasedPrevOnServer = true;
+                            } catch (_) {
+                                // 기존 HOLD가 없으면 무시
+                            }
+
+                            // 새 좌석 HOLD
+                            await SeatAPI.holdSeat(ctx.base, ctx.reservationId, segId, {
+                                passengerId: pid,
+                                seatNo,
+                            });
+
+                            // 성공하면 서버가 source of truth니까 한 번 싱크
+                            await renderer.refreshAndRender().catch(() => {});
                         } catch (err) {
-                            // 실패 시 롤백
-                            if (!state.selectedSeatsBySegment[segId]) state.selectedSeatsBySegment[segId] = {};
-                            state.selectedSeatsBySegment[segId][pid] = seatNo;
-                            SeatGrid.updateSeatUI(dom.seatGridEl, seatNo, "HOLD");
+                            // UI/로컬 롤백
+                            SeatGrid.updateSeatUI(dom.seatGridEl, seatNo, "AVAILABLE");
+
+                            if (currentSeatNo) {
+                                state.selectedSeatsBySegment[segId][pid] = currentSeatNo;
+                                SeatGrid.updateSeatUI(dom.seatGridEl, currentSeatNo, "HOLD");
+                            } else {
+                                delete state.selectedSeatsBySegment[segId][pid];
+                            }
                             updateSummaryUI();
-                            Swal.error("좌석 해제에 실패했습니다.", "오류");
+
+                            // releaseHold가 서버에서 성공했을 수도 있으니 이전 좌석을 서버에도 복구 시도
+                            if (currentSeatNo && releasedPrevOnServer) {
+                                try {
+                                    await SeatAPI.holdSeat(ctx.base, ctx.reservationId, segId, {
+                                        passengerId: pid,
+                                        seatNo: currentSeatNo,
+                                    });
+                                } catch (_) {
+                                    // 복구 실패하면 서버 기준 재동기화
+                                }
+                            }
+
+                            // 서버 기준 재동기화 (상태 불일치 방지)
+                            await renderer.refreshAndRender().catch(() => {});
+
+                            Swal.error("좌석 선택에 실패했습니다. 다시 시도해주세요.", "오류");
                         }
+
                         return;
                     }
 

--- a/src/main/webapp/resources/seat/js/seat-events.js
+++ b/src/main/webapp/resources/seat/js/seat-events.js
@@ -109,60 +109,31 @@ window.SeatEvents = (() => {
                     // 같은 좌석 재클릭 → 해제
                     if (currentSeatNo === seatNo) {
                         // 즉시 UI 업데이트
+                        // 즉시 UI 업데이트
                         SeatGrid.updateSeatUI(dom.seatGridEl, seatNo, "AVAILABLE");
                         if (state.selectedSeatsBySegment[segId]) {
                             delete state.selectedSeatsBySegment[segId][pid];
                         }
                         updateSummaryUI();
 
-                        // api 호출
-                        let releasedPrevOnServer = false;
-
                         try {
-                            // 중복 HOLD 방지 기존 HOLD가 있으면 먼저 해제
-                            try {
-                                await SeatAPI.releaseHold(ctx.base, ctx.reservationId, segId, pid);
-                                releasedPrevOnServer = true;
-                            } catch (_) {
-                                // 기존 HOLD가 없으면 무시
-                            }
+                            // 해제만 수행
+                            await SeatAPI.releaseHold(ctx.base, ctx.reservationId, segId, pid);
 
-                            // 새 좌석 HOLD
-                            await SeatAPI.holdSeat(ctx.base, ctx.reservationId, segId, {
-                                passengerId: pid,
-                                seatNo,
-                            });
-
-                            // 성공하면 서버가 source of truth니까 한 번 싱크
+                            // 서버 기준 동기화
                             await renderer.refreshAndRender().catch(() => {});
                         } catch (err) {
-                            // UI/로컬 롤백
-                            SeatGrid.updateSeatUI(dom.seatGridEl, seatNo, "AVAILABLE");
+                            // 실패 시 UI/로컬 롤백
+                            state.selectedSeatsBySegment[segId] = state.selectedSeatsBySegment[segId] || {};
+                            state.selectedSeatsBySegment[segId][pid] = seatNo;
 
-                            if (currentSeatNo) {
-                                state.selectedSeatsBySegment[segId][pid] = currentSeatNo;
-                                SeatGrid.updateSeatUI(dom.seatGridEl, currentSeatNo, "HOLD");
-                            } else {
-                                delete state.selectedSeatsBySegment[segId][pid];
-                            }
+                            SeatGrid.updateSeatUI(dom.seatGridEl, seatNo, "HOLD");
                             updateSummaryUI();
 
-                            // releaseHold가 서버에서 성공했을 수도 있으니 이전 좌석을 서버에도 복구 시도
-                            if (currentSeatNo && releasedPrevOnServer) {
-                                try {
-                                    await SeatAPI.holdSeat(ctx.base, ctx.reservationId, segId, {
-                                        passengerId: pid,
-                                        seatNo: currentSeatNo,
-                                    });
-                                } catch (_) {
-                                    // 복구 실패하면 서버 기준 재동기화
-                                }
-                            }
-
-                            // 서버 기준 재동기화 (상태 불일치 방지)
+                            // 상태 불일치 방지 동기화
                             await renderer.refreshAndRender().catch(() => {});
 
-                            Swal.error("좌석 선택에 실패했습니다. 다시 시도해주세요.", "오류");
+                            Swal.error("좌석 해제에 실패했습니다. 다시 시도해주세요.", "오류");
                         }
 
                         return;
@@ -181,7 +152,7 @@ window.SeatEvents = (() => {
                     state.selectedSeatsBySegment[segId][pid] = seatNo;
                     updateSummaryUI();
 
-                    // api 호출: releaseHold를 무조건 시도 → 중복 HOLD 방지
+                    // releaseHold를 무조건 시도 → 중복 HOLD 방지
                     try {
                         try {
                             await SeatAPI.releaseHold(ctx.base, ctx.reservationId, segId, pid);
@@ -290,6 +261,5 @@ window.SeatEvents = (() => {
             });
         }
     }
-
     return { bind };
 })();

--- a/src/main/webapp/resources/seat/js/seat-events.js
+++ b/src/main/webapp/resources/seat/js/seat-events.js
@@ -74,13 +74,20 @@ window.SeatEvents = (() => {
         function bindSeatGridClick() {
             dom.seatGridEl.addEventListener("click", async (e) => {
                 const btn = e.target.closest("button.seat-item");
-                if (!btn || state.isHolding) return;
+                if (!btn) return;
 
                 const seatNo = btn.dataset.seatNo;
                 if (!seatNo) return;
 
+                // 처리중이면 클릭 무시(연타/더블클릭 방지)
+                if (state.isHolding) {
+                    Swal?.info?.("좌석 처리 중입니다. 잠시만 기다려주세요.", "처리 중");
+                    return;
+                }
+
                 const pid = state.activePassengerId;
                 const segId = state.activeSegmentId;
+
                 const currentSeats = state.selectedSeatsBySegment[segId] || {};
                 const currentSeatNo = currentSeats[pid] || null;
 
@@ -96,67 +103,74 @@ window.SeatEvents = (() => {
                 // disabled 좌석은 클릭 무시 (현재 선택좌석 해제만 허용)
                 if (btn.disabled && !(currentSeatNo && seatNo === currentSeatNo)) return;
 
+                //  여기서부터 진짜 처리 시작
                 state.isHolding = true;
+                try {
+                    // 같은 좌석 재클릭 → 해제
+                    if (currentSeatNo === seatNo) {
+                        // 즉시 UI 업데이트
+                        SeatGrid.updateSeatUI(dom.seatGridEl, seatNo, "AVAILABLE");
+                        if (state.selectedSeatsBySegment[segId]) {
+                            delete state.selectedSeatsBySegment[segId][pid];
+                        }
+                        updateSummaryUI();
 
-                // 같은 좌석 재클릭 → 해제
-                if (currentSeatNo === seatNo) {
-                    // 1. 즉시 UI 업데이트
-                    SeatGrid.updateSeatUI(dom.seatGridEl, seatNo, "AVAILABLE");
-                    delete state.selectedSeatsBySegment[segId][pid];
+                        // 서버 해제
+                        try {
+                            await SeatAPI.releaseHold(ctx.base, ctx.reservationId, segId, pid);
+                        } catch (err) {
+                            // 실패 시 롤백
+                            if (!state.selectedSeatsBySegment[segId]) state.selectedSeatsBySegment[segId] = {};
+                            state.selectedSeatsBySegment[segId][pid] = seatNo;
+                            SeatGrid.updateSeatUI(dom.seatGridEl, seatNo, "HOLD");
+                            updateSummaryUI();
+                            Swal.error("좌석 해제에 실패했습니다.", "오류");
+                        }
+                        return;
+                    }
+
+                    // 새 좌석 선택
+                    // 즉시 UI 업데이트
+                    if (currentSeatNo) {
+                        SeatGrid.updateSeatUI(dom.seatGridEl, currentSeatNo, "AVAILABLE");
+                    }
+                    SeatGrid.updateSeatUI(dom.seatGridEl, seatNo, "HOLD");
+
+                    if (!state.selectedSeatsBySegment[segId]) {
+                        state.selectedSeatsBySegment[segId] = {};
+                    }
+                    state.selectedSeatsBySegment[segId][pid] = seatNo;
                     updateSummaryUI();
 
-                    // 2. 백그라운드 API 호출
+                    // api 호출: releaseHold를 무조건 시도 → 중복 HOLD 방지
                     try {
-                        await SeatAPI.releaseHold(ctx.base, ctx.reservationId, segId, pid);
+                        try {
+                            await SeatAPI.releaseHold(ctx.base, ctx.reservationId, segId, pid);
+                        } catch (_) {
+                            // 기존 HOLD가 없으면 무시
+                        }
+
+                        await SeatAPI.holdSeat(ctx.base, ctx.reservationId, segId, {
+                            passengerId: pid,
+                            seatNo,
+                        });
                     } catch (err) {
                         // 실패 시 롤백
-                        state.selectedSeatsBySegment[segId][pid] = seatNo;
-                        SeatGrid.updateSeatUI(dom.seatGridEl, seatNo, "HOLD");
+                        SeatGrid.updateSeatUI(dom.seatGridEl, seatNo, "AVAILABLE");
+                        if (currentSeatNo) {
+                            state.selectedSeatsBySegment[segId][pid] = currentSeatNo;
+                            SeatGrid.updateSeatUI(dom.seatGridEl, currentSeatNo, "HOLD");
+                        } else {
+                            delete state.selectedSeatsBySegment[segId][pid];
+                        }
                         updateSummaryUI();
-                        Swal.error("좌석 해제에 실패했습니다.", "오류");
-                    } finally {
-                        state.isHolding = false;
+                        Swal.error("좌석 선택에 실패했습니다. 다시 시도해주세요.", "오류");
                     }
-                    return;
-                }
-
-                // 새 좌석 선택
-                // 1. 즉시 UI 업데이트
-                if (currentSeatNo) {
-                    SeatGrid.updateSeatUI(dom.seatGridEl, currentSeatNo, "AVAILABLE");
-                }
-                SeatGrid.updateSeatUI(dom.seatGridEl, seatNo, "HOLD");
-
-                if (!state.selectedSeatsBySegment[segId]) {
-                    state.selectedSeatsBySegment[segId] = {};
-                }
-                state.selectedSeatsBySegment[segId][pid] = seatNo;
-                updateSummaryUI();
-
-                // 2. 백그라운드 API 호출
-                try {
-                    if (currentSeatNo) {
-                        await SeatAPI.releaseHold(ctx.base, ctx.reservationId, segId, pid);
-                    }
-                    await SeatAPI.holdSeat(ctx.base, ctx.reservationId, segId, {
-                        passengerId: pid,
-                        seatNo,
-                    });
-                } catch (err) {
-                    // 실패 시 롤백
-                    SeatGrid.updateSeatUI(dom.seatGridEl, seatNo, "AVAILABLE");
-                    if (currentSeatNo) {
-                        state.selectedSeatsBySegment[segId][pid] = currentSeatNo;
-                        SeatGrid.updateSeatUI(dom.seatGridEl, currentSeatNo, "HOLD");
-                    } else {
-                        delete state.selectedSeatsBySegment[segId][pid];
-                    }
-                    updateSummaryUI();
-                    Swal.error("좌석 선택에 실패했습니다. 다시 시도해주세요.", "오류");
                 } finally {
                     state.isHolding = false;
                 }
             });
+
 
             // 우측 패널 요약 업데이트 (전체 렌더링 없이)
             function updateSummaryUI() {

--- a/src/main/webapp/resources/seat/js/seat-grid.js
+++ b/src/main/webapp/resources/seat/js/seat-grid.js
@@ -69,9 +69,18 @@
         return btn;
     }
 
+    function buildEmptySeatCell() {
+        const btn = document.createElement("button");
+        btn.type = "button";
+        btn.className = "seat-item seat-item--empty";
+        btn.disabled = true;
+        btn.setAttribute("disabled", "true");
+        btn.tabIndex = -1;
+        return btn;
+    }
 
     function calcSectionByIndex(idx, total) {
-        if (total <= 0) return "front";
+        if (total <= 10) return "front";
 
         const cut1 = Math.ceil(total / 3);
         const cut2 = Math.ceil((total * 2) / 3);
@@ -130,12 +139,25 @@
                 .get(rowNo)
                 .sort((a, b) => String(a.colNo).localeCompare(String(b.colNo)));
 
-            list.forEach((seat) => {
-                const col = String(seat.colNo).toUpperCase();
-                const btn = buildSeatButton(seat, activePassengerId);
+            // colNo -> seat 매핑 (없는 컬럼은 빈칸으로 처리)
+            const seatByCol = new Map();
+            list.forEach((s) => {
+                const col = String(s.colNo || "").toUpperCase();
+                if (col) seatByCol.set(col, s);
+            });
 
-                if (LEFT_COLS.includes(col)) leftWrap.appendChild(btn);
-                else rightWrap.appendChild(btn);
+            // A,B,C 3칸 렌더 (없으면 empty cell)
+            LEFT_COLS.forEach((col) => {
+                const seat = seatByCol.get(col);
+                const cell = seat ? buildSeatButton(seat, activePassengerId) : buildEmptySeatCell();
+                leftWrap.appendChild(cell);
+            });
+
+            // D,E,F 3칸 렌더 (없으면 empty cell)
+            RIGHT_COLS.forEach((col) => {
+                const seat = seatByCol.get(col);
+                const cell = seat ? buildSeatButton(seat, activePassengerId) : buildEmptySeatCell();
+                rightWrap.appendChild(cell);
             });
 
             rowDiv.appendChild(leftWrap);
@@ -143,6 +165,17 @@
             rowDiv.appendChild(rightWrap);
             seatGridEl.appendChild(rowDiv);
         });
+
+        // 실제 존재하는 섹션(front/mid/rear) 기록
+        const present = new Set();
+        seatGridEl.querySelectorAll(".seat-row[data-section]").forEach((el) => {
+            if (el.dataset.section) present.add(el.dataset.section);
+        });
+
+        // row가 0이거나 이상할 때 최소 front 보장
+        if (!present.size) present.add("front");
+
+        seatGridEl.dataset.presentSections = Array.from(present).join(",");
     }
 
     function escapeHtml(s) {

--- a/src/main/webapp/resources/seat/js/seat-render.js
+++ b/src/main/webapp/resources/seat/js/seat-render.js
@@ -25,22 +25,21 @@ window.SeatRenderer = (() => {
             const segId = state.activeSegmentId;
             const seats = await SeatAPI.fetchSeatMap(ctx.base, ctx.reservationId, segId);
 
-            // 서버에서 이미 AVAILABLE로 바뀐 좌석은 로컬 선택에서도 제거
-            const seatStatusBySeatNo = new Map();
-            (seats || []).forEach((s) => {
-                const seatNo = String(s.seatNo || "");
-                const st = String(s.seatStatus || "").toUpperCase();
-                if (seatNo) seatStatusBySeatNo.set(seatNo, st);
-            });
+            // 서버 HOLD -> 로컬 선택 좌석 동기화 (팝업 재진입/새로고침 대비)
+            const myPassengerIds = new Set((state.passengers || []).map((p) => String(p.passengerId)));
+            const serverSelected = {}; // { passengerId: seatNo }
 
-            const currentSegmentSeats = state.selectedSeatsBySegment[segId] || {};
-            Object.entries(currentSegmentSeats).forEach(([pid, seatNo]) => {
-                const st = seatStatusBySeatNo.get(String(seatNo)) || "AVAILABLE";
-                // 서버가 AVAILABLE로 보여주면(만료/해제) 로컬도 제거
-                if (st === "AVAILABLE") {
-                    delete state.selectedSeatsBySegment[segId][pid];
+            (seats || []).forEach((s) => {
+                const st = String(s.seatStatus || "").toUpperCase();
+                const pid = s.passengerId != null ? String(s.passengerId) : "";
+                const seatNo = s.seatNo != null ? String(s.seatNo) : "";
+                if (st === "HOLD" && pid && seatNo && myPassengerIds.has(pid)) {
+                    serverSelected[pid] = seatNo;
                 }
             });
+
+            // 서버 기준으로 덮어쓰기 (불일치/유령 선택 방지)
+            state.selectedSeatsBySegment[segId] = serverSelected;
 
             SeatGrid.renderSeatGrid(dom.seatGridEl, seats, state.activePassengerId, ctx.cabinClassCode);
 


### PR DESCRIPTION
## 📌 PR 설명
<br>
좌석이 선택되었다고 표시되었음에도 미선택 알림이 뜨는 것을 해결

## ✅ 완료한 기능 명세

- [x] 전역 상태를 세그먼트 기준 상태로 맞춤

<br>

## 📸 스크린샷

<br>

## 💭 고민과 해결과정
좌석 선택 로직에서
selectedSeatsByPassenger(전역 단일 상태)와
selectedSeatsBySegment[segmentId](세그먼트별 상태)가 혼재되어 사용되고 있었음


세그먼트 전환/재진입 시 좌석 선택 상태가 UI와 불일치

이미 HOLD 중인 좌석임에도 우측 패널에서는 미선택으로 표시

빠른 클릭 시 전역 상태 기준으로 중복 HOLD가 발생할 수 있는 구조

해결 방법
모든 조회/렌더링/액션 로직을 selectedSeatsBySegment[activeSegmentId] 기준으로 통일
<br>

### 🔗 관련 이슈
Closes #220 

<br>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 결제 전 서버 기반 좌석 최신 상태 비동기 확인 및 검증 추가.
  * 좌석 팝업/선택 흐름에서 진행 상태 확인과 사용자 확인 절차 도입.

* **Bug Fixes**
  * 동일 구간 중복 선택 충돌 방지 및 선택/해제 복구 로직 강화.
  * 서버-클라이언트 좌석 동기화 방식 개선으로 잘못된 로컬 선택 제거 방지 및 오류 안내 개선.

* **Style**
  * 좌석 선택 표시 색상과 전설(legend) 스타일을 파란색에서 주황/황색 계열로 변경.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->