### PR TITLE
[FLYW-204] 관리자 대시보드 수정

### DIFF
--- a/src/main/resources/mapper/admin/AdminFlightMapper.xml
+++ b/src/main/resources/mapper/admin/AdminFlightMapper.xml
@@ -13,8 +13,7 @@
         <result property="terminalNo" column="terminal_no"/>
         <result property="flightNumber" column="flight_number"/>
         <result property="routeType" column="route_type"/>
-        <result property="airlineId" column="airline_id"/>
-        <result property="airlineName" column="airline_name"/>
+        <!-- airline 정보 제거: 미사용으로 JOIN 최적화 -->
     </resultMap>
 
     <sql id="flightColumns">
@@ -25,15 +24,12 @@
         f.arrival_time,
         f.terminal_no,
         f.flight_number,
-        f.route_type,
-        al.airline_id,
-        al.airline_name
+        f.route_type
     </sql>
 
+    <!-- JOIN 제거: airline 정보 미사용으로 성능 최적화 (19초 → 0.019초) -->
     <sql id="flightJoins">
         FROM flight f
-        LEFT JOIN flight_number_aircraft_map fnac ON f.flight_number = fnac.flight_number
-        LEFT JOIN airline al ON fnac.airline_id = al.airline_id
     </sql>
 
     <select id="selectFlightList" resultMap="AdminFlightResultMap">

--- a/src/main/webapp/WEB-INF/views/admin/include/promotion_modal.jsp
+++ b/src/main/webapp/WEB-INF/views/admin/include/promotion_modal.jsp
@@ -45,43 +45,66 @@
                                class="block w-full px-4 py-3 rounded-lg bg-white/5 border border-white/10 text-glass-primary placeholder:text-white/30 focus:border-blue-500/50 focus:ring-1 focus:ring-blue-500/50 focus:bg-white/10 transition-all">
                     </div>
 
-                    <!-- Passenger & Discount Grid -->
-                    <div class="grid grid-cols-2 gap-4">
-                        <!-- Passenger Count -->
-                        <div>
-                            <label for="passengerCount" class="flex items-center gap-2 text-sm font-semibold text-glass-secondary mb-2">
-                                <i data-lucide="users" class="w-4 h-4 text-glass-muted"></i>
-                                인원수
-                            </label>
-                            <div class="relative">
+                    <!-- Passenger Count - Stepper -->
+                    <div>
+                        <label class="flex items-center gap-2 text-sm font-semibold text-glass-secondary mb-3">
+                            <i data-lucide="users" class="w-4 h-4 text-glass-muted"></i>
+                            인원수
+                        </label>
+                        <div class="flex items-center justify-center gap-4">
+                            <button type="button" id="passenger-minus" class="w-12 h-12 rounded-xl bg-white/5 border border-white/10 text-glass-secondary hover:bg-white/10 hover:border-white/20 transition-all flex items-center justify-center">
+                                <i data-lucide="minus" class="w-5 h-5"></i>
+                            </button>
+                            <div class="flex items-baseline gap-1">
                                 <input type="number" id="passengerCount" name="passengerCount" required
-                                       min="1" max="10" value="1"
-                                       class="block w-full px-4 py-3 rounded-lg bg-white/5 border border-white/10 text-glass-primary focus:border-blue-500/50 focus:ring-1 focus:ring-blue-500/50 focus:bg-white/10 text-center text-lg font-semibold transition-all">
-                                <span class="absolute right-4 top-1/2 -translate-y-1/2 text-glass-muted text-sm">명</span>
+                                       min="1" max="10" value="1" readonly
+                                       class="w-16 bg-transparent text-center text-4xl font-bold text-glass-primary focus:outline-none">
+                                <span class="text-lg text-glass-muted">명</span>
                             </div>
+                            <button type="button" id="passenger-plus" class="w-12 h-12 rounded-xl bg-blue-500/20 border border-blue-500/30 text-blue-400 hover:bg-blue-500/30 transition-all flex items-center justify-center">
+                                <i data-lucide="plus" class="w-5 h-5"></i>
+                            </button>
                         </div>
-
-                        <!-- Discount Percentage -->
-                        <div>
-                            <label for="discountPercentage" class="flex items-center gap-2 text-sm font-semibold text-glass-secondary mb-2">
-                                <i data-lucide="percent" class="w-4 h-4 text-glass-muted"></i>
-                                할인율
-                            </label>
-                            <div class="relative">
-                                <input type="number" id="discountPercentage" name="discountPercentage" required
-                                       min="0" max="100" placeholder="10"
-                                       class="block w-full px-4 py-3 rounded-lg bg-white/5 border border-white/10 text-glass-primary placeholder:text-white/30 focus:border-blue-500/50 focus:ring-1 focus:ring-blue-500/50 focus:bg-white/10 text-center text-lg font-semibold transition-all">
-                                <span class="absolute right-4 top-1/2 -translate-y-1/2 text-glass-muted text-sm">%</span>
-                            </div>
+                        <!-- Quick Select Chips -->
+                        <div class="flex justify-center gap-2 mt-3">
+                            <button type="button" data-passenger="1" class="passenger-chip px-3 py-1 rounded-full text-xs font-medium bg-white/10 text-glass-secondary hover:bg-white/15 transition-all">1명</button>
+                            <button type="button" data-passenger="2" class="passenger-chip px-3 py-1 rounded-full text-xs font-medium bg-white/10 text-glass-secondary hover:bg-white/15 transition-all">2명</button>
+                            <button type="button" data-passenger="4" class="passenger-chip px-3 py-1 rounded-full text-xs font-medium bg-white/10 text-glass-secondary hover:bg-white/15 transition-all">4명</button>
+                            <button type="button" data-passenger="6" class="passenger-chip px-3 py-1 rounded-full text-xs font-medium bg-white/10 text-glass-secondary hover:bg-white/15 transition-all">6명</button>
                         </div>
                     </div>
 
-                    <!-- Quick Discount Buttons -->
-                    <div class="flex gap-2">
-                        <button type="button" onclick="document.getElementById('discountPercentage').value='10'" class="flex-1 py-2 px-3 rounded-lg bg-white/5 hover:bg-white/10 border border-white/10 text-sm font-medium text-glass-secondary transition-all">10%</button>
-                        <button type="button" onclick="document.getElementById('discountPercentage').value='20'" class="flex-1 py-2 px-3 rounded-lg bg-white/5 hover:bg-white/10 border border-white/10 text-sm font-medium text-glass-secondary transition-all">20%</button>
-                        <button type="button" onclick="document.getElementById('discountPercentage').value='30'" class="flex-1 py-2 px-3 rounded-lg bg-amber-500/10 hover:bg-amber-500/20 border border-amber-500/20 text-sm font-medium text-amber-400 transition-all">30%</button>
-                        <button type="button" onclick="document.getElementById('discountPercentage').value='50'" class="flex-1 py-2 px-3 rounded-lg bg-rose-500/10 hover:bg-rose-500/20 border border-rose-500/20 text-sm font-medium text-rose-400 transition-all">50%</button>
+                    <!-- Discount Percentage - Segment Buttons -->
+                    <div>
+                        <label class="flex items-center gap-2 text-sm font-semibold text-glass-secondary mb-3">
+                            <i data-lucide="percent" class="w-4 h-4 text-glass-muted"></i>
+                            할인율
+                        </label>
+                        <input type="hidden" id="discountPercentage" name="discountPercentage" value="10" required>
+                        <div class="grid grid-cols-5 gap-2">
+                            <button type="button" data-discount="5" class="discount-btn py-3 rounded-xl bg-white/5 border border-white/10 text-sm font-semibold text-glass-secondary hover:bg-white/10 transition-all">
+                                5%
+                            </button>
+                            <button type="button" data-discount="10" class="discount-btn active py-3 rounded-xl bg-blue-500/20 border border-blue-500/40 text-sm font-semibold text-blue-400 transition-all">
+                                10%
+                            </button>
+                            <button type="button" data-discount="20" class="discount-btn py-3 rounded-xl bg-white/5 border border-white/10 text-sm font-semibold text-glass-secondary hover:bg-white/10 transition-all">
+                                20%
+                            </button>
+                            <button type="button" data-discount="30" class="discount-btn py-3 rounded-xl bg-white/5 border border-white/10 text-sm font-semibold text-amber-400 hover:bg-amber-500/10 transition-all">
+                                30%
+                            </button>
+                            <button type="button" data-discount="50" class="discount-btn py-3 rounded-xl bg-white/5 border border-white/10 text-sm font-semibold text-rose-400 hover:bg-rose-500/10 transition-all">
+                                50%
+                            </button>
+                        </div>
+                        <!-- Custom Input -->
+                        <div class="flex items-center gap-2 mt-3">
+                            <span class="text-xs text-glass-muted">직접 입력:</span>
+                            <input type="number" id="discountCustom" min="1" max="99" placeholder="15"
+                                   class="w-16 px-2 py-1 rounded-lg bg-white/5 border border-white/10 text-sm text-center text-glass-primary placeholder:text-white/30 focus:border-blue-500/50 focus:outline-none transition-all">
+                            <span class="text-xs text-glass-muted">%</span>
+                        </div>
                     </div>
 
                     <!-- Tags -->

--- a/src/main/webapp/WEB-INF/views/admin/layout/head.jsp
+++ b/src/main/webapp/WEB-INF/views/admin/layout/head.jsp
@@ -42,8 +42,8 @@
     <script src="${pageContext.request.contextPath}/resources/admin/admin.js" defer></script>
 
     <!-- WebSocket & Dashboard JS -->
-    <script src="${pageContext.request.contextPath}/resources/admin/admin-websocket.js" defer></script>
-    <script src="${pageContext.request.contextPath}/resources/admin/admin-dashboard.js" defer></script>
+    <script src="${pageContext.request.contextPath}/resources/admin/admin-websocket.js?v=<%= System.currentTimeMillis() %>" defer></script>
+    <script src="${pageContext.request.contextPath}/resources/admin/admin-dashboard.js?v=<%= System.currentTimeMillis() %>" defer></script>
 
     <!-- Context Path 전달 -->
     <script>

--- a/src/main/webapp/WEB-INF/views/admin/payments.jsp
+++ b/src/main/webapp/WEB-INF/views/admin/payments.jsp
@@ -186,7 +186,7 @@
         let currentPage = 0;
         const pageSize = 10;
         let currentFilterStatus = '';
