### PR TITLE
[FLYW-209] fix: 도착일 계산 수정

### DIFF
--- a/src/main/webapp/WEB-INF/views/reservations/agreement.jsp
+++ b/src/main/webapp/WEB-INF/views/reservations/agreement.jsp
@@ -150,9 +150,9 @@
                                 <div class="airport-name">
                                     ${s.snapArrivalCity}
                                     <c:set var="depDayMillis"
-                                           value="${Math.floor(depDate.time / (1000*60*60*24))}"/>
+                                           value="${Math.floor((depDate.time - (depDate.timezoneOffset * 60 * 1000)) / (1000*60*60*24))}"/>
                                     <c:set var="arrDayMillis"
-                                           value="${Math.floor(arrDate.time / (1000*60*60*24))}"/>
+                                           value="${Math.floor((arrDate.time - (arrDate.timezoneOffset * 60 * 1000)) / (1000*60*60*24))}"/>
 
                                     <c:set var="dayDiff" value="${arrDayMillis - depDayMillis}"/>
 

--- a/src/main/webapp/WEB-INF/views/reservations/agreement.jsp
+++ b/src/main/webapp/WEB-INF/views/reservations/agreement.jsp
@@ -149,11 +149,15 @@
                                 <div class="airport-code uppercase">${s.snapArrivalAirport}</div>
                                 <div class="airport-name">
                                     ${s.snapArrivalCity}
-                                    <fmt:formatDate value="${depDate}" pattern="yyyyMMdd" var="depDay"/>
-                                    <fmt:formatDate value="${arrDate}" pattern="yyyyMMdd" var="arrDay"/>
-                                    <c:set var="dayDiff" value="${arrDay - depDay}"/>
+                                    <c:set var="depDayMillis"
+                                           value="${Math.floor(depDate.time / (1000*60*60*24))}"/>
+                                    <c:set var="arrDayMillis"
+                                           value="${Math.floor(arrDate.time / (1000*60*60*24))}"/>
+
+                                    <c:set var="dayDiff" value="${arrDayMillis - depDayMillis}"/>
+
                                     <c:if test="${dayDiff > 0}">
-                                        <span class="text-red-500 font-bold ml-1">+${dayDiff}일</span>
+                                        <span class="text-red-500 font-bold ml-1">+<fmt:formatNumber value="${dayDiff}" maxFractionDigits="0" />일</span>
                                     </c:if>
                                 </div>
                             </div>

--- a/src/main/webapp/WEB-INF/views/reservations/booking.jsp
+++ b/src/main/webapp/WEB-INF/views/reservations/booking.jsp
@@ -294,9 +294,9 @@
                                 <div class="airport-name">
                                     ${s.snapArrivalCity}
                                     <c:set var="depDayMillis"
-                                           value="${Math.floor(depDate.time / (1000*60*60*24))}"/>
+                                           value="${Math.floor((depDate.time - (depDate.timezoneOffset * 60 * 1000)) / (1000*60*60*24))}"/>
                                     <c:set var="arrDayMillis"
-                                           value="${Math.floor(arrDate.time / (1000*60*60*24))}"/>
+                                           value="${Math.floor((arrDate.time - (arrDate.timezoneOffset * 60 * 1000)) / (1000*60*60*24))}"/>
 
                                     <c:set var="dayDiff" value="${arrDayMillis - depDayMillis}"/>
 

--- a/src/main/webapp/WEB-INF/views/reservations/booking.jsp
+++ b/src/main/webapp/WEB-INF/views/reservations/booking.jsp
@@ -292,12 +292,16 @@
                                 </div>
                                 <div class="airport-code uppercase">${s.snapArrivalAirport}</div>
                                 <div class="airport-name">
-                                        ${s.snapArrivalCity}
-                                    <fmt:formatDate value="${depDate}" pattern="yyyyMMdd" var="depDay"/>
-                                    <fmt:formatDate value="${arrDate}" pattern="yyyyMMdd" var="arrDay"/>
-                                    <c:set var="dayDiff" value="${arrDay - depDay}"/>
+                                    ${s.snapArrivalCity}
+                                    <c:set var="depDayMillis"
+                                           value="${Math.floor(depDate.time / (1000*60*60*24))}"/>
+                                    <c:set var="arrDayMillis"
+                                           value="${Math.floor(arrDate.time / (1000*60*60*24))}"/>
+
+                                    <c:set var="dayDiff" value="${arrDayMillis - depDayMillis}"/>
+
                                     <c:if test="${dayDiff > 0}">
-                                        <span class="text-red-500 font-bold ml-1">+${dayDiff}일</span>
+                                        <span class="text-red-500 font-bold ml-1">+<fmt:formatNumber value="${dayDiff}" maxFractionDigits="0" />일</span>
                                     </c:if>
                                 </div>
                             </div>

--- a/src/main/webapp/WEB-INF/views/search/search.jsp
+++ b/src/main/webapp/WEB-INF/views/search/search.jsp
@@ -1083,7 +1083,6 @@
                 const panel = document.querySelector('[data-filter-panel="airline"]');
                 if (panel) {
                     panel.hidden = true;
-                    panel.style.display = 'none';
                 }
                 const btn = document.querySelector('[data-filter="airline"]');
                 if (btn) btn.setAttribute("aria-expanded", "false");

--- a/src/main/webapp/resources/main/css/main.css
+++ b/src/main/webapp/resources/main/css/main.css
@@ -456,7 +456,7 @@ html, body {
 }
 
 .diff-badge.new {
-    background: rgb(109, 251, 27);
+    background: rgb(145, 1, 161);
     color: #ffffff;
 }
 


### PR DESCRIPTION
## 📌 PR 설명
- 도착일 +1일 표시 잘못 표시되는거 수정

<br>

## ✅ 완료한 기능 명세

- [x] [FLYW-209] fix: 도착일 계산 수정

<br>

### 🔗 관련 이슈
Closes #252 

<br>

[FLYW-209]: https://sol-v.atlassian.net/browse/FLYW-209?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **버그 수정**
  * 예약 및 동의 화면에서 출발·도착 날짜 간 숙박 일수 계산 방식을 개선하여 일수 계산 오류를 방지합니다.

* **개선 사항**
  * 숙박 일수를 소수점 없이 정수로 일관되게 표시하고, 양수일 때만 "+X일" 접미사를 유지하도록 개선했습니다.
  * 검색 페이지의 필터 패널 숨김 처리를 HTML 속성 기반으로 정리했습니다.

* **스타일**
  * "new" 배지 색상을 업데이트했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->