### PR TITLE
[FLYW-201] 동일 좌석 마우스 커서 x표시 변경

### DIFF
--- a/src/main/webapp/resources/seat/css/seatgrid.css
+++ b/src/main/webapp/resources/seat/css/seatgrid.css
@@ -177,8 +177,13 @@
     background: linear-gradient(180deg, #fbbf24 0%, #f59e0b 100%);
     color: #ffffff;
     border: 2px solid #d97706;
-    cursor: not-allowed;
+    cursor: pointer;
     opacity: 0.85;
+}
+
+/* 내 HOLD 좌석은 다시 클릭 가능 */
+.seat-item--hold.seat-item--self-hold {
+    cursor: pointer;
 }
 
 .seat-item--unavailable {

--- a/src/main/webapp/resources/seat/js/seat-grid.js
+++ b/src/main/webapp/resources/seat/js/seat-grid.js
@@ -53,7 +53,7 @@
         if (status === "HOLD") {
             // 활성 승객이 잡은 HOLD만 주황색 + 클릭 가능(해제/변경)
             if (holderPid && activePassengerId && holderPid === String(activePassengerId)) {
-                btn.classList.add("seat-item--hold");
+                btn.classList.add("seat-item--hold", "seat-item--self-hold");
                 return btn;
             }
 


### PR DESCRIPTION
## 📌 PR 설명
<br>
같은 좌석 위 마우스 커서 x표시 해제
## ✅ 완료한 기능 명세

- [x] 내가 hold한 좌석만 커서 x 표시 해제
- [x] BOOKED 좌석 및 다른 사용자가 HOLD한 좌석은 기존과 동일하게 금지 표시 유지
- [x] 좌석 선택/해제 로직에는 영향 없이 UI 스타일만 분리 처리

<br>

## 📸 스크린샷

<br>

## 💭 고민과 해결과정

<br>
HOLD 상태 좌석을 하나의 스타일로 처리하면서 내가 선택한 좌석과 “다른 사용자가 점유한 좌석을  
UI에서 구분하지 못하는 문제가 있었음

해결
내가 HOLD한 좌석에만 `seat-item--self-hold 클래스를 추가하고 CSS에서 해당 클래스에 한해 커서를 pointer로 오버라이드하여 기존 로직 변경 없이 UX 문제를 해결함

### 🔗 관련 이슈
Closes #239 

<br>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **기능 개선**
  * 자신이 예약한 좌석을 클릭할 수 있도록 변경
  * 자신이 예약한 좌석과 타사용자가 예약한 좌석의 시각적 구분 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->