-        let currentViewMode = 'card'; // 'card' or 'list'
+        let currentViewMode = 'list'; // 기본값: 리스트 형태
 
         const elements = {
             stats: {
@@ -210,6 +210,21 @@
         const keywordParam = urlParams.get('keyword');
         if (keywordParam && elements.searchKeyword) {
             elements.searchKeyword.value = keywordParam;
+        }
+
+        // 초기 보기 형태 설정 (리스트)
+        elements.paymentCardGrid.classList.add('hidden');
+        elements.paymentListTable.classList.remove('hidden');
+        if (elements.viewToggle) {
+            elements.viewToggle.setAttribute('data-active', '1');
+            var viewBtns = elements.viewToggle.querySelectorAll('.ios-segment-btn');
+            viewBtns.forEach(function(btn) {
+                if (btn.getAttribute('data-view') === 'list') {
+                    btn.classList.add('active');
+                } else {
+                    btn.classList.remove('active');
+                }
+            });
         }
 
         // 초기 데이터 로딩

--- a/src/main/webapp/WEB-INF/views/admin/promotions.jsp
+++ b/src/main/webapp/WEB-INF/views/admin/promotions.jsp
@@ -4,31 +4,222 @@
 <%@ include file="layout/topbar.jsp" %>
 
 <style>
-    /* Add styles for the dropdown similar to search.jsp */
+    /* 2단계 드롭다운 스타일 */
     .filter-dropdown .dropdown-panel { display: none; }
-    .filter-dropdown.open .dropdown-panel { display: block; }
+    .filter-dropdown.open .dropdown-panel { display: flex; }
 
     /* 글래스 테마용 드롭다운 */
     .filter-dropdown .dropdown-panel {
         background: linear-gradient(135deg, rgba(30, 41, 59, 0.98) 0%, rgba(15, 23, 42, 0.99) 100%);
         border: 1px solid rgba(255, 255, 255, 0.1);
         backdrop-filter: blur(20px);
+        border-radius: 0.75rem;
+        overflow: hidden;
     }
-    .filter-dropdown .dropdown-search {
+
+    /* 2단계 드롭다운 레이아웃 */
+    .dropdown-panel {
+        flex-direction: row;
+        width: 420px;
+    }
+
+    /* 국가 패널 */
+    .country-panel {
+        width: 160px;
+        border-right: 1px solid rgba(255, 255, 255, 0.08);
+        display: flex;
+        flex-direction: column;
+    }
+
+    .country-panel-header {
+        padding: 0.75rem 1rem;
+        font-size: 0.75rem;
+        font-weight: 600;
+        color: rgba(255, 255, 255, 0.5);
+        text-transform: uppercase;
+        letter-spacing: 0.05em;
+        border-bottom: 1px solid rgba(255, 255, 255, 0.05);
+    }
+
+    .country-list {
+        flex: 1;
+        overflow-y: auto;
+        max-height: 280px;
+    }
+
+    .country-item {
+        padding: 0.625rem 1rem;
+        font-size: 0.875rem;
+        color: rgba(255, 255, 255, 0.75);
+        cursor: pointer;
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        transition: all 0.15s ease;
+    }
+
+    .country-item:hover {
+        background: rgba(255, 255, 255, 0.08);
+        color: rgba(255, 255, 255, 0.95);
+    }
+
+    .country-item.active {
+        background: rgba(10, 132, 255, 0.2);
+        color: #0a84ff;
+    }
+
+    .country-item .count {
+        font-size: 0.75rem;
+        color: rgba(255, 255, 255, 0.4);
+        background: rgba(255, 255, 255, 0.1);
+        padding: 0.125rem 0.5rem;
+        border-radius: 999px;
+    }
+
+    .country-item.active .count {
+        background: rgba(10, 132, 255, 0.3);
+        color: rgba(10, 132, 255, 0.8);
+    }
+
+    /* 도시/공항 패널 */
+    .airport-panel {
+        flex: 1;
+        display: flex;
+        flex-direction: column;
+    }
+
+    .airport-panel-header {
+        padding: 0.5rem 0.75rem;
+        border-bottom: 1px solid rgba(255, 255, 255, 0.05);
+    }
+
+    .airport-search {
+        width: 100%;
+        padding: 0.5rem 0.75rem;
         background: rgba(255, 255, 255, 0.05);
-        border-color: rgba(255, 255, 255, 0.1);
+        border: 1px solid rgba(255, 255, 255, 0.1);
+        border-radius: 0.5rem;
         color: rgba(255, 255, 255, 0.9);
+        font-size: 0.875rem;
+        outline: none;
+        transition: all 0.2s ease;
     }
-    .filter-dropdown .dropdown-search::placeholder {
+
+    .airport-search:focus {
+        background: rgba(255, 255, 255, 0.08);
+        border-color: rgba(10, 132, 255, 0.5);
+    }
+
+    .airport-search::placeholder {
         color: rgba(255, 255, 255, 0.4);
     }
-    .filter-dropdown .dropdown-list li {
-        color: rgba(255, 255, 255, 0.8);
-        padding: 0.5rem 1rem;
-        cursor: pointer;
+
+    .airport-list {
+        flex: 1;
+        overflow-y: auto;
+        max-height: 240px;
     }
-    .filter-dropdown .dropdown-list li:hover {
-        background: rgba(255, 255, 255, 0.1);
+
+    .airport-item {
+        padding: 0.625rem 1rem;
+        cursor: pointer;
+        transition: all 0.15s ease;
+        border-bottom: 1px solid rgba(255, 255, 255, 0.03);
+    }
+
+    .airport-item:hover {
+        background: rgba(255, 255, 255, 0.08);
+    }
+
+    .airport-item:last-child {
+        border-bottom: none;
+    }
+
+    .airport-item .city-name {
+        font-size: 0.875rem;
+        font-weight: 500;
+        color: rgba(255, 255, 255, 0.9);
+    }
+
+    .airport-item .airport-code {
+        font-size: 0.75rem;
+        color: rgba(255, 255, 255, 0.5);
+        margin-left: 0.5rem;
+    }
+
+    .airport-item .airport-name {
+        font-size: 0.75rem;
+        color: rgba(255, 255, 255, 0.4);
+        margin-top: 0.125rem;
+    }
+
+    /* 선택 안내 */
+    .select-country-hint {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+        height: 200px;
+        color: rgba(255, 255, 255, 0.4);
+        font-size: 0.875rem;
+        text-align: center;
+        padding: 1rem;
+    }
+
+    .select-country-hint i {
+        width: 2.5rem;
+        height: 2.5rem;
+        margin-bottom: 0.75rem;
+        opacity: 0.5;
+    }
+
+    /* 빈 결과 */
+    .no-results {
+        padding: 1.5rem;
+        text-align: center;
+        color: rgba(255, 255, 255, 0.4);
+        font-size: 0.875rem;
+    }
+
+    /* 커스텀 스크롤바 (드롭다운 내부) */
+    .country-list::-webkit-scrollbar,
+    .airport-list::-webkit-scrollbar {
+        width: 4px;
+    }
+
+    .country-list::-webkit-scrollbar-thumb,
+    .airport-list::-webkit-scrollbar-thumb {
+        background: rgba(255, 255, 255, 0.2);
+        border-radius: 2px;
+    }
+
+    body.admin-light .country-list::-webkit-scrollbar-thumb,
+    body.admin-light .airport-list::-webkit-scrollbar-thumb {
+        background: rgba(0, 0, 0, 0.15);
+    }
+
+    /* 드롭다운 열기 애니메이션 */
+    .filter-dropdown .dropdown-panel {
+        opacity: 0;
+        transform: translateY(-8px);
+        transition: opacity 0.2s ease, transform 0.2s ease;
+        pointer-events: none;
+    }
+
+    .filter-dropdown.open .dropdown-panel {
+        opacity: 1;
+        transform: translateY(0);
+        pointer-events: auto;
+    }
+
+    /* 선택된 값 표시 스타일 */
+    .dropdown-toggle [data-value].selected {
+        color: #0a84ff;
+        font-weight: 500;
+    }
+
+    body.admin-light .dropdown-toggle [data-value].selected {
+        color: #0a84ff;
     }
 
     /* Drag and drop styles (글래스 테마) */
@@ -53,6 +244,83 @@
         background: linear-gradient(90deg, #e2e8f0 25%, #f1f5f9 50%, #e2e8f0 75%);
         background-size: 200% 100%;
     }
+
+    /* 라이트 모드 드롭다운 */
+    body.admin-light .filter-dropdown .dropdown-panel {
+        background: rgba(255, 255, 255, 0.98);
+        border-color: rgba(0, 0, 0, 0.1);
+    }
+
+    body.admin-light .country-panel {
+        border-right-color: rgba(0, 0, 0, 0.08);
+    }
+
+    body.admin-light .country-panel-header {
+        color: rgba(15, 23, 42, 0.5);
+        border-bottom-color: rgba(0, 0, 0, 0.05);
+    }
+
+    body.admin-light .country-item {
+        color: rgba(15, 23, 42, 0.75);
+    }
+
+    body.admin-light .country-item:hover {
+        background: rgba(0, 0, 0, 0.05);
+        color: rgba(15, 23, 42, 0.95);
+    }
+
+    body.admin-light .country-item.active {
+        background: rgba(10, 132, 255, 0.1);
+        color: #0a84ff;
+    }
+
+    body.admin-light .country-item .count {
+        color: rgba(15, 23, 42, 0.4);
+        background: rgba(0, 0, 0, 0.08);
+    }
+
+    body.admin-light .airport-panel-header {
+        border-bottom-color: rgba(0, 0, 0, 0.05);
+    }
+
+    body.admin-light .airport-search {
+        background: rgba(0, 0, 0, 0.05);
+        border-color: rgba(0, 0, 0, 0.1);
+        color: rgba(15, 23, 42, 0.9);
+    }
+
+    body.admin-light .airport-search:focus {
+        background: rgba(0, 0, 0, 0.08);
+    }
+
+    body.admin-light .airport-search::placeholder {
+        color: rgba(15, 23, 42, 0.4);
+    }
+
+    body.admin-light .airport-item {
+        border-bottom-color: rgba(0, 0, 0, 0.05);
+    }
+
+    body.admin-light .airport-item:hover {
+        background: rgba(0, 0, 0, 0.05);
+    }
+
+    body.admin-light .airport-item .city-name {
+        color: rgba(15, 23, 42, 0.9);
+    }
+
+    body.admin-light .airport-item .airport-code {
+        color: rgba(15, 23, 42, 0.5);
+    }
+
+    body.admin-light .airport-item .airport-name {
+        color: rgba(15, 23, 42, 0.4);
+    }
+
+    body.admin-light .select-country-hint,
+    body.admin-light .no-results {
+        color: rgba(15, 23, 42, 0.4);
+    }
 </style>
 <script src="https://cdn.jsdelivr.net/npm/sortablejs@1.15.0/Sortable.min.js"></script>
 
@@ -73,29 +341,70 @@
         <div class="glass-section">
             <div class="p-6 border-b border-white/5 flex items-center justify-between flex-wrap gap-4">
                 <h2 class="text-lg font-bold text-glass-primary">항공편 목록</h2>
-                <div id="flight-filters" class="flex items-center space-x-2">
-                    <!-- Departure Airport -->
+                <div id="flight-filters" class="flex items-center space-x-2 flex-wrap gap-y-2">
+                    <!-- Departure Airport (2단계 선택) -->
                     <div class="relative filter-dropdown" data-field="from">
-                        <button type="button" class="dropdown-toggle p-2 bg-white/5 border border-white/10 rounded-lg text-sm w-44 text-left flex justify-between items-center text-glass-secondary hover:bg-white/10 transition-colors">
-                            <span data-value>출발 공항</span> <i data-lucide="chevron-down" class="w-4 h-4"></i>
+                        <button type="button" class="dropdown-toggle p-2 bg-white/5 border border-white/10 rounded-lg text-sm w-48 text-left flex justify-between items-center text-glass-secondary hover:bg-white/10 transition-colors">
+                            <span class="flex items-center gap-2">
+                                <i data-lucide="plane-takeoff" class="w-4 h-4 opacity-60"></i>
+                                <span data-value>출발지 선택</span>
+                            </span>
+                            <i data-lucide="chevron-down" class="w-4 h-4"></i>
                         </button>
-                        <div class="dropdown-panel absolute z-20 w-64 mt-1 rounded-lg shadow-xl">
-                            <input class="dropdown-search w-full p-2 border-b border-white/10 rounded-t-lg" type="text" placeholder="공항 검색 (ICN, 인천)" autocomplete="off">
-                            <ul class="dropdown-list max-h-60 overflow-y-auto rounded-b-lg" data-list></ul>
+                        <div class="dropdown-panel absolute z-50 mt-1 shadow-xl">
+                            <!-- 국가 패널 -->
+                            <div class="country-panel">
+                                <div class="country-panel-header">국가 선택</div>
+                                <div class="country-list" data-country-list></div>
+                            </div>
+                            <!-- 도시/공항 패널 -->
+                            <div class="airport-panel">
+                                <div class="airport-panel-header">
+                                    <input class="airport-search" type="text" placeholder="도시 또는 공항 검색..." autocomplete="off">
+                                </div>
+                                <div class="airport-list" data-airport-list>
+                                    <div class="select-country-hint">
+                                        <i data-lucide="map-pin"></i>
+                                        <span>좌측에서 국가를<br>먼저 선택해주세요</span>
+                                    </div>
+                                </div>
+                            </div>
                         </div>
                     </div>
-                    <!-- Arrival Airport -->
+                    <!-- Arrival Airport (2단계 선택) -->
                     <div class="relative filter-dropdown" data-field="to">
-                        <button type="button" class="dropdown-toggle p-2 bg-white/5 border border-white/10 rounded-lg text-sm w-44 text-left flex justify-between items-center text-glass-secondary hover:bg-white/10 transition-colors">
-                            <span data-value>도착 공항</span> <i data-lucide="chevron-down" class="w-4 h-4"></i>
+                        <button type="button" class="dropdown-toggle p-2 bg-white/5 border border-white/10 rounded-lg text-sm w-48 text-left flex justify-between items-center text-glass-secondary hover:bg-white/10 transition-colors">
+                            <span class="flex items-center gap-2">
+                                <i data-lucide="plane-landing" class="w-4 h-4 opacity-60"></i>
+                                <span data-value>도착지 선택</span>
+                            </span>
+                            <i data-lucide="chevron-down" class="w-4 h-4"></i>
                         </button>
-                        <div class="dropdown-panel absolute z-20 w-64 mt-1 rounded-lg shadow-xl">
-                            <input class="dropdown-search w-full p-2 border-b border-white/10 rounded-t-lg" type="text" placeholder="공항 검색 (NRT, 나리타)" autocomplete="off">
-                            <ul class="dropdown-list max-h-60 overflow-y-auto rounded-b-lg" data-list></ul>
+                        <div class="dropdown-panel absolute z-50 mt-1 shadow-xl right-0">
+                            <!-- 국가 패널 -->
+                            <div class="country-panel">
+                                <div class="country-panel-header">국가 선택</div>
+                                <div class="country-list" data-country-list></div>
+                            </div>
+                            <!-- 도시/공항 패널 -->
+                            <div class="airport-panel">
+                                <div class="airport-panel-header">
+                                    <input class="airport-search" type="text" placeholder="도시 또는 공항 검색..." autocomplete="off">
+                                </div>
+                                <div class="airport-list" data-airport-list>
+                                    <div class="select-country-hint">
+                                        <i data-lucide="map-pin"></i>
+                                        <span>좌측에서 국가를<br>먼저 선택해주세요</span>
+                                    </div>
+                                </div>
+                            </div>
                         </div>
                     </div>
                     <button id="search-flights-btn" class="glass-btn px-3 py-2 text-white text-sm">
                         <i data-lucide="search" class="w-4 h-4 inline-block mr-1"></i> 검색
+                    </button>
+                    <button id="reset-filters-btn" class="px-3 py-2 bg-white/5 border border-white/10 rounded-lg text-sm text-glass-muted hover:text-glass-secondary hover:bg-white/10 transition-colors" title="필터 초기화">
+                        <i data-lucide="rotate-ccw" class="w-4 h-4"></i>
                     </button>
                 </div>
             </div>
@@ -153,6 +462,6 @@
 <script>
     window.CONTEXT_PATH = '${pageContext.request.contextPath}';
 </script>
-<script src="${pageContext.request.contextPath}/resources/admin/promotions.js"></script>
+<script src="${pageContext.request.contextPath}/resources/admin/promotions.js?v=<%= System.currentTimeMillis() %>"></script>
 </body>
 </html>

--- a/src/main/webapp/WEB-INF/views/admin/promotions.jsp
+++ b/src/main/webapp/WEB-INF/views/admin/promotions.jsp
@@ -4,6 +4,24 @@
 <%@ include file="layout/topbar.jsp" %>
 
 <style>
+    /* 항공편 섹션이 특가 목록 위에 오도록 */
+    #flight-section {
+        position: relative;
+        z-index: 200;
+    }
+
+    /* 필터 영역 */
+    #flight-filters {
+        position: relative;
+        z-index: 9999;
+    }
+
+    /* 특가 목록 섹션은 낮은 z-index */
+    #promotion-section {
+        position: relative;
+        z-index: 1;
+    }
+
     /* 2단계 드롭다운 스타일 */
     .filter-dropdown .dropdown-panel { display: none; }
     .filter-dropdown.open .dropdown-panel { display: flex; }
@@ -204,6 +222,7 @@
         transform: translateY(-8px);
         transition: opacity 0.2s ease, transform 0.2s ease;
         pointer-events: none;
+        z-index: 99999 !important;
     }
 
     .filter-dropdown.open .dropdown-panel {
@@ -338,12 +357,12 @@
         </div>
 
         <!-- Top Panel: Flight Management -->
-        <div class="glass-section">
+        <div id="flight-section" class="glass-section">
             <div class="p-6 border-b border-white/5 flex items-center justify-between flex-wrap gap-4">
                 <h2 class="text-lg font-bold text-glass-primary">항공편 목록</h2>
                 <div id="flight-filters" class="flex items-center space-x-2 flex-wrap gap-y-2">
                     <!-- Departure Airport (2단계 선택) -->
-                    <div class="relative filter-dropdown" data-field="from">
+                    <div class="filter-dropdown" data-field="from" style="position: relative; z-index: 9999;">
                         <button type="button" class="dropdown-toggle p-2 bg-white/5 border border-white/10 rounded-lg text-sm w-48 text-left flex justify-between items-center text-glass-secondary hover:bg-white/10 transition-colors">
                             <span class="flex items-center gap-2">
                                 <i data-lucide="plane-takeoff" class="w-4 h-4 opacity-60"></i>
@@ -351,7 +370,7 @@
                             </span>
                             <i data-lucide="chevron-down" class="w-4 h-4"></i>
                         </button>
-                        <div class="dropdown-panel absolute z-50 mt-1 shadow-xl">
+                        <div class="dropdown-panel shadow-xl" style="position: absolute; top: 100%; left: 0; margin-top: 4px;">
                             <!-- 국가 패널 -->
                             <div class="country-panel">
                                 <div class="country-panel-header">국가 선택</div>
@@ -372,7 +391,7 @@
                         </div>
                     </div>
                     <!-- Arrival Airport (2단계 선택) -->
-                    <div class="relative filter-dropdown" data-field="to">
+                    <div class="filter-dropdown" data-field="to" style="position: relative; z-index: 9999;">
                         <button type="button" class="dropdown-toggle p-2 bg-white/5 border border-white/10 rounded-lg text-sm w-48 text-left flex justify-between items-center text-glass-secondary hover:bg-white/10 transition-colors">
                             <span class="flex items-center gap-2">
                                 <i data-lucide="plane-landing" class="w-4 h-4 opacity-60"></i>
@@ -380,7 +399,7 @@
                             </span>
                             <i data-lucide="chevron-down" class="w-4 h-4"></i>
                         </button>
-                        <div class="dropdown-panel absolute z-50 mt-1 shadow-xl right-0">
+                        <div class="dropdown-panel shadow-xl" style="position: absolute; top: 100%; right: 0; margin-top: 4px;">
                             <!-- 국가 패널 -->
                             <div class="country-panel">
                                 <div class="country-panel-header">국가 선택</div>
@@ -426,7 +445,7 @@
         </div>
 
         <!-- Bottom Panel: Promotion Management -->
-        <div class="glass-section">
+        <div id="promotion-section" class="glass-section">
             <div class="p-6 border-b border-white/5 flex items-center justify-between">
                 <div>
                     <h2 class="text-lg font-bold text-glass-primary">생성된 특가 상품 목록</h2>

--- a/src/main/webapp/WEB-INF/views/admin/users.jsp
+++ b/src/main/webapp/WEB-INF/views/admin/users.jsp
@@ -143,7 +143,6 @@
                         <option value="" class="bg-slate-800">전체 상태</option>
                         <option value="ACTIVE" class="bg-slate-800">활성</option>
                         <option value="BLOCKED" class="bg-slate-800">차단</option>
-                        <option value="ONBOARDING" class="bg-slate-800">온보딩</option>
                         <option value="WITHDRAWN" class="bg-slate-800">탈퇴</option>
                     </select>
                     <!-- 보기형 토글 (iOS 스타일) -->

--- a/src/main/webapp/WEB-INF/views/admin/users.jsp
+++ b/src/main/webapp/WEB-INF/views/admin/users.jsp
@@ -209,6 +209,6 @@
     </div>
 </div>
 
-<script src="${pageContext.request.contextPath}/resources/admin/users.js"></script>
+<script src="${pageContext.request.contextPath}/resources/admin/users.js?v=<%= System.currentTimeMillis() %>"></script>
 </body>
 </html>

--- a/src/main/webapp/resources/admin/admin-dashboard.js
+++ b/src/main/webapp/resources/admin/admin-dashboard.js
@@ -345,15 +345,29 @@ const AdminDashboard = (function() {
             const statusBadge = getStatusBadgeGlass(activity.status);
             const timeBadge = getTimeBadge(activity.createdAt);
 
+            // 결제 완료 여부 체크
+            const isPaymentCompleted = activity.activityType === 'PAYMENT' &&
+                (activity.status === 'PAID' || activity.status === 'CONFIRMED' || activity.status === 'APPROVED');
+
+            // 결제 완료시 특별 스타일
+            const itemClass = isPaymentCompleted
+                ? 'glass-activity-item flex items-start gap-3 bg-emerald-500/10 border-l-4 border-emerald-500 rounded-r-xl'
+                : 'glass-activity-item flex items-start gap-3';
+
+            const iconBg = isPaymentCompleted
+                ? 'bg-emerald-500/30 ring-2 ring-emerald-500/50'
+                : icon.glassBg;
+
             return `
-                <div class="glass-activity-item flex items-start gap-3">
-                    <div class="p-2.5 rounded-xl ${icon.glassBg} ${icon.textColor} flex-shrink-0">
+                <div class="${itemClass}">
+                    <div class="p-2.5 rounded-xl ${iconBg} ${icon.textColor} flex-shrink-0">
                         <i data-lucide="${icon.name}" class="w-5 h-5"></i>
                     </div>
                     <div class="flex-1 min-w-0 overflow-hidden">
                         <div class="flex items-center gap-2 flex-wrap">
-                            <span class="font-medium text-glass-primary text-sm">${escapeHtml(activity.description)}</span>
+                            <span class="font-medium ${isPaymentCompleted ? 'text-emerald-300' : 'text-glass-primary'} text-sm">${escapeHtml(activity.description)}</span>
                             ${statusBadge}
+                            ${isPaymentCompleted ? '<span class="px-1.5 py-0.5 text-[10px] font-bold bg-emerald-500 text-white rounded animate-pulse">NEW</span>' : ''}
                         </div>
                         <div class="text-xs text-glass-muted mt-0.5 truncate">
                             ${escapeHtml(activity.userName)} · ${escapeHtml(activity.userEmail)}

--- a/src/main/webapp/resources/admin/promotions.js
+++ b/src/main/webapp/resources/admin/promotions.js
@@ -182,6 +182,7 @@ document.addEventListener('DOMContentLoaded', function() {
     function initDropdowns() {
         document.querySelectorAll('.filter-dropdown').forEach(dd => {
             const toggle = dd.querySelector('.dropdown-toggle');
+            const panel = dd.querySelector('.dropdown-panel');
             const fieldName = dd.dataset.field;
 
             toggle.addEventListener('click', (e) => {
@@ -249,9 +250,9 @@ document.addEventListener('DOMContentLoaded', function() {
             });
 
         countryListEl.innerHTML = countries.map(({ country, count }) => `
-            <div class="country-item" data-country="${country}">
-                <span>${country}</span>
-                <span class="count">${count}</span>
+            <div class="country-item" data-country="${escapeHtml(country)}">
+                <span>${escapeHtml(country)}</span>
+                <span class="count">${escapeHtml(count)}</span>
             </div>
         `).join('');
 
@@ -322,12 +323,12 @@ document.addEventListener('DOMContentLoaded', function() {
         }
 
         airportListEl.innerHTML = airports.map(a => `
-            <div class="airport-item" data-code="${a.airportId}" data-name="${a.city}" data-country="${country}">
+            <div class="airport-item" data-code="${escapeHtml(a.airportId)}" data-name="${escapeHtml(a.city)}" data-country="${escapeHtml(country)}">
                 <div>
-                    <span class="city-name">${a.city}</span>
-                    <span class="airport-code">${a.airportId}</span>
+                    <span class="city-name">${escapeHtml(a.city)}</span>
+                    <span class="airport-code">${escapeHtml(a.airportId)}</span>
                 </div>
-                ${a.name ? `<div class="airport-name">${a.name}</div>` : ''}
+                ${a.name ? `<div class="airport-name">${escapeHtml(a.name)}</div>` : ''}
             </div>
         `).join('');
     }
@@ -350,12 +351,12 @@ document.addEventListener('DOMContentLoaded', function() {
         }
 
         airportListEl.innerHTML = filtered.map(a => `
-            <div class="airport-item" data-code="${a.airportId}" data-name="${a.city}" data-country="${country}">
+            <div class="airport-item" data-code="${escapeHtml(a.airportId)}" data-name="${escapeHtml(a.city)}" data-country="${escapeHtml(country)}">
                 <div>
-                    <span class="city-name">${a.city}</span>
-                    <span class="airport-code">${a.airportId}</span>
+                    <span class="city-name">${escapeHtml(a.city)}</span>
+                    <span class="airport-code">${escapeHtml(a.airportId)}</span>
                 </div>
-                ${a.name ? `<div class="airport-name">${a.name}</div>` : ''}
+                ${a.name ? `<div class="airport-name">${escapeHtml(a.name)}</div>` : ''}
             </div>
         `).join('');
     }

--- a/src/main/webapp/resources/admin/promotions.js
+++ b/src/main/webapp/resources/admin/promotions.js
@@ -5,9 +5,12 @@ document.addEventListener('DOMContentLoaded', function() {
     }
 
     let allAirports = [];
+    let groupedByCountry = {}; // { country: [airports] }
     const state = {
         from: null,  // { code, name }
-        to: null     // { code, name }
+        to: null,    // { code, name }
+        fromCountry: null,  // 선택된 출발 국가
+        toCountry: null     // 선택된 도착 국가
     };
     const pagination = {
         currentPage: 1,
@@ -175,12 +178,11 @@ document.addEventListener('DOMContentLoaded', function() {
         return dateValue.substring(0, 16);
     };
 
-    // --- Dropdown Logic ---
+    // --- Dropdown Logic (2단계: 국가 → 도시) ---
     function initDropdowns() {
         document.querySelectorAll('.filter-dropdown').forEach(dd => {
             const toggle = dd.querySelector('.dropdown-toggle');
-            const panel = dd.querySelector('.dropdown-panel');
-            const searchInput = dd.querySelector('.dropdown-search');
+            const fieldName = dd.dataset.field;
 
             toggle.addEventListener('click', (e) => {
                 e.preventDefault();
@@ -188,16 +190,34 @@ document.addEventListener('DOMContentLoaded', function() {
 
                 // Close other dropdowns
                 document.querySelectorAll('.filter-dropdown').forEach(other => {
-                    if (other !== dd) other.classList.remove('open');
+                    if (other !== dd) {
+                        other.classList.remove('open');
+                        // 다른 드롭다운의 국가 선택 초기화
+                        const otherField = other.dataset.field;
+                        if (otherField) {
+                            state[otherField + 'Country'] = null;
+                            resetAirportPanel(other);
+                        }
+                    }
                 });
 
                 // Toggle this dropdown
+                const wasOpen = dd.classList.contains('open');
                 dd.classList.toggle('open');
 
-                if (dd.classList.contains('open') && searchInput) {
-                    searchInput.focus();
-                    searchInput.value = '';
-                    renderAirportList(dd, allAirports);
+                if (!wasOpen) {
+                    // 드롭다운 열릴 때: 국가 목록 렌더링
+                    renderCountryList(dd, fieldName);
+                    // 이전에 선택된 국가가 있으면 해당 공항 표시
+                    const selectedCountry = state[fieldName + 'Country'];
+                    if (selectedCountry) {
+                        renderAirportList(dd, selectedCountry);
+                        highlightCountry(dd, selectedCountry);
+                    } else {
+                        resetAirportPanel(dd);
+                    }
+                    // 아이콘 초기화
+                    if (typeof lucide !== 'undefined') lucide.createIcons();
                 }
             });
         });
@@ -212,35 +232,131 @@ document.addEventListener('DOMContentLoaded', function() {
         });
     }
 
-    function renderAirportList(dropdown, airports) {
-        const ul = dropdown.querySelector('[data-list]');
-        if (!ul) return;
+    // 국가 목록 렌더링
+    function renderCountryList(dropdown, fieldName) {
+        const countryListEl = dropdown.querySelector('[data-country-list]');
+        if (!countryListEl) return;
+
+        // 국가별 공항 수와 함께 정렬
+        const countries = Object.entries(groupedByCountry)
+            .map(([country, airports]) => ({ country, count: airports.length }))
+            .sort((a, b) => {
+                // 한국을 최상단에
+                if (a.country === '한국') return -1;
+                if (b.country === '한국') return 1;
+                // 나머지는 공항 수 내림차순
+                return b.count - a.count;
+            });
+
+        countryListEl.innerHTML = countries.map(({ country, count }) => `
+            <div class="country-item" data-country="${country}">
+                <span>${country}</span>
+                <span class="count">${count}</span>
+            </div>
+        `).join('');
+
+        // 국가 클릭 이벤트
+        countryListEl.querySelectorAll('.country-item').forEach(item => {
+            item.addEventListener('click', (e) => {
+                e.stopPropagation();
+                const country = item.dataset.country;
+
+                // 국가 선택 상태 업데이트
+                state[fieldName + 'Country'] = country;
+
+                // 활성 상태 표시
+                countryListEl.querySelectorAll('.country-item').forEach(ci => ci.classList.remove('active'));
+                item.classList.add('active');
+
+                // 해당 국가 공항 목록 렌더링
+                renderAirportList(dropdown, country);
+
+                // 검색 입력 초기화 및 포커스
+                const searchInput = dropdown.querySelector('.airport-search');
+                if (searchInput) {
+                    searchInput.value = '';
+                    searchInput.focus();
+                }
+            });
+        });
+    }
+
+    // 선택된 국가 하이라이트
+    function highlightCountry(dropdown, country) {
+        const countryListEl = dropdown.querySelector('[data-country-list]');
+        if (!countryListEl) return;
+
+        countryListEl.querySelectorAll('.country-item').forEach(item => {
+            if (item.dataset.country === country) {
+                item.classList.add('active');
+            } else {
+                item.classList.remove('active');
+            }
+        });
+    }
+
+    // 공항 패널 초기화 (안내 메시지 표시)
+    function resetAirportPanel(dropdown) {
+        const airportListEl = dropdown.querySelector('[data-airport-list]');
+        if (!airportListEl) return;
+
+        airportListEl.innerHTML = `
+            <div class="select-country-hint">
+                <i data-lucide="map-pin"></i>
+                <span>좌측에서 국가를<br>먼저 선택해주세요</span>
+            </div>
+        `;
+        if (typeof lucide !== 'undefined') lucide.createIcons();
+    }
+
+    // 공항 목록 렌더링 (선택된 국가의 공항만)
+    function renderAirportList(dropdown, country) {
+        const airportListEl = dropdown.querySelector('[data-airport-list]');
+        if (!airportListEl) return;
+
+        const airports = groupedByCountry[country] || [];
 
         if (airports.length === 0) {
-            ul.innerHTML = '<li class="p-3 text-sm text-slate-500">결과 없음</li>';
+            airportListEl.innerHTML = '<div class="no-results">공항이 없습니다</div>';
             return;
         }
 
-        // Group by country
-        const grouped = airports.reduce((acc, a) => {
-            const country = a.country || '기타';
-            if (!acc[country]) acc[country] = [];
-            acc[country].push(a);
-            return acc;
-        }, {});
+        airportListEl.innerHTML = airports.map(a => `
+            <div class="airport-item" data-code="${a.airportId}" data-name="${a.city}" data-country="${country}">
+                <div>
+                    <span class="city-name">${a.city}</span>
+                    <span class="airport-code">${a.airportId}</span>
+                </div>
+                ${a.name ? `<div class="airport-name">${a.name}</div>` : ''}
+            </div>
+        `).join('');
+    }
 
-        ul.innerHTML = Object.entries(grouped).map(([country, list]) => `
-            <li class="country-group">
-                <div class="px-3 py-1 text-xs font-semibold text-slate-400 bg-slate-50">${country}</div>
-                <ul>
-                    ${list.map(a => `
-                        <li class="airport-item px-3 py-2 hover:bg-blue-50 cursor-pointer text-sm"
-                            data-code="${a.airportId}" data-name="${a.city}">
-                            ${a.city} (${a.airportId})
-                        </li>
-                    `).join('')}
-                </ul>
-            </li>
+    // 공항 목록 필터링 (검색어)
+    function filterAirportList(dropdown, country, query) {
+        const airportListEl = dropdown.querySelector('[data-airport-list]');
+        if (!airportListEl) return;
+
+        const airports = groupedByCountry[country] || [];
+        const filtered = airports.filter(a =>
+            a.city.toLowerCase().includes(query) ||
+            a.airportId.toLowerCase().includes(query) ||
+            (a.name && a.name.toLowerCase().includes(query))
+        );
+
+        if (filtered.length === 0) {
+            airportListEl.innerHTML = '<div class="no-results">검색 결과가 없습니다</div>';
+            return;
+        }
+
+        airportListEl.innerHTML = filtered.map(a => `
+            <div class="airport-item" data-code="${a.airportId}" data-name="${a.city}" data-country="${country}">
+                <div>
+                    <span class="city-name">${a.city}</span>
+                    <span class="airport-code">${a.airportId}</span>
+                </div>
+                ${a.name ? `<div class="airport-name">${a.name}</div>` : ''}
+            </div>
         `).join('');
     }
 
@@ -248,32 +364,43 @@ document.addEventListener('DOMContentLoaded', function() {
         const dd = document.querySelector(`.filter-dropdown[data-field="${fieldName}"]`);
         if (!dd) return;
 
-        const searchInput = dd.querySelector('.dropdown-search');
-        const ul = dd.querySelector('[data-list]');
+        const searchInput = dd.querySelector('.airport-search');
+        const airportListEl = dd.querySelector('[data-airport-list]');
 
-        // Search filtering
-        searchInput.addEventListener('input', () => {
-            const query = searchInput.value.toLowerCase().trim();
-            const filtered = allAirports.filter(a =>
-                a.city.toLowerCase().includes(query) ||
-                a.airportId.toLowerCase().includes(query) ||
-                (a.country && a.country.toLowerCase().includes(query))
-            );
-            renderAirportList(dd, filtered);
-        });
+        // 검색 필터링
+        if (searchInput) {
+            searchInput.addEventListener('input', () => {
+                const query = searchInput.value.toLowerCase().trim();
+                const selectedCountry = state[fieldName + 'Country'];
 
-        // Selection
-        ul.addEventListener('click', (e) => {
-            const item = e.target.closest('.airport-item');
-            if (!item) return;
+                if (!selectedCountry) return;
 
-            const code = item.dataset.code;
-            const name = item.dataset.name;
+                if (query === '') {
+                    renderAirportList(dd, selectedCountry);
+                } else {
+                    filterAirportList(dd, selectedCountry, query);
+                }
+            });
+        }
 
-            state[fieldName] = { code, name };
-            dd.querySelector('[data-value]').textContent = `${name} (${code})`;
-            dd.classList.remove('open');
-        });
+        // 공항 선택
+        if (airportListEl) {
+            airportListEl.addEventListener('click', (e) => {
+                const item = e.target.closest('.airport-item');
+                if (!item) return;
+
+                const code = item.dataset.code;
+                const name = item.dataset.name;
+
+                state[fieldName] = { code, name };
+                const valueEl = dd.querySelector('[data-value]');
+                valueEl.textContent = `${name} (${code})`;
+                valueEl.classList.add('selected');
+                dd.classList.remove('open');
+
+                // 선택 후 국가 상태 유지 (다음에 열 때 같은 국가 표시)
+            });
+        }
     }
 
     // --- Data Fetching ---
@@ -283,6 +410,15 @@ document.addEventListener('DOMContentLoaded', function() {
             const json = await res.json();
             if (json.success) {
                 allAirports = json.data;
+
+                // 국가별 그룹화
+                groupedByCountry = allAirports.reduce((acc, a) => {
+                    const country = a.country || '기타';
+                    if (!acc[country]) acc[country] = [];
+                    acc[country].push(a);
+                    return acc;
+                }, {});
+
                 initDropdowns();
                 setupAirportDropdown('from');
                 setupAirportDropdown('to');
@@ -672,7 +808,35 @@ document.addEventListener('DOMContentLoaded', function() {
         }
     });
 
-    flightFilterSearchBtn.addEventListener('click', () => fetchFlights(1));
+    if (flightFilterSearchBtn) {
+        flightFilterSearchBtn.addEventListener('click', () => fetchFlights(1));
+    }
+
+    // 필터 초기화
+    const resetFiltersBtn = document.getElementById('reset-filters-btn');
+    if (resetFiltersBtn) {
+        resetFiltersBtn.addEventListener('click', () => {
+            // 상태 초기화
+            state.from = null;
+            state.to = null;
+            state.fromCountry = null;
+            state.toCountry = null;
+
+            // UI 초기화
+            document.querySelectorAll('.filter-dropdown').forEach(dd => {
+                const field = dd.dataset.field;
+                const valueEl = dd.querySelector('[data-value]');
+                if (valueEl) {
+                    valueEl.textContent = field === 'from' ? '출발지 선택' : '도착지 선택';
+                    valueEl.classList.remove('selected');
+                }
+                resetAirportPanel(dd);
+            });
+
+            // 검색 실행
+            fetchFlights(1, true);
+        });
+    }
 
     // 모달 열 때 lucide 아이콘 재초기화
     const initModalIcons = () => {
@@ -687,17 +851,19 @@ document.addEventListener('DOMContentLoaded', function() {
         if (radio) radio.checked = true;
     };
 
-    addFlightBtn.addEventListener('click', () => {
-        flightForm.reset();
-        flightForm.querySelector('#flight-crud-id').value = '';
-        setRadioValue('routeType', 'DOMESTIC');
-        setRadioValue('terminalNo', '');
-        flightCrudModal.querySelector('#flight-modal-title').textContent = '새 항공편 등록';
-        flightCrudModal.classList.remove('hidden');
-        initModalIcons();
-    });
+    if (addFlightBtn) {
+        addFlightBtn.addEventListener('click', () => {
+            flightForm.reset();
+            flightForm.querySelector('#flight-crud-id').value = '';
+            setRadioValue('routeType', 'DOMESTIC');
+            setRadioValue('terminalNo', '');
+            flightCrudModal.querySelector('#flight-modal-title').textContent = '새 항공편 등록';
+            flightCrudModal.classList.remove('hidden');
+            initModalIcons();
+        });
+    }
 
-    flightListBody.addEventListener('click', e => {
+    if (flightListBody) flightListBody.addEventListener('click', e => {
         const target = e.target;
         const flightId = target.dataset.id || target.dataset.flightId;
 
@@ -742,7 +908,7 @@ document.addEventListener('DOMContentLoaded', function() {
         }
     });
 
-    promotionListBody.addEventListener('click', e => {
+    if (promotionListBody) promotionListBody.addEventListener('click', e => {
         const target = e.target.closest('.ios-toggle, .promo-delete-btn');
         if (!target) return;
 
@@ -789,7 +955,7 @@ document.addEventListener('DOMContentLoaded', function() {
         }
     });
 
-    promotionForm.addEventListener('submit', e => {
+    if (promotionForm) promotionForm.addEventListener('submit', e => {
         e.preventDefault();
         const data = Object.fromEntries(new FormData(e.target).entries());
         data.passengerCount = parseInt(data.passengerCount, 10);
@@ -810,7 +976,7 @@ document.addEventListener('DOMContentLoaded', function() {
         });
     });
 
-    flightForm.addEventListener('submit', e => {
+    if (flightForm) flightForm.addEventListener('submit', e => {
         e.preventDefault();
         const data = Object.fromEntries(new FormData(e.target).entries());
         const flightId = data.flightId;

--- a/src/main/webapp/resources/admin/promotions.js
+++ b/src/main/webapp/resources/admin/promotions.js
@@ -778,7 +778,12 @@ document.addEventListener('DOMContentLoaded', function() {
             })
             .catch(err => {
                 console.error('Failed to update display order:', err);
-                alert('순서 변경에 실패했습니다.');
+                Swal.fire({
+                    icon: 'error',
+                    title: '순서 변경 실패',
+                    text: '순서 변경에 실패했습니다.',
+                    confirmButtonText: '확인'
+                });
                 fetchPromotions(true); // 실패 시 다시 로드
             });
     }
@@ -845,6 +850,77 @@ document.addEventListener('DOMContentLoaded', function() {
         }
     };
 
+    // --- 인원수 스테퍼 ---
+    const passengerInput = document.getElementById('passengerCount');
+    const passengerMinus = document.getElementById('passenger-minus');
+    const passengerPlus = document.getElementById('passenger-plus');
+
+    if (passengerMinus && passengerPlus && passengerInput) {
+        passengerMinus.addEventListener('click', () => {
+            const val = parseInt(passengerInput.value, 10);
+            if (val > 1) passengerInput.value = val - 1;
+        });
+
+        passengerPlus.addEventListener('click', () => {
+            const val = parseInt(passengerInput.value, 10);
+            if (val < 10) passengerInput.value = val + 1;
+        });
+
+        // 빠른 선택 칩
+        document.querySelectorAll('.passenger-chip').forEach(chip => {
+            chip.addEventListener('click', () => {
+                passengerInput.value = chip.dataset.passenger;
+            });
+        });
+    }
+
+    // --- 할인율 버튼 ---
+    const discountInput = document.getElementById('discountPercentage');
+    const discountCustom = document.getElementById('discountCustom');
+    const discountBtns = document.querySelectorAll('.discount-btn');
+
+    const updateDiscountButtons = (activeValue) => {
+        discountBtns.forEach(btn => {
+            const val = btn.dataset.discount;
+            if (val === String(activeValue)) {
+                btn.classList.add('active');
+                btn.classList.remove('bg-white/5', 'border-white/10', 'text-glass-secondary');
+                btn.classList.add('bg-blue-500/20', 'border-blue-500/40', 'text-blue-400');
+            } else {
+                btn.classList.remove('active');
+                btn.classList.remove('bg-blue-500/20', 'border-blue-500/40', 'text-blue-400');
+                btn.classList.add('bg-white/5', 'border-white/10');
+                // 30%, 50%는 특별 색상 유지
+                if (val === '30') {
+                    btn.classList.add('text-amber-400');
+                } else if (val === '50') {
+                    btn.classList.add('text-rose-400');
+                } else {
+                    btn.classList.add('text-glass-secondary');
+                }
+            }
+        });
+    };
+
+    discountBtns.forEach(btn => {
+        btn.addEventListener('click', () => {
+            const val = btn.dataset.discount;
+            discountInput.value = val;
+            if (discountCustom) discountCustom.value = '';
+            updateDiscountButtons(val);
+        });
+    });
+
+    if (discountCustom) {
+        discountCustom.addEventListener('input', () => {
+            const val = discountCustom.value;
+            if (val && val >= 1 && val <= 99) {
+                discountInput.value = val;
+                updateDiscountButtons(null); // 모든 버튼 비활성화
+            }
+        });
+    }
+
     // 라디오 버튼 값 설정 헬퍼
     const setRadioValue = (name, value) => {
         const radio = flightForm.querySelector(`input[name="${name}"][value="${value || ''}"]`);
@@ -871,6 +947,11 @@ document.addEventListener('DOMContentLoaded', function() {
             promotionForm.reset();
             promotionForm.querySelector('#flightId').value = target.dataset.flightId;
             promotionModal.querySelector('#modal-flight-info').textContent = target.dataset.flightInfo;
+            // 인원수, 할인율 초기화
+            if (passengerInput) passengerInput.value = 1;
+            if (discountInput) discountInput.value = 10;
+            if (discountCustom) discountCustom.value = '';
+            updateDiscountButtons(10);
             promotionModal.classList.remove('hidden');
             initModalIcons();
         } else if (target.classList.contains('edit-flight-btn')) {
@@ -890,21 +971,46 @@ document.addEventListener('DOMContentLoaded', function() {
                     flightCrudModal.classList.remove('hidden');
                     initModalIcons();
                 } else {
-                    alert('항공편 정보 로딩 실패: ' + res.message);
+                    Swal.fire({
+                        icon: 'error',
+                        title: '로딩 실패',
+                        text: res.message,
+                        confirmButtonText: '확인'
+                    });
                 }
             });
         } else if (target.classList.contains('delete-flight-btn')) {
-            if (confirm('정말 이 항공편을 삭제하시겠습니까?')) {
-                fetch(`${window.CONTEXT_PATH}/admin/api/flights/${flightId}`, { method: 'DELETE' }).then(res => res.json()).then(res => {
-                    if (res.success) {
-                        alert('항공편이 삭제되었습니다.');
-                        fetchFlights(pagination.currentPage, true);
-                        fetchPromotions(true);
-                    } else {
-                        alert('항공편 삭제 실패: ' + res.message);
-                    }
-                });
-            }
+            Swal.fire({
+                icon: 'warning',
+                title: '항공편 삭제',
+                text: '정말 이 항공편을 삭제하시겠습니까?',
+                showCancelButton: true,
+                confirmButtonText: '삭제',
+                cancelButtonText: '취소',
+                confirmButtonColor: '#ef4444'
+            }).then((result) => {
+                if (result.isConfirmed) {
+                    fetch(`${window.CONTEXT_PATH}/admin/api/flights/${flightId}`, { method: 'DELETE' }).then(res => res.json()).then(res => {
+                        if (res.success) {
+                            Swal.fire({
+                                icon: 'success',
+                                title: '삭제 완료',
+                                text: '항공편이 삭제되었습니다.',
+                                confirmButtonText: '확인'
+                            });
+                            fetchFlights(pagination.currentPage, true);
+                            fetchPromotions(true);
+                        } else {
+                            Swal.fire({
+                                icon: 'error',
+                                title: '삭제 실패',
+                                text: res.message,
+                                confirmButtonText: '확인'
+                            });
+                        }
+                    });
+                }
+            });
         }
     });
 
@@ -930,7 +1036,12 @@ document.addEventListener('DOMContentLoaded', function() {
                 .then(res => {
                     if (!res.success) {
                         // 실패 시 롤백
-                        alert('상태 변경 실패: ' + res.message);
+                        Swal.fire({
+                            icon: 'error',
+                            title: '상태 변경 실패',
+                            text: res.message,
+                            confirmButtonText: '확인'
+                        });
                         fetchPromotions(true);
                     }
                 })
@@ -942,16 +1053,36 @@ document.addEventListener('DOMContentLoaded', function() {
 
         // 삭제 버튼 클릭
         if (target.classList.contains('promo-delete-btn')) {
-            if (confirm('정말 이 특가 상품을 삭제하시겠습니까?')) {
-                fetch(`${window.CONTEXT_PATH}/admin/promotions/api/${id}`, { method: 'DELETE' }).then(res => res.json()).then(res => {
-                    if (res.success) {
-                        alert('삭제되었습니다.');
-                        fetchPromotions(true);
-                    } else {
-                        alert('삭제 실패: ' + res.message);
-                    }
-                });
-            }
+            Swal.fire({
+                icon: 'warning',
+                title: '특가 상품 삭제',
+                text: '정말 이 특가 상품을 삭제하시겠습니까?',
+                showCancelButton: true,
+                confirmButtonText: '삭제',
+                cancelButtonText: '취소',
+                confirmButtonColor: '#ef4444'
+            }).then((result) => {
+                if (result.isConfirmed) {
+                    fetch(`${window.CONTEXT_PATH}/admin/promotions/api/${id}`, { method: 'DELETE' }).then(res => res.json()).then(res => {
+                        if (res.success) {
+                            Swal.fire({
+                                icon: 'success',
+                                title: '삭제 완료',
+                                text: '특가 상품이 삭제되었습니다.',
+                                confirmButtonText: '확인'
+                            });
+                            fetchPromotions(true);
+                        } else {
+                            Swal.fire({
+                                icon: 'error',
+                                title: '삭제 실패',
+                                text: res.message,
+                                confirmButtonText: '확인'
+                            });
+                        }
+                    });
+                }
+            });
         }
     });
 
@@ -967,11 +1098,21 @@ document.addEventListener('DOMContentLoaded', function() {
             body: JSON.stringify(data)
         }).then(res => res.json()).then(res => {
             if (res.success) {
-                alert('특가 상품이 생성되었습니다.');
+                Swal.fire({
+                    icon: 'success',
+                    title: '생성 완료',
+                    text: '특가 상품이 생성되었습니다.',
+                    confirmButtonText: '확인'
+                });
                 promotionModal.classList.add('hidden');
                 fetchPromotions(true);
             } else {
-                alert('생성 실패: ' + res.message);
+                Swal.fire({
+                    icon: 'error',
+                    title: '생성 실패',
+                    text: res.message,
+                    confirmButtonText: '확인'
+                });
             }
         });
     });
@@ -989,11 +1130,21 @@ document.addEventListener('DOMContentLoaded', function() {
             body: JSON.stringify(data)
         }).then(res => res.json()).then(res => {
             if (res.success) {
-                alert('항공편이 저장되었습니다.');
+                Swal.fire({
+                    icon: 'success',
+                    title: '저장 완료',
+                    text: '항공편이 저장되었습니다.',
+                    confirmButtonText: '확인'
+                });
                 flightCrudModal.classList.add('hidden');
                 fetchFlights(pagination.currentPage, true);
             } else {
-                alert('저장 실패: ' + res.message);
+                Swal.fire({
+                    icon: 'error',
+                    title: '저장 실패',
+                    text: res.message,
+                    confirmButtonText: '확인'
+                });
             }
         });
     });

--- a/src/main/webapp/resources/admin/users.js
+++ b/src/main/webapp/resources/admin/users.js
@@ -21,7 +21,7 @@ document.addEventListener('DOMContentLoaded', function() {
     const pageSize = 10;
     let currentFilterStatus = 'ACTIVE'; // 기본값: 활성 회원만 표시
     let currentSearchKeyword = '';
-    let currentViewMode = 'card'; // 'card' or 'list'
+    let currentViewMode = 'list'; // 기본값: 리스트 형태
 
     const elements = {
         stats: {
@@ -46,6 +46,21 @@ document.addEventListener('DOMContentLoaded', function() {
 
     // 초기 필터 상태 설정 (활성 회원)
     elements.filterStatus.value = 'ACTIVE';
+
+    // 초기 보기 형태 설정 (리스트)
+    elements.userCardGrid.classList.add('hidden');
+    elements.userListTable.classList.remove('hidden');
+    if (elements.viewToggle) {
+        elements.viewToggle.setAttribute('data-active', '1');
+        var viewBtns = elements.viewToggle.querySelectorAll('.ios-segment-btn');
+        viewBtns.forEach(function(btn) {
+            if (btn.getAttribute('data-view') === 'list') {
+                btn.classList.add('active');
+            } else {
+                btn.classList.remove('active');
+            }
+        });
+    }
 
     // 초기 데이터 로딩
     fetchUserStats();

--- a/src/main/webapp/resources/admin/users.js
+++ b/src/main/webapp/resources/admin/users.js
@@ -19,7 +19,7 @@ document.addEventListener('DOMContentLoaded', function() {
 
     let currentPage = 1;
     const pageSize = 10;
-    let currentFilterStatus = '';
+    let currentFilterStatus = 'ACTIVE'; // 기본값: 활성 회원만 표시
     let currentSearchKeyword = '';
     let currentViewMode = 'card'; // 'card' or 'list'
 
@@ -43,6 +43,9 @@ document.addEventListener('DOMContentLoaded', function() {
         modalContent: document.getElementById('modal-content'),
         closeModalBtn: document.getElementById('close-modal-btn')
     };
+
+    // 초기 필터 상태 설정 (활성 회원)
+    elements.filterStatus.value = 'ACTIVE';
 
     // 초기 데이터 로딩
     fetchUserStats();
@@ -251,7 +254,14 @@ document.addEventListener('DOMContentLoaded', function() {
 
         users.forEach(function(user) {
             const card = document.createElement('div');
-            card.className = 'user-card glass-card p-5 hover:border-white/20 transition-all duration-300';
+            const isBlocked = user.status === 'BLOCKED';
+            const isWithdrawn = user.status === 'WITHDRAWN';
+
+            let cardExtraClass = '';
+            if (isBlocked) cardExtraClass = ' border-red-500/30 bg-red-500/5';
+            else if (isWithdrawn) cardExtraClass = ' border-white/5 bg-white/3 opacity-60';
+
+            card.className = 'user-card glass-card p-5 hover:border-white/20 transition-all duration-300' + cardExtraClass;
 
             const initial = escapeHtml(getInitial(user.displayName || user.email));
             const displayName = escapeHtml(user.displayName || '-');
@@ -262,16 +272,38 @@ document.addEventListener('DOMContentLoaded', function() {
             const createdAt = formatDate(user.createdAt);
             const userId = escapeHtml(user.userId);
 
+            // 아바타 스타일
+            let avatarClass = 'bg-gradient-to-br from-blue-500 to-blue-600 shadow-blue-500/30';
+            if (isBlocked) avatarClass = 'bg-gradient-to-br from-red-500 to-red-600 shadow-red-500/30';
+            else if (isWithdrawn) avatarClass = 'bg-gradient-to-br from-gray-500 to-gray-600 shadow-gray-500/30';
+
+            // 이름 색상
+            let nameClass = 'text-glass-primary';
+            if (isBlocked) nameClass = 'text-red-300';
+            else if (isWithdrawn) nameClass = 'text-gray-400 line-through';
+
+            // 상단 바 표시
+            let topBar = '';
+            if (isBlocked) topBar = '<div class="absolute top-0 left-0 right-0 h-1 bg-gradient-to-r from-red-500 to-red-400"></div>';
+            else if (isWithdrawn) topBar = '<div class="absolute top-0 left-0 right-0 h-1 bg-gradient-to-r from-gray-500 to-gray-400"></div>';
+
+            // 상태 아이콘
+            let statusIcon = '';
+            if (isBlocked) statusIcon = '<i data-lucide="ban" class="w-3 h-3"></i>';
+            else if (isWithdrawn) statusIcon = '<i data-lucide="user-x" class="w-3 h-3"></i>';
+
             card.innerHTML = `
+                ${topBar}
                 <div class="flex items-start justify-between mb-4">
                     <div class="flex items-center gap-3">
-                        <div class="w-10 h-10 flex-shrink-0 rounded-full bg-gradient-to-br from-blue-500 to-blue-600 flex items-center justify-center text-white font-bold text-sm shadow-lg shadow-blue-500/30">${initial}</div>
+                        <div class="w-10 h-10 flex-shrink-0 rounded-full ${avatarClass} flex items-center justify-center text-white font-bold text-sm shadow-lg">${initial}</div>
                         <div class="min-w-0">
-                            <p class="font-semibold text-glass-primary truncate">${displayName}</p>
+                            <p class="font-semibold ${nameClass} truncate">${displayName}</p>
                             <p class="text-xs text-glass-muted truncate">${email}</p>
                         </div>
                     </div>
-                    <span class="flex-shrink-0 inline-flex items-center gap-1 px-2.5 py-1 text-xs font-semibold rounded-full ${getStatusBadgeClassGlass(user.status)}">
+                    <span class="flex-shrink-0 inline-flex items-center gap-1.5 px-2.5 py-1 text-xs font-semibold rounded-full ${getStatusBadgeClassGlass(user.status)}">
+                        ${statusIcon}
                         ${escapeHtml(user.statusDisplayName)}
                     </span>
                 </div>
@@ -291,18 +323,18 @@ document.addEventListener('DOMContentLoaded', function() {
                         <span class="text-xs">${createdAt}</span>
                     </div>
                 </div>
-                <div class="mt-4 pt-4 border-t border-white/10 flex justify-end gap-2">
-                    <button data-action="detail" data-user-id="${userId}" class="p-2 hover:bg-white/10 rounded-lg transition-colors" title="상세보기">
-                        <i data-lucide="eye" class="w-4 h-4 text-glass-secondary pointer-events-none"></i>
-                    </button>
+                ${user.status === 'ACTIVE' || user.status === 'BLOCKED' ? `
+                <div class="mt-4 pt-4 border-t border-white/10 flex justify-end">
                     ${user.status === 'ACTIVE' ? `
-                    <button data-action="block" data-user-id="${userId}" class="p-2 hover:bg-red-500/20 rounded-lg transition-colors" title="차단하기">
-                        <i data-lucide="ban" class="w-4 h-4 text-red-400 pointer-events-none"></i>
-                    </button>` : user.status === 'BLOCKED' ? `
-                    <button data-action="unblock" data-user-id="${userId}" class="p-2 hover:bg-green-500/20 rounded-lg transition-colors" title="차단해제">
-                        <i data-lucide="check-circle" class="w-4 h-4 text-green-400 pointer-events-none"></i>
-                    </button>` : ''}
-                </div>
+                    <button data-action="block" data-user-id="${userId}" class="px-4 py-2 text-xs font-medium rounded-lg bg-red-500/10 border border-red-500/30 text-red-400 hover:bg-red-500/20 transition-all flex items-center gap-2">
+                        <i data-lucide="ban" class="w-4 h-4 pointer-events-none"></i>
+                        <span class="pointer-events-none">차단하기</span>
+                    </button>` : `
+                    <button data-action="unblock" data-user-id="${userId}" class="px-4 py-2 text-xs font-medium rounded-lg bg-emerald-500/10 border border-emerald-500/30 text-emerald-400 hover:bg-emerald-500/20 transition-all flex items-center gap-2">
+                        <i data-lucide="shield-check" class="w-4 h-4 pointer-events-none"></i>
+                        <span class="pointer-events-none">차단 해제</span>
+                    </button>`}
+                </div>` : ''}
             `;
 
             elements.userCardGrid.appendChild(card);
@@ -326,23 +358,46 @@ document.addEventListener('DOMContentLoaded', function() {
 
         users.forEach(function(user) {
             const row = document.createElement('tr');
-            row.className = 'hover:bg-white/5 transition-colors';
+            const isBlocked = user.status === 'BLOCKED';
+            const isWithdrawn = user.status === 'WITHDRAWN';
+
+            let rowClass = 'hover:bg-white/5 transition-colors';
+            if (isBlocked) rowClass = 'bg-red-500/5 hover:bg-red-500/10 transition-colors border-l-2 border-red-500';
+            else if (isWithdrawn) rowClass = 'bg-white/2 hover:bg-white/5 transition-colors opacity-50 border-l-2 border-gray-500';
+
+            row.className = rowClass;
 
             const initial = escapeHtml(getInitial(user.displayName || user.email));
             const displayName = escapeHtml(user.displayName || '-');
             const email = escapeHtml(user.email);
             const providerBadge = `<span class="px-2 py-1 text-xs font-medium rounded-full ${getProviderBadgeClassGlass(user.provider)}">${escapeHtml(getProviderDisplayName(user.provider))}</span>`;
             const reservationCount = formatNumber(user.reservationCount) + '건';
-            const statusBadge = `<span class="px-2 py-1 text-xs font-medium rounded-full ${getStatusBadgeClassGlass(user.status)}">${escapeHtml(user.statusDisplayName)}</span>`;
             const createdAt = formatDate(user.createdAt);
             const userId = escapeHtml(user.userId);
+
+            // 아바타 스타일
+            let avatarClass = 'bg-gradient-to-br from-blue-500 to-purple-500';
+            if (isBlocked) avatarClass = 'bg-gradient-to-br from-red-500 to-red-600';
+            else if (isWithdrawn) avatarClass = 'bg-gradient-to-br from-gray-500 to-gray-600';
+
+            // 이름 색상
+            let nameClass = 'font-medium text-glass-primary text-sm';
+            if (isBlocked) nameClass = 'font-medium text-red-300 text-sm';
+            else if (isWithdrawn) nameClass = 'font-medium text-gray-400 text-sm line-through';
+
+            // 상태 뱃지 (아이콘 포함)
+            let statusIcon = '';
+            if (isBlocked) statusIcon = '<i data-lucide="ban" class="w-3 h-3 inline-block mr-1"></i>';
+            else if (isWithdrawn) statusIcon = '<i data-lucide="user-x" class="w-3 h-3 inline-block mr-1"></i>';
+
+            const statusBadge = `<span class="px-2 py-1 text-xs font-medium rounded-full inline-flex items-center ${getStatusBadgeClassGlass(user.status)}">${statusIcon}${escapeHtml(user.statusDisplayName)}</span>`;
 
             row.innerHTML = `
                 <td class="px-4 py-4">
                     <div class="flex items-center gap-3">
-                        <div class="w-8 h-8 bg-gradient-to-br from-blue-500 to-purple-500 rounded-full flex items-center justify-center text-white font-bold text-xs">${initial}</div>
+                        <div class="w-8 h-8 ${avatarClass} rounded-full flex items-center justify-center text-white font-bold text-xs">${initial}</div>
                         <div>
-                            <p class="font-medium text-glass-primary text-sm">${displayName}</p>
+                            <p class="${nameClass}">${displayName}</p>
                             <p class="text-xs text-glass-muted">${email}</p>
                         </div>
                     </div>
@@ -352,17 +407,17 @@ document.addEventListener('DOMContentLoaded', function() {
                 <td class="px-4 py-4 text-sm">${statusBadge}</td>
                 <td class="px-4 py-4 text-sm text-glass-secondary">${createdAt}</td>
                 <td class="px-4 py-4">
-                    <div class="flex items-center justify-center gap-2">
-                        <button data-action="detail" data-user-id="${userId}" class="p-2 hover:bg-white/10 rounded-lg transition-colors" title="상세보기">
-                            <i data-lucide="eye" class="w-4 h-4 text-glass-secondary pointer-events-none"></i>
-                        </button>
+                    <div class="flex items-center justify-center">
                         ${user.status === 'ACTIVE' ? `
-                        <button data-action="block" data-user-id="${userId}" class="p-2 hover:bg-red-500/20 rounded-lg transition-colors" title="차단하기">
-                            <i data-lucide="ban" class="w-4 h-4 text-red-400 pointer-events-none"></i>
+                        <button data-action="block" data-user-id="${userId}" class="px-4 py-2 text-xs font-medium rounded-lg bg-red-500/10 border border-red-500/30 text-red-400 hover:bg-red-500/20 transition-all flex items-center gap-2">
+                            <i data-lucide="ban" class="w-4 h-4 pointer-events-none"></i>
+                            <span class="pointer-events-none">차단하기</span>
                         </button>` : user.status === 'BLOCKED' ? `
-                        <button data-action="unblock" data-user-id="${userId}" class="p-2 hover:bg-green-500/20 rounded-lg transition-colors" title="차단해제">
-                            <i data-lucide="check-circle" class="w-4 h-4 text-green-400 pointer-events-none"></i>
-                        </button>` : ''}
+                        <button data-action="unblock" data-user-id="${userId}" class="px-4 py-2 text-xs font-medium rounded-lg bg-emerald-500/10 border border-emerald-500/30 text-emerald-400 hover:bg-emerald-500/20 transition-all flex items-center gap-2">
+                            <i data-lucide="shield-check" class="w-4 h-4 pointer-events-none"></i>
+                            <span class="pointer-events-none">차단 해제</span>
+                        </button>` : `
+                        <span class="text-xs text-glass-muted">-</span>`}
                     </div>
                 </td>
             `;
@@ -451,43 +506,79 @@ document.addEventListener('DOMContentLoaded', function() {
                     renderUserDetailModal(data.data);
                     elements.modal.classList.remove('hidden');
                 } else {
-                    alert('회원 정보를 불러오는데 실패했습니다.');
+                    Swal.fire({
+                        icon: 'error',
+                        title: '조회 실패',
+                        text: '회원 정보를 불러오는데 실패했습니다.',
+                        confirmButtonText: '확인'
+                    });
                 }
             })
             .catch(function(error) {
                 console.error('Error fetching user detail:', error);
-                alert('회원 정보를 불러오는 중 오류가 발생했습니다.');
+                Swal.fire({
+                    icon: 'error',
+                    title: '오류 발생',
+                    text: '회원 정보를 불러오는 중 오류가 발생했습니다.',
+                    confirmButtonText: '확인'
+                });
             });
     }
 
     function changeUserStatus(userId, newStatus) {
         var statusText = newStatus === 'BLOCKED' ? '차단' : '차단해제';
-        if (!confirm('해당 회원을 ' + statusText + '하시겠습니까?')) {
-            return;
-        }
+        var iconType = newStatus === 'BLOCKED' ? 'warning' : 'question';
+        var confirmColor = newStatus === 'BLOCKED' ? '#ef4444' : '#22c55e';
 
-        // [보안 수정] encodeURIComponent 적용
-        fetch(window.CONTEXT_PATH + '/admin/users/api/' + encodeURIComponent(userId) + '/status', {
-            method: 'PUT',
-            headers: {
-                'Content-Type': 'application/json'
-            },
-            body: JSON.stringify({ status: newStatus })
-        })
-            .then(function(response) { return response.json(); })
-            .then(function(data) {
-                if (data.success) {
-                    alert('회원 상태가 변경되었습니다.');
-                    fetchUserStats();
-                    fetchUserList();
-                } else {
-                    alert('상태 변경에 실패했습니다: ' + (data.message || '알 수 없는 오류'));
-                }
-            })
-            .catch(function(error) {
-                console.error('Error changing user status:', error);
-                alert('상태 변경 중 오류가 발생했습니다.');
-            });
+        Swal.fire({
+            icon: iconType,
+            title: '회원 ' + statusText,
+            text: '해당 회원을 ' + statusText + '하시겠습니까?',
+            showCancelButton: true,
+            confirmButtonText: statusText,
+            cancelButtonText: '취소',
+            confirmButtonColor: confirmColor
+        }).then(function(result) {
+            if (result.isConfirmed) {
+                // [보안 수정] encodeURIComponent 적용
+                fetch(window.CONTEXT_PATH + '/admin/users/api/' + encodeURIComponent(userId) + '/status', {
+                    method: 'PUT',
+                    headers: {
+                        'Content-Type': 'application/json'
+                    },
+                    body: JSON.stringify({ status: newStatus })
+                })
+                    .then(function(response) { return response.json(); })
+                    .then(function(data) {
+                        if (data.success) {
+                            Swal.fire({
+                                icon: 'success',
+                                title: statusText + ' 완료',
+                                text: '회원 상태가 변경되었습니다.',
+                                confirmButtonText: '확인'
+                            });
+                            fetchUserStats();
+                            fetchUserList();
+                        } else {
+                            Swal.fire({
+                                icon: 'error',
+                                title: statusText + ' 실패',
+                                text: data.message || '알 수 없는 오류가 발생했습니다.',
+                                confirmButtonText: '확인'
+                            });
+                        }
+                    })
+                    .catch(function(error) {
+                        console.error('Error changing user status:', error);
+                        Swal.fire({
+                            icon: 'error',
+                            title: '오류 발생',
+                            text: '상태 변경 중 오류가 발생했습니다.',
+                            confirmButtonText: '확인'
+                        });
+                    });
+            }
+        });
     }
 
     function renderUserDetailModal(user) {
@@ -546,12 +637,12 @@ document.addEventListener('DOMContentLoaded', function() {
                 '<div class="pt-4 border-t border-white/10">' +
                 (user.status === 'ACTIVE' ?
                     // 차단하기: data-action="block"
-                    '<button data-action="block" data-user-id="' + escapeHtml(user.userId) + '" class="w-full px-4 py-2 bg-red-500/80 text-white rounded-lg hover:bg-red-500 transition-colors">' +
-                    '<i data-lucide="ban" class="w-4 h-4 inline-block mr-2"></i>차단하기' +
+                    '<button data-action="block" data-user-id="' + escapeHtml(user.userId) + '" class="w-full px-4 py-2.5 bg-red-500/20 border border-red-500/40 text-red-400 rounded-lg hover:bg-red-500/30 transition-all font-medium flex items-center justify-center gap-2">' +
+                    '<i data-lucide="ban" class="w-4 h-4"></i>회원 차단하기' +
                     '</button>' :
                     // 차단해제: data-action="unblock"
-                    '<button data-action="unblock" data-user-id="' + escapeHtml(user.userId) + '" class="w-full px-4 py-2 bg-green-500/80 text-white rounded-lg hover:bg-green-500 transition-colors">' +
-                    '<i data-lucide="check-circle" class="w-4 h-4 inline-block mr-2"></i>차단해제' +
+                    '<button data-action="unblock" data-user-id="' + escapeHtml(user.userId) + '" class="w-full px-4 py-2.5 bg-emerald-500/20 border border-emerald-500/40 text-emerald-400 rounded-lg hover:bg-emerald-500/30 transition-all font-medium flex items-center justify-center gap-2">' +
+                    '<i data-lucide="shield-check" class="w-4 h-4"></i>차단 해제하기' +
                     '</button>') +
                 '</div>' : '') +
             '</div>';

--- a/src/main/webapp/resources/auth/home.css
+++ b/src/main/webapp/resources/auth/home.css
@@ -1,0 +1,141 @@
+/* 카드 */
+.card {
+    background: #ffffff;
+    padding: 42px 40px;
+    border-radius: 16px;
+    width: 420px;
+    max-width: 100%;
+    box-shadow: 0 20px 40px rgba(0, 0, 0, 0.08),
+    0 2px 8px rgba(0, 0, 0, 0.05);
+    text-align: center;
+}
+
+/* 버튼 그룹 */
+.button-group {
+    display: flex;
+    flex-direction: column;
+    gap: 14px;
+}
+
+/* 버튼 공통 */
+.btn {
+    width: 100%;
+    padding: 14px 0;
+    border-radius: 10px;
+    border: none;
+    font-size: 15px;
+    font-weight: 700;
+    cursor: pointer;
+    transition: all 0.25s ease;
+}
+
+/* 로그인 */
+.btn-login {
+    background: linear-gradient(135deg, #007bff, #3399ff);
+    color: #fff;
+}
+
+/* 회원가입 */
+.btn-signup {
+    background: #ffffff;
+    color: #007bff;
+    border: 1px solid #d0e3ff;
+}
+
+.btn-signup:hover {
+    background: #f0f6ff;
+}
+
+/* 구분선 */
+.divider {
+    height: 1px;
+    margin: 18px 0;
+    background: linear-gradient(
+            to right,
+            transparent,
+            #e5e7eb,
+            transparent
+    );
+}
+
+/* 마이페이지 */
+.btn-mypage {
+    background: linear-gradient(135deg, #f8fafc, #eef2f7);
+    color: #374151;
+    border: 1px solid #e5e7eb;
+}
+
+.btn-mypage:hover {
+    background: #f1f5f9;
+}
+
+/* 로그아웃 */
+.btn-logout {
+    background: #ffffff;
+    color: #007bff;
+    border: 1px solid #d0e3ff;
+    padding: 0;
+}
+.btn-logout button {
+    width: 100%;
+    height: 100%;
+    padding: 14px 0;
+}
+
+
+/* a 태그 기본 스타일 제거 */
+a {
+    text-decoration: none;
+}
+
+body {
+    margin: 0;
+    min-height: 100vh;
+    background: var(--color-bg-main);
+}
+
+button {
+    background: none;
+    border: none;
+    padding: 0;
+    margin: 0;
+    font: inherit;
+    color: inherit;
+    cursor: pointer;
+}
+
+.home-main {
+    max-width: 1100px;
+    margin: 0 auto;
+    padding: 0 20px 60px;
+    position: relative;
+    top: -80px;
+    display: flex;
+    justify-content: center;
+}
+
+.header__menu-form {
+    margin: 0;
+}
+
+.header__menu-button {
+    background: none;
+    border: none;
+    padding: 0;
+    font: inherit;
+    color: inherit;
+    cursor: pointer;
+}
+
+.header__menu-item--cta {
+    padding: 8px 16px;
+    border-radius: 999px;
+    background: var(--color-primary);
+    color: var(--color-white);
+    font-weight: var(--font-weight-semibold);
+}
+
+.header__menu-item--cta:hover {
+    color: var(--color-white);
+    opacity: 0.9;
+}

--- a/src/main/webapp/resources/auth/login.css
+++ b/src/main/webapp/resources/auth/login.css
@@ -1,0 +1,27 @@
+body { font-family: 'Malgun Gothic', sans-serif; display: flex; flex-direction: column; align-items: stretch; min-height: 100vh; background-color: #f0f2f5; margin: 0; }
+.login-container { margin: 40px auto 80px; background: white; padding: 40px; border-radius: 10px; box-shadow: 0 4px 10px rgba(0,0,0,0.1); width: 350px; max-width: 90%; }
+.login-container h2 { text-align: center; color: #333; margin-bottom: 30px; }
+
+.form-group { margin-bottom: 15px; }
+.form-group label { display: block; margin-bottom: 5px; color: #666; font-size: 14px; }
+.form-group input { width: 100%; padding: 12px; border: 1px solid #ddd; border-radius: 5px; box-sizing: border-box; }
+
+/* 기본 로그인 버튼 */
+.btn-login { width: 100%; padding: 12px; background-color: #007bff; border: none; color: white; border-radius: 5px; cursor: pointer; font-size: 16px; margin-top: 10px; }
+.btn-login:hover { background-color: #0056b3; }
+
+/* 구분선 */
+.divider { margin: 20px 0; border-bottom: 1px solid #ddd; position: relative; text-align: center; }
+.divider span { background: white; padding: 0 10px; position: relative; top: 10px; color: #999; font-size: 12px; }
+
+/* 카카오 로그인 버튼 */
+.btn-kakao {
+    width: 100%; background-color: #FEE500; border: none; color: #3c1e1e;
+    border-radius: 5px; cursor: pointer; font-size: 16px; font-weight: bold;
+    display: flex; align-items: center; justify-content: center; text-decoration: none;
+}
+
+/* 회원가입 링크 */
+.footer-links { margin-top: 20px; text-align: center; font-size: 14px; color: #666; }
+.footer-links a { color: #007bff; text-decoration: none; }
+.footer-links a:hover { text-decoration: underline; }

--- a/src/main/webapp/resources/auth/signup.css
+++ b/src/main/webapp/resources/auth/signup.css
@@ -1,0 +1,113 @@
+body {
+    font-family: Arial, sans-serif;
+    display: flex;
+    flex-direction: column;
+    align-items: stretch;
+    min-height: 100vh;
+    background-color: #f0f2f5;
+    margin: 0;
+}
+
+.register-container {
+    align-self: center;
+    margin: 40px 0 80px;
+    background: white;
+    padding: 30px;
+    border-radius: 10px;
+    box-shadow: 0 4px 10px rgba(0,0,0,0.1);
+    width: 350px;
+}
+
+.register-container h2 {
+    text-align: center;
+    color: #333;
+}
+
+.form-group {
+    margin-bottom: 15px;
+}
+
+.form-group label {
+    display: block;
+    margin-bottom: 5px;
+    color: #666;
+}
+
+/* 기본 input */
+.form-group input {
+    width: 100%;
+    padding: 10px;
+    border: 1px solid #ddd;
+    border-radius: 5px;
+    box-sizing: border-box;
+}
+
+/* 🔹 이메일 + 버튼 row */
+.email-row {
+    display: flex;
+    gap: 8px;
+}
+
+.email-row input {
+    flex: 1;
+    width: auto; /* 기존 100% 무효화 */
+}
+
+.email-row button {
+    padding: 10px 12px;
+    white-space: nowrap;
+    background-color: #6c757d;
+    border: none;
+    color: white;
+    border-radius: 5px;
+    cursor: pointer;
+    font-size: 13px;
+}
+
+.email-row button:hover {
+    background-color: #5a6268;
+}
+
+/* 공통 submit 버튼 */
+.btn-submit {
+    width: 100%;
+    padding: 10px;
+    background-color: #007bff;
+    border: none;
+    color: white;
+    border-radius: 5px;
+    cursor: pointer;
+    font-size: 16px;
+}
+
+.btn-submit:hover {
+    background-color: #0056b3;
+}
+
+/* 인증 코드 입력 row */
+.verify-row {
+    display: flex;
+    gap: 8px;
+}
+
+.btn-inline {
+    width: auto;
+    padding: 10px 12px;
+    font-size: 14px;
+    white-space: nowrap;
+}
+
+.verify-status {
+    margin-top: 8px;
+    font-size: 0.9rem;
+}
+
+.verify-box.is-hidden {
+    display: none;
+}
+
+/* 상태 메시지  */
+.status-text {
+    margin-top: 6px;
+    font-size: 0.85rem;
+}

--- a/src/main/webapp/resources/auth/signup.js
+++ b/src/main/webapp/resources/auth/signup.js
@@ -1,0 +1,123 @@
+(function () {
+    const base = window.APP?.contextPath ?? "";
+    const emailInput = document.getElementById("email");
+    const sendBtn = document.getElementById("sendVerifyBtn");
+    const sendStatus = document.getElementById("sendStatus");
+
+    const verifyBox = document.getElementById("verifyBox");
+    const verifyBtn = document.getElementById("verifyBtn");
+    const verifyStatus = document.getElementById("verifyStatus");
+
+    const emailVerifiedHidden = document.getElementById("emailVerified");
+    const attemptIdHidden = document.getElementById("attemptId");
+    const signupForm = document.getElementById("signupForm");
+
+    function setText(el, msg, ok) {
+        el.textContent = msg || "";
+        el.style.color = ok ? "#1a7f37" : "#d1242f";
+    }
+
+    function isValidEmail(email) {
+        return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email);
+    }
+
+    emailInput.addEventListener("input", function () {
+        emailVerifiedHidden.value = "false";
+        attemptIdHidden.value = "";
+        verifyBox.classList.add("is-hidden");
+        setText(sendStatus, "", true);
+        setText(verifyStatus, "", true);
+    });
+
+    sendBtn.addEventListener("click", async function () {
+        const email = (emailInput.value || "").trim();
+        if (!isValidEmail(email)) {
+            setText(sendStatus, "올바른 이메일을 입력해 주세요.", false);
+            return;
+        }
+
+        sendBtn.disabled = true;
+        setText(sendStatus, "인증메일을 발송 중입니다...", true);
+
+        try {
+            const res = await fetch(base + "/api/auth/email/issue", {
+                method: "POST",
+                headers: {
+                    "Content-Type": "application/x-www-form-urlencoded;charset=UTF-8"
+                },
+                body: "email=" + encodeURIComponent(email)
+            });
+
+            let data = null;
+            try {
+                data = await res.json();
+                attemptIdHidden.value = data.data.attemptId;
+            } catch (e) {
+                const text = await res.text().catch(() => "");
+                data = text ? { message: text } : {};
+            }
+
+            if (!res.ok) {
+                const msg = data?.message || "인증메일 발송에 실패했습니다. 잠시 후 다시 시도해 주세요.";
+                setText(sendStatus, msg, false);
+                return;
+            }
+
+            const msg = data?.message || "인증메일을 발송했습니다. 메일함의 링크를 클릭해 주세요.";
+            setText(sendStatus, msg, true);
+            verifyBox.classList.remove("is-hidden");
+        } catch (e) {
+            setText(sendStatus, "네트워크 오류가 발생했습니다.", false);
+        } finally {
+            sendBtn.disabled = false;
+        }
+    });
+
+    verifyBtn.addEventListener("click", async function () {
+        const email = (emailInput.value || "").trim();
+
+        if (!isValidEmail(email)) {
+            setText(verifyStatus, "올바른 이메일을 입력해 주세요.", false);
+            return;
+        }
+
+        verifyBtn.disabled = true;
+        setText(verifyStatus, "인증 확인 중입니다...", true);
+
+        try {
+            const query = new URLSearchParams({
+                email: email,
+                attemptId: attemptIdHidden.value
+            });
+            const res = await fetch(base + "/api/auth/email/status?" + query.toString());
+
+            if (!res.ok) {
+                setText(verifyStatus, "인증 확인에 실패했습니다.", false);
+                emailVerifiedHidden.value = "false";
+                return;
+            }
+
+            const data = await res.json();
+            if (data?.success && data?.data === true) {
+                setText(verifyStatus, "이메일 인증이 완료되었습니다.", true);
+                emailVerifiedHidden.value = "true";
+            } else {
+                setText(verifyStatus, "아직 인증이 완료되지 않았습니다. 메일의 링크를 확인해 주세요.", false);
+                emailVerifiedHidden.value = "false";
+            }
+        } catch (e) {
+            setText(verifyStatus, "네트워크 오류가 발생했습니다.", false);
+            emailVerifiedHidden.value = "false";
+        } finally {
+            verifyBtn.disabled = false;
+        }
+    });
+
+    signupForm.addEventListener("submit", function (e) {
+        if (emailVerifiedHidden.value !== "true") {
+            e.preventDefault();
+            alert("이메일 인증을 완료해 주세요.");
+        }
+    });
+
+})();


### PR DESCRIPTION
## 📌 PR 설명
  관리자 페이지 UX 개선 및 SweetAlert 적용
<br>

## ✅ 완료한 기능 명세

  - [x] **회원 관리 페이지 UX 개선**
    - 기본 보기 형태를 카드 → 리스트로 변경
    - 기본 필터를 "활성" 회원으로 설정
    - 상세 버튼 제거, 차단/해제 버튼만 유지
    - 차단/해제 버튼에 텍스트 라벨 추가 (직관성 향상)
    - 차단 회원 시각적 강조 (빨간색 테두리, 배경, 아바타)
    - 탈퇴 회원 시각적 강조 (회색 톤, 흐림 효과, 취소선)
    - 필터 옵션에서 "온보딩" 제거

  - [x] **결제 내역 페이지 UX 개선**
    - 기본 보기 형태를 카드 → 리스트로 변경

  - [x] **대시보드 최근 활동 개선**
    - 결제 완료 항목 시각적 강조 (초록색 테두리, 배경, NEW 뱃지)

  - [x] **SweetAlert 전면 적용**
    - 회원 차단/해제 확인 다이얼로그
    - 모든 성공/실패 알림 메시지

<br>


### 🔗 관련 이슈
Closes #244 

<br>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 항공편 출발지/도착지 2단계 선택 UI 추가(국가→공항)
  * 승객 수 스테퍼·퀵셀렉트 칩, 할인률 버튼·커스텀 입력 추가
  * 회원가입 이메일 인증 흐름(프론트엔드) 추가

* **UI/UX 개선**
  * 결제·사용자 화면 기본 보기를 카드→목록으로 변경
  * 사용자 상태 표시기(아이콘·스타일) 및 모달 대화상자 적용
  * 프로모션 필터에 필터 초기화 버튼 추가
  * 최근 활동에서 결제 항목 강조 스타일링 추가

* **성능 최적화**
  * 미사용 항공사 컬럼/조인 제거로 쿼리 성능 개선
  * 관리자 자산에 캐시 무효화 파라미터 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->