### PR TITLE
[FLYW-140] CSRF 설정 분리 (JSP Web 활성화 / API Origin 검증 적용)

### DIFF
--- a/src/main/java/com/flyway/auth/controller/AuthController.java
+++ b/src/main/java/com/flyway/auth/controller/AuthController.java
@@ -116,6 +116,11 @@ public class AuthController {
         }
     }
 
+    @GetMapping("/auth/csrf")
+    public ResponseEntity<Void> csrf() {
+        return ResponseEntity.noContent().build();
+    }
+
     private void autoLoginByEmail(String email, HttpServletRequest req, HttpServletResponse res) {
         UserDetails userDetails = emailUserDetailsService.loadUserByUsername(email);
         authenticateAndSave(userDetails, req, res);

--- a/src/main/java/com/flyway/auth/controller/AuthViewController.java
+++ b/src/main/java/com/flyway/auth/controller/AuthViewController.java
@@ -7,6 +7,7 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 
 import javax.servlet.http.HttpSession;
 
@@ -17,7 +18,12 @@ public class AuthViewController {
     private static final String OAUTH_SIGNUP_EMAIL_ATTR = "OAUTH_SIGNUP_EMAIL";
 
     @GetMapping("/login")
-    public String loginView() {
+    public String loginView(@RequestParam(value = "returnUrl", required = false) String returnUrl,
+                            Model model) {
+        String safeReturnUrl = sanitizeReturnUrl(returnUrl);
+        if (safeReturnUrl != null) {
+            model.addAttribute("returnUrl", safeReturnUrl);
+        }
         return "login";
     }
 
@@ -55,6 +61,18 @@ public class AuthViewController {
         session.removeAttribute(OAUTH_SIGNUP_EMAIL_ATTR);
 
         return "signup";
+    }
+
+    private String sanitizeReturnUrl(String raw) {
+        if (raw == null) return null;
+        String path = raw.trim();
+        if (path.isEmpty()) return null;
+        if (!path.startsWith("/")) return null;
+        if (path.startsWith("//") || path.startsWith("/\\")) return null;
+        String lower = path.toLowerCase();
+        if (lower.startsWith("/http")) return null;
+        if (path.contains("://")) return null;
+        return path;
     }
 
 }

--- a/src/main/java/com/flyway/auth/service/AuthTokenService.java
+++ b/src/main/java/com/flyway/auth/service/AuthTokenService.java
@@ -22,6 +22,11 @@ public interface AuthTokenService {
     void logout(HttpServletRequest request, HttpServletResponse response);
 
     /**
+     * 강제 로그아웃: 세션/보안 컨텍스트 정리 + 쿠키 삭제
+     */
+    void forceLogout(HttpServletRequest request, HttpServletResponse response);
+
+    /**
      * 토큰 폐기
      */
     void revokeAllRefreshTokens(String userId, LocalDateTime now);

--- a/src/main/java/com/flyway/auth/service/AuthTokenServiceImpl.java
+++ b/src/main/java/com/flyway/auth/service/AuthTokenServiceImpl.java
@@ -159,6 +159,7 @@ public class AuthTokenServiceImpl implements AuthTokenService {
     }
 
     @Override
+    @Transactional
     public void forceLogout(HttpServletRequest request, HttpServletResponse response) {
         try {
             logout(request, response);

--- a/src/main/java/com/flyway/auth/service/AuthTokenServiceImpl.java
+++ b/src/main/java/com/flyway/auth/service/AuthTokenServiceImpl.java
@@ -16,7 +16,6 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
-import org.springframework.security.core.context.SecurityContextHolder;
 
 import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletRequest;

--- a/src/main/java/com/flyway/auth/service/AuthTokenServiceImpl.java
+++ b/src/main/java/com/flyway/auth/service/AuthTokenServiceImpl.java
@@ -12,13 +12,16 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseCookie;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
+import org.springframework.security.core.context.SecurityContextHolder;
 
 import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.HttpSession;
 import java.security.SecureRandom;
 import java.time.LocalDateTime;
 import java.util.Base64;
@@ -32,7 +35,8 @@ public class AuthTokenServiceImpl implements AuthTokenService {
     private static final String ACCESS_COOKIE = "accessToken";
     private static final String REFRESH_COOKIE = "refreshToken";
     private static final String ACCESS_COOKIE_PATH = "/";
-    private static final String REFRESH_COOKIE_PATH = "/auth";
+    private static final String REFRESH_COOKIE_PATH = "/";
+    private static final String LEGACY_REFRESH_COOKIE_PATH = "/auth";
 
     private final JwtProvider jwtProvider;
     private final JwtProperties jwtProperties;
@@ -77,23 +81,27 @@ public class AuthTokenServiceImpl implements AuthTokenService {
 
         String refreshRaw = readCookie(request, REFRESH_COOKIE);
         if (!StringUtils.hasText(refreshRaw)) {
+            forceLogout(request, response);
             throw new BusinessException(ErrorCode.AUTH_REFRESH_TOKEN_MISSING);
         }
 
         String hash = tokenHasher.hash(refreshRaw);
         RefreshToken stored = refreshTokenRepository.findByTokenHash(hash);
         if (stored == null) {
+            forceLogout(request, response);
             throw new BusinessException(ErrorCode.AUTH_REFRESH_TOKEN_INVALID);
         }
 
         /* 만료/폐기 체크 */
         if (stored.getRevokedAt() != null || !stored.getExpiresAt().isAfter(now)) {
+            forceLogout(request, response);
             throw new BusinessException(ErrorCode.AUTH_REFRESH_TOKEN_EXPIRED);
         }
 
         /* 재사용 탐지 */
         if (stored.getRotatedAt() != null) {
             refreshTokenRepository.revokeAllByUserId(stored.getUserId(), now);
+            forceLogout(request, response);
             throw new BusinessException(ErrorCode.AUTH_REFRESH_TOKEN_REUSED);
         }
 
@@ -123,6 +131,7 @@ public class AuthTokenServiceImpl implements AuthTokenService {
 
         /* 동시 요청/레이스: 이미 회전됐거나 revoke인 경우 */
         if (rotated == 0) {
+            forceLogout(request, response);
             throw new BusinessException(ErrorCode.AUTH_REFRESH_TOKEN_ALREADY_USED);
         }
 
@@ -147,7 +156,29 @@ public class AuthTokenServiceImpl implements AuthTokenService {
         }
 
         deleteCookie(response, ACCESS_COOKIE, ACCESS_COOKIE_PATH);
-        deleteCookie(response, REFRESH_COOKIE, REFRESH_COOKIE_PATH);
+        deleteRefreshCookies(response);
+    }
+
+    @Override
+    public void forceLogout(HttpServletRequest request, HttpServletResponse response) {
+        try {
+            logout(request, response);
+        } catch (Exception e) {
+            log.warn("[AUTH] force logout - token cleanup failed", e);
+            deleteCookie(response, ACCESS_COOKIE, ACCESS_COOKIE_PATH);
+            deleteRefreshCookies(response);
+        }
+
+        try {
+            HttpSession session = request.getSession(false);
+            if (session != null) {
+                session.invalidate();
+            }
+        } catch (Exception e) {
+            log.warn("[AUTH] force logout - session invalidate failed", e);
+        }
+
+        SecurityContextHolder.clearContext();
     }
 
     @Transactional
@@ -193,6 +224,11 @@ public class AuthTokenServiceImpl implements AuthTokenService {
             .maxAge(0)
             .build();
         response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
+    }
+
+    private void deleteRefreshCookies(HttpServletResponse response) {
+        deleteCookie(response, REFRESH_COOKIE, REFRESH_COOKIE_PATH);
+        deleteCookie(response, REFRESH_COOKIE, LEGACY_REFRESH_COOKIE_PATH);
     }
 
     private String readCookie(HttpServletRequest request, String name) {

--- a/src/main/java/com/flyway/auth/service/AuthTokenServiceImpl.java
+++ b/src/main/java/com/flyway/auth/service/AuthTokenServiceImpl.java
@@ -42,6 +42,7 @@ public class AuthTokenServiceImpl implements AuthTokenService {
 
     private final RefreshTokenRepository refreshTokenRepository;
     private final TokenHasher tokenHasher;
+    private final RefreshTokenRevocationService refreshTokenRevocationService;
 
     @Value("${cookie.secure:false}")
     private boolean cookieSecure;
@@ -99,7 +100,7 @@ public class AuthTokenServiceImpl implements AuthTokenService {
 
         /* 재사용 탐지 */
         if (stored.getRotatedAt() != null) {
-            refreshTokenRepository.revokeAllByUserId(stored.getUserId(), now);
+            refreshTokenRevocationService.revokeAllByUserTokens(stored.getUserId(), now);
             forceLogout(request, response);
             throw new BusinessException(ErrorCode.AUTH_REFRESH_TOKEN_REUSED);
         }

--- a/src/main/java/com/flyway/auth/service/RefreshTokenRevocationService.java
+++ b/src/main/java/com/flyway/auth/service/RefreshTokenRevocationService.java
@@ -1,0 +1,21 @@
+package com.flyway.auth.service;
+
+import com.flyway.auth.repository.RefreshTokenRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+@Service
+@RequiredArgsConstructor
+public class RefreshTokenRevocationService {
+
+    private final RefreshTokenRepository refreshTokenRepository;
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void revokeAllByUserTokens(String userId, LocalDateTime now) {
+        refreshTokenRepository.revokeAllByUserId(userId, now);
+    }
+}

--- a/src/main/java/com/flyway/search/controller/FlightApiController.java
+++ b/src/main/java/com/flyway/search/controller/FlightApiController.java
@@ -39,8 +39,8 @@ public class FlightApiController {
     }
 
     // 검색
-    @PostMapping("/api/public/flights/search")
-    public SearchResultDto search(@RequestBody FlightSearchRequest dto) {
+    @GetMapping("/api/public/flights/search")
+    public SearchResultDto search(@ModelAttribute FlightSearchRequest dto) {
         return service.search(dto);
     }
 

--- a/src/main/java/com/flyway/search/dto/FlightSearchRequest.java
+++ b/src/main/java/com/flyway/search/dto/FlightSearchRequest.java
@@ -1,6 +1,7 @@
 package com.flyway.search.dto;
 
 import lombok.Data;
+import org.springframework.format.annotation.DateTimeFormat;
 
 import java.time.LocalDate;
 
@@ -9,7 +10,9 @@ public class FlightSearchRequest {
     private String tripType;
     private String from;
     private String to;
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
     private LocalDate dateStart;
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
     private LocalDate dateEnd;
     private Integer passengers;
     private String cabinClass;

--- a/src/main/java/com/flyway/security/config/SecurityConfigApi.java
+++ b/src/main/java/com/flyway/security/config/SecurityConfigApi.java
@@ -30,16 +30,19 @@ public class SecurityConfigApi extends WebSecurityConfigurerAdapter {
     private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
     private final JwtAccessDeniedHandler jwtAccessDeniedHandler;
     private final UserDetailsService userIdUserDetailsService;
+    private final SecurityOriginProperties securityOriginProperties;
 
     public SecurityConfigApi(
             JwtProvider jwtProvider,
             JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint,
             JwtAccessDeniedHandler jwtAccessDeniedHandler,
+            SecurityOriginProperties securityOriginProperties,
             @Qualifier("userIdUserDetailsService") UserDetailsService userIdUserDetailsService
     ) {
         this.jwtProvider = jwtProvider;
         this.jwtAuthenticationEntryPoint = jwtAuthenticationEntryPoint;
         this.jwtAccessDeniedHandler = jwtAccessDeniedHandler;
+        this.securityOriginProperties = securityOriginProperties;
         this.userIdUserDetailsService = userIdUserDetailsService;
     }
 
@@ -50,6 +53,11 @@ public class SecurityConfigApi extends WebSecurityConfigurerAdapter {
                 jwtAuthenticationEntryPoint,
                 userIdUserDetailsService
         );
+    }
+
+    @Bean
+    public OriginRefererCheckFilter apiOriginRefererCheckFilter() {
+        return OriginRefererCheckFilter.forApi(securityOriginProperties.getAllowedOrigins());
     }
 
     @Override
@@ -91,7 +99,7 @@ public class SecurityConfigApi extends WebSecurityConfigurerAdapter {
                 .anyRequest().authenticated()
                 .and()
 
-                .addFilterBefore(OriginRefererCheckFilter.forApi(), CsrfFilter.class)
+                .addFilterBefore(apiOriginRefererCheckFilter(), CsrfFilter.class)
                 .addFilterBefore(jwtApiAuthFilter(), UsernamePasswordAuthenticationFilter.class)
                 .addFilterAfter(new OnboardingAccessFilter(), JwtApiAuthFilter.class);
     }

--- a/src/main/java/com/flyway/security/config/SecurityConfigApi.java
+++ b/src/main/java/com/flyway/security/config/SecurityConfigApi.java
@@ -16,6 +16,8 @@ import org.springframework.security.config.annotation.web.configuration.WebSecur
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.security.web.csrf.CookieCsrfTokenRepository;
+import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
 
 @Configuration
 @EnableWebSecurity
@@ -56,7 +58,15 @@ public class SecurityConfigApi extends WebSecurityConfigurerAdapter {
                 .sessionCreationPolicy(SessionCreationPolicy.STATELESS)
                 .and()
 
-                .csrf().disable()
+                .csrf(csrf -> csrf
+                        .csrfTokenRepository(CookieCsrfTokenRepository.withHttpOnlyFalse())
+                        // 로그인 전/토큰 재발급 같은 엔드포인트는 "의도적으로" 예외 가능
+                        .ignoringRequestMatchers(
+                                new AntPathRequestMatcher("/api/auth/loginProc", "POST"),
+                                new AntPathRequestMatcher("/api/auth/refresh", "POST"),
+                                new AntPathRequestMatcher("/api/auth/logout", "POST")
+                        )
+                )
                 .formLogin().disable()
                 .httpBasic().disable()
 

--- a/src/main/java/com/flyway/security/config/SecurityConfigApi.java
+++ b/src/main/java/com/flyway/security/config/SecurityConfigApi.java
@@ -3,6 +3,7 @@ package com.flyway.security.config;
 import com.flyway.security.handler.JwtAccessDeniedHandler;
 import com.flyway.security.handler.JwtAuthenticationEntryPoint;
 import com.flyway.security.filter.OnboardingAccessFilter;
+import com.flyway.security.filter.OriginRefererCheckFilter;
 import com.flyway.security.jwt.JwtApiAuthFilter;
 import com.flyway.security.jwt.JwtProvider;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -16,6 +17,7 @@ import org.springframework.security.config.annotation.web.configuration.WebSecur
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.security.web.csrf.CsrfFilter;
 import org.springframework.security.web.csrf.CookieCsrfTokenRepository;
 import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
 
@@ -89,6 +91,7 @@ public class SecurityConfigApi extends WebSecurityConfigurerAdapter {
                 .anyRequest().authenticated()
                 .and()
 
+                .addFilterBefore(OriginRefererCheckFilter.forApi(), CsrfFilter.class)
                 .addFilterBefore(jwtApiAuthFilter(), UsernamePasswordAuthenticationFilter.class)
                 .addFilterAfter(new OnboardingAccessFilter(), JwtApiAuthFilter.class);
     }

--- a/src/main/java/com/flyway/security/config/SecurityConfigWeb.java
+++ b/src/main/java/com/flyway/security/config/SecurityConfigWeb.java
@@ -24,6 +24,7 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.authentication.AuthenticationFailureHandler;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.security.web.authentication.logout.LogoutHandler;
+import org.springframework.security.web.csrf.CookieCsrfTokenRepository;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -122,6 +123,10 @@ public class SecurityConfigWeb extends WebSecurityConfigurerAdapter {
     @Override
     protected void configure(HttpSecurity http) throws Exception {
         http
+                .csrf()
+                .csrfTokenRepository(CookieCsrfTokenRepository.withHttpOnlyFalse())
+                .and()
+
                 .authorizeRequests()
                 .antMatchers(STATIC_RESOURCES).permitAll()
                 .antMatchers(PUBLIC_ENDPOINTS).permitAll().anyRequest().authenticated()

--- a/src/main/java/com/flyway/security/config/SecurityConfigWeb.java
+++ b/src/main/java/com/flyway/security/config/SecurityConfigWeb.java
@@ -7,6 +7,7 @@ import com.flyway.security.filter.OnboardingAccessFilter;
 import com.flyway.security.filter.RefreshTokenSessionSyncFilter;
 import com.flyway.security.handler.JwtAuthenticationEntryPoint;
 import com.flyway.security.handler.LoginSuccessHandler;
+import com.flyway.security.handler.WebLoginRedirectEntryPoint;
 import com.flyway.security.jwt.JwtProvider;
 import com.flyway.security.jwt.JwtWebAuthFilter;
 import lombok.extern.slf4j.Slf4j;
@@ -46,6 +47,7 @@ public class SecurityConfigWeb extends WebSecurityConfigurerAdapter {
     private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
     private final PasswordEncoder passwordEncoder;
     private final LoginSuccessHandler loginSuccessHandler;
+    private final WebLoginRedirectEntryPoint webLoginRedirectEntryPoint;
     private final UserDetailsService userIdUserDetailsService;
     private final UserDetailsService emailUserDetailsService;
     private final AuthTokenService authTokenService;
@@ -57,6 +59,7 @@ public class SecurityConfigWeb extends WebSecurityConfigurerAdapter {
             JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint,
             PasswordEncoder passwordEncoder,
             LoginSuccessHandler loginSuccessHandler,
+            WebLoginRedirectEntryPoint webLoginRedirectEntryPoint,
             AuthTokenService authTokenService,
             RefreshTokenRepository refreshTokenRepository,
             TokenHasher tokenHasher,
@@ -67,6 +70,7 @@ public class SecurityConfigWeb extends WebSecurityConfigurerAdapter {
         this.jwtAuthenticationEntryPoint = jwtAuthenticationEntryPoint;
         this.passwordEncoder = passwordEncoder;
         this.loginSuccessHandler = loginSuccessHandler;
+        this.webLoginRedirectEntryPoint = webLoginRedirectEntryPoint;
         this.authTokenService = authTokenService;
         this.refreshTokenRepository = refreshTokenRepository;
         this.tokenHasher = tokenHasher;
@@ -123,6 +127,10 @@ public class SecurityConfigWeb extends WebSecurityConfigurerAdapter {
                 .authorizeRequests()
                 .antMatchers(STATIC_RESOURCES).permitAll()
                 .antMatchers(PUBLIC_ENDPOINTS).permitAll().anyRequest().authenticated()
+                .and()
+
+                .exceptionHandling()
+                .authenticationEntryPoint(webLoginRedirectEntryPoint)
                 .and()
 
                 .formLogin()

--- a/src/main/java/com/flyway/security/config/SecurityConfigWeb.java
+++ b/src/main/java/com/flyway/security/config/SecurityConfigWeb.java
@@ -56,6 +56,7 @@ public class SecurityConfigWeb extends WebSecurityConfigurerAdapter {
     private final AuthTokenService authTokenService;
     private final RefreshTokenRepository refreshTokenRepository;
     private final TokenHasher tokenHasher;
+    private final SecurityOriginProperties securityOriginProperties;
 
     public SecurityConfigWeb(
             JwtProvider jwtProvider,
@@ -66,6 +67,7 @@ public class SecurityConfigWeb extends WebSecurityConfigurerAdapter {
             AuthTokenService authTokenService,
             RefreshTokenRepository refreshTokenRepository,
             TokenHasher tokenHasher,
+            SecurityOriginProperties securityOriginProperties,
             @Qualifier("userIdUserDetailsService") UserDetailsService userIdUserDetailsService,
             @Qualifier("emailUserDetailsService") UserDetailsService emailUserDetailsService
     ) {
@@ -77,6 +79,7 @@ public class SecurityConfigWeb extends WebSecurityConfigurerAdapter {
         this.authTokenService = authTokenService;
         this.refreshTokenRepository = refreshTokenRepository;
         this.tokenHasher = tokenHasher;
+        this.securityOriginProperties = securityOriginProperties;
         this.userIdUserDetailsService = userIdUserDetailsService;
         this.emailUserDetailsService = emailUserDetailsService;
     }
@@ -101,6 +104,11 @@ public class SecurityConfigWeb extends WebSecurityConfigurerAdapter {
                 authTokenService,
                 excludes
         );
+    }
+
+    @Bean
+    public OriginRefererCheckFilter webOriginRefererCheckFilter() {
+        return OriginRefererCheckFilter.forWeb(securityOriginProperties.getAllowedOrigins());
     }
 
     @Bean
@@ -155,7 +163,7 @@ public class SecurityConfigWeb extends WebSecurityConfigurerAdapter {
                 .permitAll()
                 .and()
 
-                .addFilterBefore(OriginRefererCheckFilter.forWeb(), CsrfFilter.class)
+                .addFilterBefore(webOriginRefererCheckFilter(), CsrfFilter.class)
                 .addFilterBefore(jwtWebAuthFilter(), UsernamePasswordAuthenticationFilter.class)
                 .addFilterAfter(refreshTokenSessionSyncFilter(), JwtWebAuthFilter.class)
                 .addFilterAfter(new OnboardingAccessFilter(), RefreshTokenSessionSyncFilter.class);

--- a/src/main/java/com/flyway/security/config/SecurityConfigWeb.java
+++ b/src/main/java/com/flyway/security/config/SecurityConfigWeb.java
@@ -1,7 +1,10 @@
 package com.flyway.security.config;
 
 import com.flyway.auth.service.AuthTokenService;
+import com.flyway.auth.repository.RefreshTokenRepository;
+import com.flyway.auth.util.TokenHasher;
 import com.flyway.security.filter.OnboardingAccessFilter;
+import com.flyway.security.filter.RefreshTokenSessionSyncFilter;
 import com.flyway.security.handler.JwtAuthenticationEntryPoint;
 import com.flyway.security.handler.LoginSuccessHandler;
 import com.flyway.security.jwt.JwtProvider;
@@ -21,6 +24,10 @@ import org.springframework.security.web.authentication.AuthenticationFailureHand
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.security.web.authentication.logout.LogoutHandler;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
 @Slf4j
 @Configuration
 @Order(3)
@@ -32,7 +39,7 @@ public class SecurityConfigWeb extends WebSecurityConfigurerAdapter {
 
     private static final String[] PUBLIC_ENDPOINTS = {
             "/", "/login", "/loginProc", "/signup", "/auth/**", "/search/**",
-            "/payments/success", "/payments/fail", "/payments/complete", "/api/sms/**"
+            "/payments/success", "/payments/fail", "/payments/complete", "/api/sms/**", "/error", "/error/**",
     };
 
     private final JwtProvider jwtProvider;
@@ -42,6 +49,8 @@ public class SecurityConfigWeb extends WebSecurityConfigurerAdapter {
     private final UserDetailsService userIdUserDetailsService;
     private final UserDetailsService emailUserDetailsService;
     private final AuthTokenService authTokenService;
+    private final RefreshTokenRepository refreshTokenRepository;
+    private final TokenHasher tokenHasher;
 
     public SecurityConfigWeb(
             JwtProvider jwtProvider,
@@ -49,6 +58,8 @@ public class SecurityConfigWeb extends WebSecurityConfigurerAdapter {
             PasswordEncoder passwordEncoder,
             LoginSuccessHandler loginSuccessHandler,
             AuthTokenService authTokenService,
+            RefreshTokenRepository refreshTokenRepository,
+            TokenHasher tokenHasher,
             @Qualifier("userIdUserDetailsService") UserDetailsService userIdUserDetailsService,
             @Qualifier("emailUserDetailsService") UserDetailsService emailUserDetailsService
     ) {
@@ -57,6 +68,8 @@ public class SecurityConfigWeb extends WebSecurityConfigurerAdapter {
         this.passwordEncoder = passwordEncoder;
         this.loginSuccessHandler = loginSuccessHandler;
         this.authTokenService = authTokenService;
+        this.refreshTokenRepository = refreshTokenRepository;
+        this.tokenHasher = tokenHasher;
         this.userIdUserDetailsService = userIdUserDetailsService;
         this.emailUserDetailsService = emailUserDetailsService;
     }
@@ -67,6 +80,19 @@ public class SecurityConfigWeb extends WebSecurityConfigurerAdapter {
                 jwtProvider,
                 jwtAuthenticationEntryPoint,
                 userIdUserDetailsService
+        );
+    }
+
+    @Bean
+    public RefreshTokenSessionSyncFilter refreshTokenSessionSyncFilter() {
+        List<String> excludes = new ArrayList<>();
+        excludes.addAll(Arrays.asList(STATIC_RESOURCES));
+        excludes.addAll(Arrays.asList(PUBLIC_ENDPOINTS));
+        return new RefreshTokenSessionSyncFilter(
+                refreshTokenRepository,
+                tokenHasher,
+                authTokenService,
+                excludes
         );
     }
 
@@ -117,7 +143,8 @@ public class SecurityConfigWeb extends WebSecurityConfigurerAdapter {
                 .and()
 
                 .addFilterBefore(jwtWebAuthFilter(), UsernamePasswordAuthenticationFilter.class)
-                .addFilterAfter(new OnboardingAccessFilter(), JwtWebAuthFilter.class);
+                .addFilterAfter(refreshTokenSessionSyncFilter(), JwtWebAuthFilter.class)
+                .addFilterAfter(new OnboardingAccessFilter(), RefreshTokenSessionSyncFilter.class);
     }
 
     @Bean
@@ -125,4 +152,3 @@ public class SecurityConfigWeb extends WebSecurityConfigurerAdapter {
         return (request, response, authentication) -> authTokenService.logout(request, response);
     }
 }
-

--- a/src/main/java/com/flyway/security/config/SecurityConfigWeb.java
+++ b/src/main/java/com/flyway/security/config/SecurityConfigWeb.java
@@ -4,6 +4,7 @@ import com.flyway.auth.service.AuthTokenService;
 import com.flyway.auth.repository.RefreshTokenRepository;
 import com.flyway.auth.util.TokenHasher;
 import com.flyway.security.filter.OnboardingAccessFilter;
+import com.flyway.security.filter.OriginRefererCheckFilter;
 import com.flyway.security.filter.RefreshTokenSessionSyncFilter;
 import com.flyway.security.handler.JwtAuthenticationEntryPoint;
 import com.flyway.security.handler.LoginSuccessHandler;
@@ -24,6 +25,7 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.authentication.AuthenticationFailureHandler;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.security.web.authentication.logout.LogoutHandler;
+import org.springframework.security.web.csrf.CsrfFilter;
 import org.springframework.security.web.csrf.CookieCsrfTokenRepository;
 
 import java.util.ArrayList;
@@ -153,6 +155,7 @@ public class SecurityConfigWeb extends WebSecurityConfigurerAdapter {
                 .permitAll()
                 .and()
 
+                .addFilterBefore(OriginRefererCheckFilter.forWeb(), CsrfFilter.class)
                 .addFilterBefore(jwtWebAuthFilter(), UsernamePasswordAuthenticationFilter.class)
                 .addFilterAfter(refreshTokenSessionSyncFilter(), JwtWebAuthFilter.class)
                 .addFilterAfter(new OnboardingAccessFilter(), RefreshTokenSessionSyncFilter.class);

--- a/src/main/java/com/flyway/security/config/SecurityConfigWeb.java
+++ b/src/main/java/com/flyway/security/config/SecurityConfigWeb.java
@@ -122,8 +122,6 @@ public class SecurityConfigWeb extends WebSecurityConfigurerAdapter {
     @Override
     protected void configure(HttpSecurity http) throws Exception {
         http
-                .csrf().disable()
-
                 .authorizeRequests()
                 .antMatchers(STATIC_RESOURCES).permitAll()
                 .antMatchers(PUBLIC_ENDPOINTS).permitAll().anyRequest().authenticated()

--- a/src/main/java/com/flyway/security/config/SecurityOriginProperties.java
+++ b/src/main/java/com/flyway/security/config/SecurityOriginProperties.java
@@ -1,0 +1,43 @@
+package com.flyway.security.config;
+
+import lombok.Getter;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+@Getter
+@Component
+public class SecurityOriginProperties {
+
+    private static final String FALLBACK_ALLOWED_ORIGIN = "https://flyway.kr";
+
+    private final List<String> allowedOrigins;
+
+    public SecurityOriginProperties(@Value("${security.allowed-origins:}") String allowedOriginsRaw) {
+        this.allowedOrigins = parseAllowedOrigins(allowedOriginsRaw);
+    }
+
+    private List<String> parseAllowedOrigins(String raw) {
+        Set<String> values = new LinkedHashSet<>();
+        if (StringUtils.hasText(raw)) {
+            String[] tokens = raw.split(",");
+            for (String token : tokens) {
+                if (StringUtils.hasText(token)) {
+                    values.add(token.trim());
+                }
+            }
+        }
+
+        if (values.isEmpty()) {
+            values.add(FALLBACK_ALLOWED_ORIGIN);
+        }
+
+        return Collections.unmodifiableList(new ArrayList<>(values));
+    }
+}

--- a/src/main/java/com/flyway/security/filter/OriginRefererCheckFilter.java
+++ b/src/main/java/com/flyway/security/filter/OriginRefererCheckFilter.java
@@ -1,0 +1,203 @@
+package com.flyway.security.filter;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.lang.NonNull;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+@Slf4j
+public class OriginRefererCheckFilter extends OncePerRequestFilter {
+
+    private static final Set<String> STATE_CHANGING_METHODS =
+            new LinkedHashSet<>(Arrays.asList("POST", "PUT", "PATCH", "DELETE"));
+
+    private static final List<String> DEFAULT_ALLOWED_ORIGINS = Arrays.asList(
+            "https://flyway.kr",
+            "http://localhost:8080"
+    );
+
+    private final Set<String> allowedOrigins;
+    private final List<String> includeBasePaths;
+    private final List<String> excludeBasePaths;
+    private final Set<String> excludeExactPaths;
+
+    public OriginRefererCheckFilter(
+            Collection<String> allowedOrigins,
+            Collection<String> includeBasePaths,
+            Collection<String> excludeBasePaths,
+            Collection<String> excludeExactPaths
+    ) {
+        this.allowedOrigins = normalizeOrigins(allowedOrigins);
+        this.includeBasePaths = normalizePaths(includeBasePaths);
+        this.excludeBasePaths = normalizePaths(excludeBasePaths);
+        this.excludeExactPaths = new LinkedHashSet<>();
+        if (excludeExactPaths != null) {
+            for (String p : excludeExactPaths) {
+                if (StringUtils.hasText(p)) {
+                    this.excludeExactPaths.add(normalizePath(p));
+                }
+            }
+        }
+    }
+
+    public static OriginRefererCheckFilter forApi() {
+        return new OriginRefererCheckFilter(
+                DEFAULT_ALLOWED_ORIGINS,
+                Arrays.asList("/api"),
+                null,
+                null
+        );
+    }
+
+    public static OriginRefererCheckFilter forWeb() {
+        return new OriginRefererCheckFilter(
+                DEFAULT_ALLOWED_ORIGINS,
+                Arrays.asList("/mypage", "/reservations", "/payment", "/payments"),
+                Arrays.asList("/oauth", "/auth"),
+                Arrays.asList("/loginProc")
+        );
+    }
+
+    @Override
+    protected boolean shouldNotFilter(HttpServletRequest request) {
+        String method = request.getMethod();
+        if (!StringUtils.hasText(method)) return true;
+
+        String upperMethod = method.toUpperCase();
+        if ("OPTIONS".equals(upperMethod)) return true;
+        if (!STATE_CHANGING_METHODS.contains(upperMethod)) return true;
+
+        String path = resolvePath(request);
+        if (!isIncludedPath(path)) return true;
+        return isExcludedPath(path);
+    }
+
+    @Override
+    protected void doFilterInternal(
+            @NonNull HttpServletRequest request,
+            @NonNull HttpServletResponse response,
+            @NonNull FilterChain filterChain
+    ) throws ServletException, IOException {
+        String origin = trimToNull(request.getHeader("Origin"));
+        String referer = trimToNull(request.getHeader("Referer"));
+
+        boolean allowed;
+        if (StringUtils.hasText(origin)) {
+            allowed = isAllowedOrigin(origin);
+        } else {
+            allowed = isAllowedReferer(referer);
+        }
+
+        if (!allowed) {
+            log.warn("[OriginRefererCheck] blocked. method={}, requestURI={}, origin={}, referer={}",
+                    request.getMethod(), request.getRequestURI(), origin, referer);
+            response.setStatus(HttpServletResponse.SC_FORBIDDEN);
+            response.setContentType("text/plain;charset=UTF-8");
+            response.getWriter().write("Forbidden");
+            return;
+        }
+
+        filterChain.doFilter(request, response);
+    }
+
+    private boolean isAllowedOrigin(String origin) {
+        if (!StringUtils.hasText(origin)) return false;
+        return allowedOrigins.contains(normalizeOrigin(origin));
+    }
+
+    private boolean isAllowedReferer(String referer) {
+        if (!StringUtils.hasText(referer)) return false;
+        for (String allowedOrigin : allowedOrigins) {
+            if (referer.equals(allowedOrigin) || referer.startsWith(allowedOrigin + "/")) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private boolean isIncludedPath(String path) {
+        for (String basePath : includeBasePaths) {
+            if (matchesBasePath(path, basePath)) return true;
+        }
+        return false;
+    }
+
+    private boolean isExcludedPath(String path) {
+        if (excludeExactPaths.contains(path)) return true;
+        for (String basePath : excludeBasePaths) {
+            if (matchesBasePath(path, basePath)) return true;
+        }
+        return false;
+    }
+
+    private boolean matchesBasePath(String path, String basePath) {
+        return path.equals(basePath) || path.startsWith(basePath + "/");
+    }
+
+    private String resolvePath(HttpServletRequest request) {
+        String uri = request.getRequestURI();
+        String contextPath = request.getContextPath();
+        if (StringUtils.hasText(contextPath) && uri.startsWith(contextPath)) {
+            return uri.substring(contextPath.length());
+        }
+        return uri;
+    }
+
+    private Set<String> normalizeOrigins(Collection<String> origins) {
+        Set<String> normalized = new LinkedHashSet<>();
+        if (origins == null) return normalized;
+        for (String origin : origins) {
+            if (StringUtils.hasText(origin)) {
+                normalized.add(normalizeOrigin(origin));
+            }
+        }
+        return normalized;
+    }
+
+    private List<String> normalizePaths(Collection<String> paths) {
+        List<String> normalized = new ArrayList<>();
+        if (paths == null) return normalized;
+        for (String p : paths) {
+            if (StringUtils.hasText(p)) {
+                normalized.add(normalizePath(p));
+            }
+        }
+        return normalized;
+    }
+
+    private String normalizeOrigin(String origin) {
+        String value = origin.trim();
+        if (value.endsWith("/")) {
+            return value.substring(0, value.length() - 1);
+        }
+        return value;
+    }
+
+    private String normalizePath(String path) {
+        String value = path.trim();
+        if (!value.startsWith("/")) {
+            value = "/" + value;
+        }
+        while (value.length() > 1 && value.endsWith("/")) {
+            value = value.substring(0, value.length() - 1);
+        }
+        return value;
+    }
+
+    private String trimToNull(String value) {
+        if (!StringUtils.hasText(value)) return null;
+        return value.trim();
+    }
+}

--- a/src/main/java/com/flyway/security/filter/OriginRefererCheckFilter.java
+++ b/src/main/java/com/flyway/security/filter/OriginRefererCheckFilter.java
@@ -114,9 +114,12 @@ public class OriginRefererCheckFilter extends OncePerRequestFilter {
     }
 
     private boolean isAllowedReferer(String referer) {
-        if (!StringUtils.hasText(referer)) return false;
+        String normalizedReferer = trimToNull(referer);
+        if (!StringUtils.hasText(normalizedReferer)) return false;
+        normalizedReferer = normalizeOrigin(normalizedReferer);
+
         for (String allowedOrigin : allowedOrigins) {
-            if (referer.equals(allowedOrigin) || referer.startsWith(allowedOrigin + "/")) {
+            if (normalizedReferer.equals(allowedOrigin) || normalizedReferer.startsWith(allowedOrigin + "/")) {
                 return true;
             }
         }

--- a/src/main/java/com/flyway/security/filter/OriginRefererCheckFilter.java
+++ b/src/main/java/com/flyway/security/filter/OriginRefererCheckFilter.java
@@ -24,11 +24,6 @@ public class OriginRefererCheckFilter extends OncePerRequestFilter {
     private static final Set<String> STATE_CHANGING_METHODS =
             new LinkedHashSet<>(Arrays.asList("POST", "PUT", "PATCH", "DELETE"));
 
-    private static final List<String> DEFAULT_ALLOWED_ORIGINS = Arrays.asList(
-            "https://flyway.kr",
-            "http://localhost:8080"
-    );
-
     private final Set<String> allowedOrigins;
     private final List<String> includeBasePaths;
     private final List<String> excludeBasePaths;
@@ -53,18 +48,18 @@ public class OriginRefererCheckFilter extends OncePerRequestFilter {
         }
     }
 
-    public static OriginRefererCheckFilter forApi() {
+    public static OriginRefererCheckFilter forApi(Collection<String> allowedOrigins) {
         return new OriginRefererCheckFilter(
-                DEFAULT_ALLOWED_ORIGINS,
+                allowedOrigins,
                 Arrays.asList("/api"),
                 null,
                 null
         );
     }
 
-    public static OriginRefererCheckFilter forWeb() {
+    public static OriginRefererCheckFilter forWeb(Collection<String> allowedOrigins) {
         return new OriginRefererCheckFilter(
-                DEFAULT_ALLOWED_ORIGINS,
+                allowedOrigins,
                 Arrays.asList("/mypage", "/reservations", "/payment", "/payments"),
                 Arrays.asList("/oauth", "/auth"),
                 Arrays.asList("/loginProc")

--- a/src/main/java/com/flyway/security/filter/OriginRefererCheckFilter.java
+++ b/src/main/java/com/flyway/security/filter/OriginRefererCheckFilter.java
@@ -15,6 +15,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Set;
 
 @Slf4j
@@ -179,10 +180,10 @@ public class OriginRefererCheckFilter extends OncePerRequestFilter {
 
     private String normalizeOrigin(String origin) {
         String value = origin.trim();
-        if (value.endsWith("/")) {
-            return value.substring(0, value.length() - 1);
+        while (value.length() > 1 && value.endsWith("/")) {
+            value = value.substring(0, value.length() - 1);
         }
-        return value;
+        return value.toLowerCase(Locale.ROOT);
     }
 
     private String normalizePath(String path) {

--- a/src/main/java/com/flyway/security/filter/RefreshTokenSessionSyncFilter.java
+++ b/src/main/java/com/flyway/security/filter/RefreshTokenSessionSyncFilter.java
@@ -19,6 +19,8 @@ import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -85,7 +87,9 @@ public class RefreshTokenSessionSyncFilter extends OncePerRequestFilter {
     ) throws IOException {
         log.debug("[AUTH] force logout by refresh sync. reason={}, uri={}", reason, request.getRequestURI());
         authTokenService.forceLogout(request, response);
-        response.sendRedirect(request.getContextPath() + "/login");
+        String returnUrl = buildReturnUrl(request);
+        String encoded = URLEncoder.encode(returnUrl, StandardCharsets.UTF_8);
+        response.sendRedirect(request.getContextPath() + "/login?returnUrl=" + encoded);
     }
 
     private boolean isAuthenticated(Authentication auth) {
@@ -129,5 +133,21 @@ public class RefreshTokenSessionSyncFilter extends OncePerRequestFilter {
             return path.substring(contextPath.length());
         }
         return path;
+    }
+
+    private String buildReturnUrl(HttpServletRequest request) {
+        String method = request.getMethod();
+        if (method != null && !method.equalsIgnoreCase("GET")) {
+            return "/";
+        }
+        String path = resolvePath(request);
+        String query = request.getQueryString();
+        String raw = (query != null && !query.isBlank()) ? path + "?" + query : path;
+        if (raw == null || raw.isBlank()) return "/";
+        if (!raw.startsWith("/")) return "/";
+        if (raw.startsWith("//") || raw.startsWith("/\\")) return "/";
+        String lower = raw.toLowerCase();
+        if (lower.startsWith("/http") || raw.contains("://")) return "/";
+        return raw;
     }
 }

--- a/src/main/java/com/flyway/security/filter/RefreshTokenSessionSyncFilter.java
+++ b/src/main/java/com/flyway/security/filter/RefreshTokenSessionSyncFilter.java
@@ -1,0 +1,133 @@
+package com.flyway.security.filter;
+
+import com.flyway.auth.domain.RefreshToken;
+import com.flyway.auth.repository.RefreshTokenRepository;
+import com.flyway.auth.service.AuthTokenService;
+import com.flyway.auth.util.TokenHasher;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.lang.NonNull;
+import org.springframework.security.authentication.AnonymousAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Slf4j
+@RequiredArgsConstructor
+public class RefreshTokenSessionSyncFilter extends OncePerRequestFilter {
+
+    private static final String REFRESH_COOKIE = "refreshToken";
+
+    private final RefreshTokenRepository refreshTokenRepository;
+    private final TokenHasher tokenHasher;
+    private final AuthTokenService authTokenService;
+    private final List<String> excludePatterns;
+
+    @Override
+    protected void doFilterInternal(
+            @NonNull HttpServletRequest request,
+            @NonNull HttpServletResponse response,
+            @NonNull FilterChain filterChain
+    ) throws ServletException, IOException {
+        String path = resolvePath(request);
+
+        /* 필터 적용 제외 경로: 검증 없이 통과 */
+        if (isExcluded(path)) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+        if (!isAuthenticated(auth)) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        String refreshRaw = readCookie(request, REFRESH_COOKIE);
+        if (!StringUtils.hasText(refreshRaw)) {
+            forceLogoutAndRedirect(request, response, "missing_refresh");
+            return;
+        }
+
+        String hash = tokenHasher.hash(refreshRaw);
+        RefreshToken stored = refreshTokenRepository.findByTokenHash(hash);
+        if (isInvalid(stored)) {
+            forceLogoutAndRedirect(request, response, "invalid_refresh");
+            return;
+        }
+
+        filterChain.doFilter(request, response);
+    }
+
+    private boolean isInvalid(RefreshToken stored) {
+        if (stored == null) return true;
+        LocalDateTime now = LocalDateTime.now();
+        return stored.getRevokedAt() != null
+                || stored.getRotatedAt() != null
+                || stored.getExpiresAt() == null
+                || !stored.getExpiresAt().isAfter(now);
+    }
+
+    private void forceLogoutAndRedirect(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            String reason
+    ) throws IOException {
+        log.debug("[AUTH] force logout by refresh sync. reason={}, uri={}", reason, request.getRequestURI());
+        authTokenService.forceLogout(request, response);
+        response.sendRedirect(request.getContextPath() + "/login");
+    }
+
+    private boolean isAuthenticated(Authentication auth) {
+        return auth != null
+                && auth.isAuthenticated()
+                && !(auth instanceof AnonymousAuthenticationToken);
+    }
+
+    /* 요청 경로가 excludePatterns에 포함되는 경우 필터를 적용하지 않음 */
+    private boolean isExcluded(String path) {
+        for (String pattern : excludePatterns) {
+            if (matches(path, pattern)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private boolean matches(String path, String pattern) {
+        if (pattern == null || pattern.isEmpty()) return false;
+        if (pattern.endsWith("/**")) {
+            String prefix = pattern.substring(0, pattern.length() - 3);
+            return path.startsWith(prefix);
+        }
+        return path.equals(pattern);
+    }
+
+    private String readCookie(HttpServletRequest request, String name) {
+        Cookie[] cookies = request.getCookies();
+        if (cookies == null) return null;
+        for (Cookie c : cookies) {
+            if (name.equals(c.getName())) return c.getValue();
+        }
+        return null;
+    }
+
+    private String resolvePath(HttpServletRequest request) {
+        String path = request.getRequestURI();
+        String contextPath = request.getContextPath();
+        if (contextPath != null && !contextPath.isEmpty() && path.startsWith(contextPath)) {
+            return path.substring(contextPath.length());
+        }
+        return path;
+    }
+}

--- a/src/main/java/com/flyway/security/handler/LoginSuccessHandler.java
+++ b/src/main/java/com/flyway/security/handler/LoginSuccessHandler.java
@@ -56,6 +56,10 @@ public class LoginSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
     }
 
     private String resolveTargetPath(HttpServletRequest request) {
+        String returnUrl = sanitizeReturnUrl(request.getParameter("returnUrl"));
+        if (returnUrl != null) {
+            return returnUrl;
+        }
         Object attribute = request.getAttribute(REDIRECT_PATH_ATTRIBUTE);
         if (attribute instanceof String) {
             String path = ((String) attribute).trim();
@@ -64,5 +68,17 @@ public class LoginSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
             }
         }
         return "/";
+    }
+
+    private String sanitizeReturnUrl(String raw) {
+        if (raw == null) return null;
+        String path = raw.trim();
+        if (path.isEmpty()) return null;
+        if (!path.startsWith("/")) return null;
+        if (path.startsWith("//") || path.startsWith("/\\")) return null;
+        String lower = path.toLowerCase();
+        if (lower.startsWith("/http")) return null;
+        if (path.contains("://")) return null;
+        return path;
     }
 }

--- a/src/main/java/com/flyway/security/handler/WebLoginRedirectEntryPoint.java
+++ b/src/main/java/com/flyway/security/handler/WebLoginRedirectEntryPoint.java
@@ -1,0 +1,58 @@
+package com.flyway.security.handler;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+
+@Slf4j
+@Component
+public class WebLoginRedirectEntryPoint implements AuthenticationEntryPoint {
+
+    @Override
+    public void commence(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            AuthenticationException authException
+    ) throws IOException {
+        String path = resolvePath(request);
+
+        /* 무한 루프 방지 */
+        if ("/login".equals(path) || "/login/".equals(path)) {
+            response.sendRedirect(request.getContextPath() + "/login");
+            return;
+        }
+
+        String returnUrl = buildReturnUrl(request);
+        String encoded = URLEncoder.encode(returnUrl, StandardCharsets.UTF_8);
+        response.sendRedirect(request.getContextPath() + "/login?returnUrl=" + encoded);
+    }
+
+    private String resolvePath(HttpServletRequest request) {
+        String uri = request.getRequestURI();
+        String ctx = request.getContextPath();
+        return (ctx != null && !ctx.isEmpty() && uri.startsWith(ctx)) ? uri.substring(ctx.length()) : uri;
+    }
+
+    private String buildReturnUrl(HttpServletRequest request) {
+        String method = request.getMethod();
+        if (method != null && !method.equalsIgnoreCase("GET")) {
+            return "/";
+        }
+        String path = resolvePath(request);
+        String query = request.getQueryString();
+        String raw = (query != null && !query.isBlank()) ? path + "?" + query : path;
+        if (raw == null || raw.isBlank()) return "/";
+        if (!raw.startsWith("/")) return "/";
+        if (raw.startsWith("//") || raw.startsWith("/\\")) return "/";
+        String lower = raw.toLowerCase();
+        if (lower.startsWith("/http") || raw.contains("://")) return "/";
+        return raw;
+    }
+}

--- a/src/main/java/com/flyway/security/jwt/JwtApiAuthFilter.java
+++ b/src/main/java/com/flyway/security/jwt/JwtApiAuthFilter.java
@@ -4,7 +4,6 @@ import com.flyway.security.handler.JwtAuthenticationEntryPoint;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.lang.NonNull;
-import org.springframework.security.authentication.AnonymousAuthenticationToken;
 import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
@@ -28,6 +27,7 @@ public class JwtApiAuthFilter extends OncePerRequestFilter {
 
     private static final String ACCESS_TOKEN_COOKIE_NAME = "accessToken";
     private static final int TOKEN_LOG_PREFIX_LEN = 20;
+    public static final String JWT_AUTHENTICATED_ATTR = "JWT_AUTHENTICATED";
 
     private final JwtProvider jwtProvider;
     private final JwtAuthenticationEntryPoint authenticationEntryPoint;
@@ -62,14 +62,14 @@ public class JwtApiAuthFilter extends OncePerRequestFilter {
             return;
         }
 
-        if (isAlreadyAuthenticated()) {
-            log.debug("[JWT][API] already authenticated. uri={}", uri);
+        if (isJwtAuthenticatedRequest(req)) {
+            log.debug("[JWT][API] already jwt-authenticated. uri={}", uri);
             chain.doFilter(req, res);
             return;
         }
 
         try {
-            authenticate(token);
+            authenticate(token, req);
             log.debug("[JWT][API] authenticated. uri={}, tokenPrefix={}", uri, safePrefix(token, TOKEN_LOG_PREFIX_LEN));
             chain.doFilter(req, res);
 
@@ -85,15 +85,17 @@ public class JwtApiAuthFilter extends OncePerRequestFilter {
         }
     }
 
-    private void authenticate(String token) {
+    private void authenticate(String token, HttpServletRequest req) {
         String userId = jwtProvider.getSubjectOrThrow(token);
 
         UserDetails userDetails = userIdUserDetailsService.loadUserByUsername(userId);
 
-        Authentication auth = new UsernamePasswordAuthenticationToken(
+        UsernamePasswordAuthenticationToken auth = new UsernamePasswordAuthenticationToken(
                 userDetails, null, userDetails.getAuthorities()
         );
+        auth.setDetails(JWT_AUTHENTICATED_ATTR);
         SecurityContextHolder.getContext().setAuthentication(auth);
+        req.setAttribute(JWT_AUTHENTICATED_ATTR, Boolean.TRUE);
     }
 
     private String extractAccessTokenFromCookie(HttpServletRequest req) {
@@ -108,11 +110,17 @@ public class JwtApiAuthFilter extends OncePerRequestFilter {
         return null;
     }
 
-    private boolean isAlreadyAuthenticated() {
+    private boolean isJwtAuthenticatedRequest(HttpServletRequest req) {
+        Object flag = req.getAttribute(JWT_AUTHENTICATED_ATTR);
+        if (Boolean.TRUE.equals(flag)) {
+            return true;
+        }
         Authentication existing = SecurityContextHolder.getContext().getAuthentication();
-        return existing != null
-                && existing.isAuthenticated()
-                && !(existing instanceof AnonymousAuthenticationToken);
+        if (existing == null || !existing.isAuthenticated()) {
+            return false;
+        }
+        Object details = existing.getDetails();
+        return JWT_AUTHENTICATED_ATTR.equals(details) || Boolean.TRUE.equals(details);
     }
 
     private String resolvePath(HttpServletRequest request) {

--- a/src/main/java/com/flyway/security/jwt/JwtWebAuthFilter.java
+++ b/src/main/java/com/flyway/security/jwt/JwtWebAuthFilter.java
@@ -29,7 +29,7 @@ public class JwtWebAuthFilter extends OncePerRequestFilter {
 
     private static final String ACCESS_TOKEN_COOKIE_NAME = "accessToken";
     private static final String ADMIN_PREFIX = "/admin/";
-    public static final String JWT_AUTHENTICATED_ATTR = "JWT_AUTHENTICATED";
+    private static final String JWT_AUTHENTICATED_ATTR = "JWT_AUTHENTICATED";
 
     private final JwtProvider jwtProvider;
     private final JwtAuthenticationEntryPoint entryPoint;

--- a/src/main/java/com/flyway/security/jwt/JwtWebAuthFilter.java
+++ b/src/main/java/com/flyway/security/jwt/JwtWebAuthFilter.java
@@ -50,7 +50,7 @@ public class JwtWebAuthFilter extends OncePerRequestFilter {
     ) throws ServletException, IOException {
 
         String path = resolvePath(request);
-        if (path.startsWith("/login")) {
+        if (path.equals("/login") || path.startsWith("/login/")) {
             filterChain.doFilter(request, response);
             return;
         }

--- a/src/main/java/com/flyway/security/jwt/JwtWebAuthFilter.java
+++ b/src/main/java/com/flyway/security/jwt/JwtWebAuthFilter.java
@@ -5,7 +5,6 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.lang.NonNull;
 import org.springframework.security.authentication.AnonymousAuthenticationToken;
-import org.springframework.security.authentication.AuthenticationServiceException;
 import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
@@ -21,6 +20,8 @@ import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -28,6 +29,7 @@ public class JwtWebAuthFilter extends OncePerRequestFilter {
 
     private static final String ACCESS_TOKEN_COOKIE_NAME = "accessToken";
     private static final String ADMIN_PREFIX = "/admin/";
+    public static final String JWT_AUTHENTICATED_ATTR = "JWT_AUTHENTICATED";
 
     private final JwtProvider jwtProvider;
     private final JwtAuthenticationEntryPoint entryPoint;
@@ -47,6 +49,12 @@ public class JwtWebAuthFilter extends OncePerRequestFilter {
             @NonNull FilterChain filterChain
     ) throws ServletException, IOException {
 
+        String path = resolvePath(request);
+        if (path.startsWith("/login")) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
         try {
             if (!isAuthenticated()) {
                 String token = extractAccessTokenFromCookie(request);
@@ -62,6 +70,7 @@ public class JwtWebAuthFilter extends OncePerRequestFilter {
                             );
 
                     SecurityContextHolder.getContext().setAuthentication(auth);
+                    request.setAttribute(JWT_AUTHENTICATED_ATTR, Boolean.TRUE);
 
                     log.debug("[JWT][WEB] authenticated. uri={}, userId={}",
                             request.getRequestURI(), userId);
@@ -74,15 +83,11 @@ public class JwtWebAuthFilter extends OncePerRequestFilter {
             SecurityContextHolder.clearContext();
             log.warn("[JWT][WEB] bad credentials. uri={}, msg={}",
                     request.getRequestURI(), e.getMessage());
-            entryPoint.commence(request, response, e);
+            redirectToLogin(request, response);
         } catch (Exception e) {
             SecurityContextHolder.clearContext();
             log.error("[JWT][WEB] unexpected exception. uri={}", request.getRequestURI(), e);
-            entryPoint.commence(
-                    request,
-                    response,
-                    new AuthenticationServiceException("JWT authentication failed", e)
-            );
+            redirectToLogin(request, response);
         }
     }
 
@@ -109,5 +114,27 @@ public class JwtWebAuthFilter extends OncePerRequestFilter {
         String uri = request.getRequestURI();
         String ctx = request.getContextPath();
         return (ctx != null && !ctx.isEmpty() && uri.startsWith(ctx)) ? uri.substring(ctx.length()) : uri;
+    }
+
+    private void redirectToLogin(HttpServletRequest request, HttpServletResponse response) throws IOException {
+        String returnUrl = buildReturnUrl(request);
+        String encoded = URLEncoder.encode(returnUrl, StandardCharsets.UTF_8);
+        response.sendRedirect(request.getContextPath() + "/login?returnUrl=" + encoded);
+    }
+
+    private String buildReturnUrl(HttpServletRequest request) {
+        String method = request.getMethod();
+        if (method != null && !method.equalsIgnoreCase("GET")) {
+            return "/";
+        }
+        String path = resolvePath(request);
+        String query = request.getQueryString();
+        String raw = (query != null && !query.isBlank()) ? path + "?" + query : path;
+        if (raw == null || raw.isBlank()) return "/";
+        if (!raw.startsWith("/")) return "/";
+        if (raw.startsWith("//") || raw.startsWith("/\\")) return "/";
+        String lower = raw.toLowerCase();
+        if (lower.startsWith("/http") || raw.contains("://")) return "/";
+        return raw;
     }
 }

--- a/src/main/resources/config/application-prod.properties
+++ b/src/main/resources/config/application-prod.properties
@@ -58,3 +58,6 @@ toss.payments.fail-url=https://www.flyway.kr/payments/fail
 sms.nurigo.api-key=${SMS_NURIGO_API_KEY}
 sms.nurigo.api-secret=${SMS_NURIGO_API_SECRET}
 sms.nurigo.sender=${SMS_NURIGO_SENDER}
+
+#==== Security ====
+security.allowed-origins=https://flyway.kr

--- a/src/main/resources/config/application-prod.properties
+++ b/src/main/resources/config/application-prod.properties
@@ -60,4 +60,4 @@ sms.nurigo.api-secret=${SMS_NURIGO_API_SECRET}
 sms.nurigo.sender=${SMS_NURIGO_SENDER}
 
 #==== Security ====
-security.allowed-origins=https://flyway.kr
+security.allowed-origins=https://flyway.kr,https://www.flyway.kr

--- a/src/main/webapp/WEB-INF/views/auth/include/head.jsp
+++ b/src/main/webapp/WEB-INF/views/auth/include/head.jsp
@@ -29,6 +29,10 @@
 <!-- SweetAlert2 -->
 <script src="https://cdn.jsdelivr.net/npm/sweetalert2@11"></script>
 <script src="${pageContext.request.contextPath}/resources/common/js/swal-utils.js"></script>
+<script type="module">
+    import { csrfFetch } from "${pageContext.request.contextPath}/resources/common/js/csrfFetch.js";
+    window.csrfFetch = csrfFetch;
+</script>
 <!-- Flatpickr (달력) -->
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/flatpickr/dist/flatpickr.min.css">
 <script src="https://cdn.jsdelivr.net/npm/flatpickr"></script>

--- a/src/main/webapp/WEB-INF/views/common/head.jsp
+++ b/src/main/webapp/WEB-INF/views/common/head.jsp
@@ -26,3 +26,7 @@
 
 <!-- SweetAlert2 공통 유틸리티 -->
 <script src="${pageContext.request.contextPath}/resources/common/js/swal-utils.js"></script>
+<script type="module">
+    import { csrfFetch } from "${pageContext.request.contextPath}/resources/common/js/csrfFetch.js";
+    window.csrfFetch = csrfFetch;
+</script>

--- a/src/main/webapp/WEB-INF/views/common/header.jsp
+++ b/src/main/webapp/WEB-INF/views/common/header.jsp
@@ -53,6 +53,7 @@
               마이페이지
             </a>
             <form action="${pageContext.request.contextPath}/auth/logout" method="post" class="dropdown-form">
+              <sec:csrfInput/>
               <button type="submit" class="dropdown-item dropdown-logout">
                 <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
                   <path stroke-linecap="round" stroke-linejoin="round" d="M17 16l4-4m0 0l-4-4m4 4H7m6 4v1a3 3 0 01-3 3H6a3 3 0 01-3-3V7a3 3 0 013-3h4a3 3 0 013 3v1"/>

--- a/src/main/webapp/WEB-INF/views/home.jsp
+++ b/src/main/webapp/WEB-INF/views/home.jsp
@@ -1,4 +1,5 @@
 <%@ page contentType="text/html; charset=UTF-8" pageEncoding="UTF-8" %>
+<%@ taglib prefix="sec" uri="http://www.springframework.org/security/tags" %>
 <!DOCTYPE html>
 <html lang="ko">
 <head>
@@ -240,6 +241,7 @@
 
 <!-- Hidden Form for Reservation -->
 <form id="reservationForm" action="${pageContext.request.contextPath}/reservations/draft" method="post" style="display:none;">
+    <sec:csrfInput/>
     <input type="hidden" id="hiddenOutFlightId" name="outFlightId">
     <input type="hidden" id="hiddenInFlightId" name="inFlightId">
     <input type="hidden" id="hiddenPassengerCount" name="passengerCount">

--- a/src/main/webapp/WEB-INF/views/login.jsp
+++ b/src/main/webapp/WEB-INF/views/login.jsp
@@ -1,5 +1,6 @@
 <%@ page language="java" contentType="text/html; charset=UTF-8" pageEncoding="UTF-8"%>
 <%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="fn" uri="http://java.sun.com/jsp/jstl/functions" %>
 <!DOCTYPE html>
 <html>
 <head>
@@ -28,6 +29,7 @@
                 </div>
             </c:if>
             <form action="${pageContext.request.contextPath}/loginProc" method="post" class="space-y-5">
+                <input type="hidden" name="returnUrl" value="${fn:escapeXml(returnUrl)}">
                 <div>
                     <label class="block text-sm font-medium text-slate-700 mb-1.5">이메일</label>
                     <div class="relative">

--- a/src/main/webapp/WEB-INF/views/login.jsp
+++ b/src/main/webapp/WEB-INF/views/login.jsp
@@ -1,6 +1,7 @@
 <%@ page language="java" contentType="text/html; charset=UTF-8" pageEncoding="UTF-8"%>
 <%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
 <%@ taglib prefix="fn" uri="http://java.sun.com/jsp/jstl/functions" %>
+<%@ taglib prefix="sec" uri="http://www.springframework.org/security/tags" %>
 <!DOCTYPE html>
 <html>
 <head>
@@ -29,6 +30,7 @@
                 </div>
             </c:if>
             <form action="${pageContext.request.contextPath}/loginProc" method="post" class="space-y-5">
+                <sec:csrfInput/>
                 <input type="hidden" name="returnUrl" value="${fn:escapeXml(returnUrl)}">
                 <div>
                     <label class="block text-sm font-medium text-slate-700 mb-1.5">이메일</label>

--- a/src/main/webapp/WEB-INF/views/payment/refund-test.jsp
+++ b/src/main/webapp/WEB-INF/views/payment/refund-test.jsp
@@ -37,6 +37,10 @@
             cursor: not-allowed;
         }
     </style>
+    <script type="module">
+        import { csrfFetch } from "${pageContext.request.contextPath}/resources/common/js/csrfFetch.js";
+        window.csrfFetch = csrfFetch;
+    </script>
 </head>
 <body>
 <div class="container">
@@ -105,7 +109,7 @@
         }
 
         if (confirm('결제 ID: ' + paymentId + '\n환불 사유: ' + reason + '\n\n정말로 환불을 요청하시겠습니까?')) {
-            fetch(contextPath + '/api/payments/' + paymentId + '/refund',{
+            csrfFetch(contextPath + '/api/payments/' + paymentId + '/refund',{
                 method: 'POST',
                 headers: {
                     'Content-Type': 'application/json',
@@ -140,4 +144,3 @@
 </script>
 </body>
 </html>
-

--- a/src/main/webapp/WEB-INF/views/reservations/agreement.jsp
+++ b/src/main/webapp/WEB-INF/views/reservations/agreement.jsp
@@ -1,6 +1,7 @@
 <%@ page contentType="text/html; charset=UTF-8" pageEncoding="UTF-8"%>
 <%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core"%>
 <%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt"%>
+<%@ taglib prefix="sec" uri="http://www.springframework.org/security/tags" %>
 <!doctype html>
 <html lang="ko">
 <head>
@@ -197,6 +198,7 @@
                 </c:if>
 
                 <form method="post" id="agreeForm">
+                    <sec:csrfInput/>
                     <input type="hidden" name="agreeAll" id="agreeAllHidden" value="false"/>
 
                     <!-- 전체 동의 -->

--- a/src/main/webapp/WEB-INF/views/reservations/booking.jsp
+++ b/src/main/webapp/WEB-INF/views/reservations/booking.jsp
@@ -2,6 +2,7 @@
 <%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core"%>
 <%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt"%>
 <%@ taglib prefix="fn" uri="http://java.sun.com/jsp/jstl/functions" %>
+<%@ taglib prefix="sec" uri="http://www.springframework.org/security/tags" %>
 
 <!doctype html>
 <html lang="ko">
@@ -324,6 +325,7 @@
 
                 <c:url var="saveUrl" value="/reservations/${vm.reservationId}/passengers"/>
                 <form id="passengerForm">
+                    <sec:csrfInput/>
                     <c:forEach var="p" items="${vm.passengers}" varStatus="st">
                         <div class="mb-8 last:mb-0 pb-8 last:pb-0">
                             <h4 class="font-bold text-sm text-gray-800 mb-4">탑승자 ${st.index + 1}</h4>

--- a/src/main/webapp/WEB-INF/views/seat/seat-assets-js.jspf
+++ b/src/main/webapp/WEB-INF/views/seat/seat-assets-js.jspf
@@ -1,6 +1,10 @@
 <%-- SweetAlert2 --%>
 <script src="https://cdn.jsdelivr.net/npm/sweetalert2@11"></script>
 <script src="${pageContext.request.contextPath}/resources/common/js/swal-utils.js"></script>
+<script type="module">
+    import { csrfFetch } from "${pageContext.request.contextPath}/resources/common/js/csrfFetch.js";
+    window.csrfFetch = csrfFetch;
+</script>
 
 <%-- Seat Selection --%>
 <script defer src="${pageContext.request.contextPath}/resources/seat/js/seat-api.js?v=<%= System.currentTimeMillis() %>"></script>

--- a/src/main/webapp/WEB-INF/views/signup.jsp
+++ b/src/main/webapp/WEB-INF/views/signup.jsp
@@ -1,5 +1,6 @@
 <%@ page language="java" contentType="text/html; charset=UTF-8" pageEncoding="UTF-8" %>
 <%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="sec" uri="http://www.springframework.org/security/tags" %>
 
 <!DOCTYPE html>
 <html lang="ko">
@@ -92,6 +93,7 @@
     </c:if>
 
     <form id="signupForm" action="${pageContext.request.contextPath}/auth/signup" method="post" class="bg-white p-8 rounded-2xl shadow-sm border border-slate-200 space-y-5">
+      <sec:csrfInput/>
 
       <!-- Name -->
       <div>

--- a/src/main/webapp/resources/auth/signup.js
+++ b/src/main/webapp/resources/auth/signup.js
@@ -40,7 +40,7 @@
         setText(sendStatus, "인증메일을 발송 중입니다...", true);
 
         try {
-            const res = await fetch(base + "/api/auth/email/issue", {
+            const res = await csrfFetch(base + "/api/auth/email/issue", {
                 method: "POST",
                 headers: {
                     "Content-Type": "application/x-www-form-urlencoded;charset=UTF-8"
@@ -89,7 +89,7 @@
                 email: email,
                 attemptId: attemptIdHidden.value
             });
-            const res = await fetch(base + "/api/auth/email/status?" + query.toString());
+            const res = await csrfFetch(base + "/api/auth/email/status?" + query.toString());
 
             if (!res.ok) {
                 setText(verifyStatus, "인증 확인에 실패했습니다.", false);

--- a/src/main/webapp/resources/common/js/authFetch.js
+++ b/src/main/webapp/resources/common/js/authFetch.js
@@ -38,7 +38,6 @@ function toFetchUrl(input) {
 export async function fetchWithRefresh(input, init = {}) {
     const doFetch = async (overrideInit = {}) => {
         const merged = { ...init, ...overrideInit };
-        // csrfFetch가 GET/POST 알아서 처리함
         return csrfFetch(input, merged);
     };
 

--- a/src/main/webapp/resources/common/js/authFetch.js
+++ b/src/main/webapp/resources/common/js/authFetch.js
@@ -1,3 +1,5 @@
+import { csrfFetch } from "./csrfFetch.js";
+
 const CONFIG = {
     REFRESH_URL: "/auth/refresh",
     LOGIN_URL: "/login",
@@ -8,50 +10,45 @@ let refreshPromise = null;
 function getBasePath() {
     return window.APP?.contextPath ?? "";
 }
-
 function isAbsoluteHttpUrl(url) {
     return typeof url === "string" && /^https?:\/\//i.test(url);
 }
-
 function joinBasePath(base, path) {
     if (!base) return path;
     const b = base.endsWith("/") ? base.slice(0, -1) : base;
     const p = path.startsWith("/") ? path : `/${path}`;
     return `${b}${p}`;
 }
-
 function normalizeInputToUrl(input) {
     if (input instanceof Request) return input.url;
     if (typeof input === "string") return input;
     return String(input);
 }
-
 function toFetchUrl(input) {
     const raw = normalizeInputToUrl(input);
     if (isAbsoluteHttpUrl(raw)) return raw;
-
-    const base = getBasePath();
-    return joinBasePath(base, raw);
+    return joinBasePath(getBasePath(), raw);
 }
 
+/**
+ * 인증 필요 API 전용
+ * - 401이면 refresh 시도 후 재요청
+ * - refresh 실패/재시도 후에도 401이면 /login 이동
+ */
 export async function fetchWithRefresh(input, init = {}) {
-    const doFetch = async () =>
-        fetch(toFetchUrl(input), {
-            credentials: "same-origin",
-            ...init,
-        });
+    const doFetch = async (overrideInit = {}) => {
+        const merged = { ...init, ...overrideInit };
+        // csrfFetch가 GET/POST 알아서 처리함
+        return csrfFetch(input, merged);
+    };
 
     let res = await doFetch();
-
     if (res.status !== 401) return res;
 
     if (!refreshPromise) {
         refreshPromise = (async () => {
             try {
-                const refreshRes = await fetch(toFetchUrl(CONFIG.REFRESH_URL), {
-                    method: "POST",
-                    credentials: "same-origin",
-                });
+                const refreshRes = await csrfFetch(CONFIG.REFRESH_URL, { method: "POST" });
                 return refreshRes.ok;
             } catch (e) {
                 return false;
@@ -68,7 +65,6 @@ export async function fetchWithRefresh(input, init = {}) {
         throw new Error("Unauthorized (refresh failed)");
     }
 
-    // refresh 성공 → 재시도
     res = await doFetch();
 
     if (res.status === 401) {

--- a/src/main/webapp/resources/common/js/csrfFetch.js
+++ b/src/main/webapp/resources/common/js/csrfFetch.js
@@ -1,0 +1,96 @@
+const CONFIG = {
+    CSRF_COOKIE_NAME: "XSRF-TOKEN",
+    CSRF_HEADER_NAME: "X-XSRF-TOKEN",
+    CSRF_BOOTSTRAP_URL: "/auth/csrf",
+};
+
+function getBasePath() {
+    return window.APP?.contextPath ?? "";
+}
+
+function isAbsoluteHttpUrl(url) {
+    return typeof url === "string" && /^https?:\/\//i.test(url);
+}
+
+function joinBasePath(base, path) {
+    if (!base) return path;
+    const b = base.endsWith("/") ? base.slice(0, -1) : base;
+    const p = path.startsWith("/") ? path : `/${path}`;
+    return `${b}${p}`;
+}
+
+function normalizeInputToUrl(input) {
+    if (input instanceof Request) return input.url;
+    if (typeof input === "string") return input;
+    return String(input);
+}
+
+function toFetchUrl(input) {
+    const raw = normalizeInputToUrl(input);
+    if (isAbsoluteHttpUrl(raw)) return raw;
+    return joinBasePath(getBasePath(), raw);
+}
+
+function readCookieRaw(name) {
+    const found = document.cookie
+        .split("; ")
+        .find((row) => row.startsWith(name + "="));
+    if (!found) return null;
+    const idx = found.indexOf("=");
+    return found.substring(idx + 1);
+}
+
+function readCookie(name) {
+    const raw = readCookieRaw(name);
+    return raw ? decodeURIComponent(raw) : null;
+}
+
+function isStateChanging(method) {
+    const m = (method || "GET").toUpperCase();
+    return ["POST", "PUT", "PATCH", "DELETE"].includes(m);
+}
+
+async function ensureCsrfCookie() {
+    const existing = readCookie(CONFIG.CSRF_COOKIE_NAME);
+    if (existing) return existing;
+
+    try {
+        await fetch(toFetchUrl(CONFIG.CSRF_BOOTSTRAP_URL), {
+            method: "GET",
+            credentials: "same-origin",
+            cache: "no-store",
+        });
+    } catch (e) {}
+
+    return readCookie(CONFIG.CSRF_COOKIE_NAME);
+}
+
+function withCsrfHeader(init = {}) {
+    const method = (init.method || "GET").toUpperCase();
+    if (!isStateChanging(method)) return init;
+
+    const headers = new Headers(init.headers || {});
+    if (!headers.has(CONFIG.CSRF_HEADER_NAME)) {
+        const token = readCookie(CONFIG.CSRF_COOKIE_NAME);
+        if (token) headers.set(CONFIG.CSRF_HEADER_NAME, token);
+    }
+
+    return { ...init, headers };
+}
+
+/**
+ * csrfFetch
+ * - GET/HEAD/OPTIONS: 그냥 fetch
+ * - POST/PUT/PATCH/DELETE: CSRF 쿠키 보장 + 헤더 자동첨부
+ * - 401 처리/refresh/redirect 절대 안 함
+ */
+export async function csrfFetch(input, init = {}) {
+    const merged = { credentials: "same-origin", ...init };
+
+    if (isStateChanging(merged.method)) {
+        const token = await ensureCsrfCookie();
+        if (!token) throw new Error("CSRF token cookie not found (bootstrap failed)");
+    }
+
+    return fetch(toFetchUrl(input), withCsrfHeader(merged));
+}

--- a/src/main/webapp/resources/common/js/csrfFetch.js
+++ b/src/main/webapp/resources/common/js/csrfFetch.js
@@ -4,6 +4,31 @@ const CONFIG = {
     CSRF_BOOTSTRAP_URL: "/auth/csrf",
 };
 
+let csrfFetchReady = false;
+const pendingCsrfFetchCalls = [];
+
+function enqueueCsrfFetchCall(args) {
+    return new Promise((resolve, reject) => {
+        pendingCsrfFetchCalls.push({ args, resolve, reject });
+    });
+}
+
+function flushQueuedCsrfFetchCalls() {
+    while (pendingCsrfFetchCalls.length > 0) {
+        const call = pendingCsrfFetchCalls.shift();
+        csrfFetch(...call.args).then(call.resolve).catch(call.reject);
+    }
+}
+
+if (typeof window !== "undefined") {
+    window.csrfFetch = (...args) => {
+        if (csrfFetchReady) {
+            return csrfFetch(...args);
+        }
+        return enqueueCsrfFetchCall(args);
+    };
+}
+
 function getBasePath() {
     return window.APP?.contextPath ?? "";
 }
@@ -93,4 +118,11 @@ export async function csrfFetch(input, init = {}) {
     }
 
     return fetch(toFetchUrl(input), withCsrfHeader(merged));
+}
+
+csrfFetchReady = true;
+
+if (typeof window !== "undefined") {
+    window.csrfFetch = (...args) => csrfFetch(...args);
+    flushQueuedCsrfFetchCalls();
 }

--- a/src/main/webapp/resources/common/js/csrfFetch.js
+++ b/src/main/webapp/resources/common/js/csrfFetch.js
@@ -16,10 +16,11 @@ function enqueueCsrfFetchCall(args) {
 function flushQueuedCsrfFetchCalls() {
     while (pendingCsrfFetchCalls.length > 0) {
         const call = pendingCsrfFetchCalls.shift();
-        csrfFetch(...call.args).then(call.resolve).catch(call.reject);
+        Promise.resolve(csrfFetch(...call.args)).then(call.resolve).catch(call.reject);
     }
 }
 
+// Early global binding: queue calls until this module finishes initialization.
 if (typeof window !== "undefined") {
     window.csrfFetch = (...args) => {
         if (csrfFetchReady) {

--- a/src/main/webapp/resources/main/js/main.js
+++ b/src/main/webapp/resources/main/js/main.js
@@ -5,7 +5,7 @@ document.addEventListener("DOMContentLoaded", () => {
 
 async function loadHotSixAirport() {
     try {
-        const res = await fetch(`${CONTEXT_PATH}/api/public/rank/realtime`);
+        const res = await csrfFetch(`${CONTEXT_PATH}/api/public/rank/realtime`);
         if (!res.ok) {
             throw new Error(`HTTP ${res.status}`);
         }

--- a/src/main/webapp/resources/main/js/promotion.js
+++ b/src/main/webapp/resources/main/js/promotion.js
@@ -67,7 +67,7 @@ function moveNext() {
 // api 호출
 async function loadPromotionCard() {
     try {
-        const res = await fetch(`${CONTEXT_PATH}/api/public/promotions`);
+        const res = await csrfFetch(`${CONTEXT_PATH}/api/public/promotions`);
         if(!res.ok) {
             throw new Error(`HTTP ${res.status}`);
         }

--- a/src/main/webapp/resources/mypage/js/render/bookings.js
+++ b/src/main/webapp/resources/mypage/js/render/bookings.js
@@ -12,6 +12,7 @@ import {
     formatReservationId,
     getContextPath,
 } from "../utils.js";
+import { csrfFetch } from "../../../common/js/csrfFetch.js";
 
 let airlineMapPromise = null;
 
@@ -26,7 +27,7 @@ function toAssetUrl(path) {
 async function getAirlineMap() {
     if (airlineMapPromise) return airlineMapPromise;
     const url = `${getContextPath()}/resources/mypage/json/airline.json`;
-    airlineMapPromise = fetch(url, { headers: { Accept: "application/json" } })
+    airlineMapPromise = csrfFetch(url, { headers: { Accept: "application/json" } })
         .then((res) => (res.ok ? res.json() : {}))
         .catch(() => ({}));
     return airlineMapPromise;

--- a/src/main/webapp/resources/mypage/js/render/dashboard.js
+++ b/src/main/webapp/resources/mypage/js/render/dashboard.js
@@ -9,6 +9,7 @@ import {
     formatReservationId,
     getContextPath,
 } from "../utils.js";
+import { csrfFetch } from "../../../common/js/csrfFetch.js";
 
 export function updateDashboardProfile(profile) {
     const name = profile?.name || "";
@@ -113,7 +114,7 @@ function toAssetUrl(path) {
 
 function getAirlineMap() {
     const url = `${getContextPath()}/resources/mypage/json/airline.json`;
-    return fetch(url, { headers: { Accept: "application/json" } })
+    return csrfFetch(url, { headers: { Accept: "application/json" } })
         .then((res) => (res.ok ? res.json() : {}))
         .catch(() => ({}));
 }

--- a/src/main/webapp/resources/mypage/js/render/detail.js
+++ b/src/main/webapp/resources/mypage/js/render/detail.js
@@ -11,6 +11,7 @@ import {
     getContextPath,
 } from "../utils.js";
 import { fetchJson } from "../api.js";
+import { csrfFetch } from "../../../common/js/csrfFetch.js";
 
 let airlineMapPromise = null;
 
@@ -25,7 +26,7 @@ function toAssetUrl(path) {
 async function getAirlineMap() {
     if (airlineMapPromise) return airlineMapPromise;
     const url = `${getContextPath()}/resources/mypage/json/airline.json`;
-    airlineMapPromise = fetch(url, { headers: { Accept: "application/json" } })
+    airlineMapPromise = csrfFetch(url, { headers: { Accept: "application/json" } })
         .then((res) => (res.ok ? res.json() : {}))
         .catch(() => ({}));
     return airlineMapPromise;

--- a/src/main/webapp/resources/search/js/details.js
+++ b/src/main/webapp/resources/search/js/details.js
@@ -27,7 +27,7 @@ async function openDetailPage(index) {
 
     const requestSeq = ++detailRequestSeq;
     try {
-        const res = await fetch(`${CONTEXT_PATH}/api/public/flights/details?cabinClass=${cabinClass}&routeType=${routeType}`);
+        const res = await csrfFetch(`${CONTEXT_PATH}/api/public/flights/details?cabinClass=${cabinClass}&routeType=${routeType}`);
 
         if (res.ok) {
             const details = await res.json();

--- a/src/main/webapp/resources/search/js/filtering.js
+++ b/src/main/webapp/resources/search/js/filtering.js
@@ -20,7 +20,7 @@ document.addEventListener("DOMContentLoaded", async () => {
 });
 
 async function loadAirlines() {
-    const res = await fetch(`${CONTEXT_PATH}/api/public/airlines`);
+    const res = await csrfFetch(`${CONTEXT_PATH}/api/public/airlines`);
     const data = await res.json();
 
     AIRLINES = data.map(a => ({

--- a/src/main/webapp/resources/search/js/flight.js
+++ b/src/main/webapp/resources/search/js/flight.js
@@ -285,7 +285,7 @@ async function fetchPriceHistory({ flightId, cabinClassCode, from, to }) {
 
     const url = `${CONTEXT_PATH}/api/public/flights/price-history?${params.toString()}`;
 
-    const res = await fetch(url, { headers: { "Accept": "application/json" } });
+    const res = await csrfFetch(url, { headers: { "Accept": "application/json" } });
     if (!res.ok) throw new Error("price-history fetch failed");
     return await res.json(); // { points: [{t, price, type}, ...] }
 }
@@ -683,10 +683,10 @@ document.getElementById("resultList").addEventListener("click", async (e) => {
                 params.set("inFlightId", inId);
             }
 
-            const response = await fetch(`${CONTEXT_PATH}/api/public/flights/prices?${params}`, {
+            const response = await csrfFetch(`${CONTEXT_PATH}/api/public/flights/prices?${params}`, {
                 method: 'GET',
                 headers: {
-                    'Content-Type': 'application/json'
+                    'Accept': 'application/json'
                 }
             });
 

--- a/src/main/webapp/resources/search/js/search.js
+++ b/src/main/webapp/resources/search/js/search.js
@@ -3,6 +3,7 @@ let ARR_AIRPORTS = [];
 let allOptions = [];
 let displayedOptions = [];
 let details = {};
+const csrfFetch = window.csrfFetch || ((input, init = {}) => fetch(input, { credentials: "same-origin", ...init }));
 
 async function loadDepAirports() {
     const res = await fetch(`${CONTEXT_PATH}/api/public/depAirports`);
@@ -785,14 +786,16 @@ async function executeSearch() {
     };
 
     try {
-        // 3) 검색 API 호출 (POST)
-        const res = await fetch(`${CONTEXT_PATH}/api/public/flights/search`, {
-            method: "POST",
-            headers: {
-                "Content-Type": "application/json",
-                "Accept": "application/json"
-            },
-            body: JSON.stringify(payload)
+        const paramsBuilder = new URLSearchParams();
+        Object.entries(payload).forEach(([key, value]) => {
+            if (value === null || value === undefined || value === "") return;
+            paramsBuilder.append(key, value);
+        });
+        const params = paramsBuilder.toString();
+        // 3) 검색 API 호출 (GET)
+        const res = await csrfFetch(`${CONTEXT_PATH}/api/public/flights/search?${params}`, {
+            method: "GET",
+            headers: { "Accept": "application/json" }
         });
 
         const json = await res.json();

--- a/src/main/webapp/resources/search/js/search.js
+++ b/src/main/webapp/resources/search/js/search.js
@@ -3,10 +3,8 @@ let ARR_AIRPORTS = [];
 let allOptions = [];
 let displayedOptions = [];
 let details = {};
-const csrfFetch = window.csrfFetch || ((input, init = {}) => fetch(input, { credentials: "same-origin", ...init }));
-
 async function loadDepAirports() {
-    const res = await fetch(`${CONTEXT_PATH}/api/public/depAirports`);
+    const res = await csrfFetch(`${CONTEXT_PATH}/api/public/depAirports`);
     const data = await res.json();
     DEP_AIRPORTS = data.map(a => ({
         code: a.airportId,
@@ -241,7 +239,7 @@ function setFieldText(fieldName, mainText, hintText = "") {
 async function loadArrAirports(depCode) {
     if (!depCode) return;
 
-    const res = await fetch(
+    const res = await csrfFetch(
         `${CONTEXT_PATH}/api/public/arrAirports?depAirport=${depCode}`
     );
     const data = await res.json();

--- a/src/main/webapp/resources/seat/js/seat-api.js
+++ b/src/main/webapp/resources/seat/js/seat-api.js
@@ -1,4 +1,5 @@
 (function (global) {
+
     async function safeJson(res) {
         const ct = res.headers.get("content-type") || "";
         const text = await res.text();
@@ -16,13 +17,13 @@
     }
 
     function fetchSeatMap(ctx, reservationId, segmentId) {
-        return fetch(`${ctx}/api/seats/reservations/${encodeURIComponent(reservationId)}/segments/${encodeURIComponent(segmentId)}`, {
+        return csrfFetch(`${ctx}/api/seats/reservations/${encodeURIComponent(reservationId)}/segments/${encodeURIComponent(segmentId)}`, {
             credentials: 'include'  // 쿠키 포함 (JWT 인증용)
         }).then(safeJson).then(d => d?.data ?? []);
     }
 
     function holdSeat(ctx, reservationId, segmentId, body) {
-        return fetch(`${ctx}/api/seats/reservations/${encodeURIComponent(reservationId)}/segments/${encodeURIComponent(segmentId)}/hold`,
+        return csrfFetch(`${ctx}/api/seats/reservations/${encodeURIComponent(reservationId)}/segments/${encodeURIComponent(segmentId)}/hold`,
             {
                 method: "POST",
                 headers: { "Content-Type": "application/json", "Accept": "application/json" },
@@ -31,7 +32,7 @@
             }).then(safeJson);
     }
     function releaseHold(ctx, reservationId, segmentId, passengerId) {
-        return fetch(`${ctx}/api/seats/reservations/${encodeURIComponent(reservationId)}/segments/${encodeURIComponent(segmentId)}/hold/${encodeURIComponent(passengerId)}`, {
+        return csrfFetch(`${ctx}/api/seats/reservations/${encodeURIComponent(reservationId)}/segments/${encodeURIComponent(segmentId)}/hold/${encodeURIComponent(passengerId)}`, {
             method: "DELETE",
             headers: { "Accept": "application/json" },
             credentials: 'include'

--- a/src/main/webapp/resources/signup/js/signup.js
+++ b/src/main/webapp/resources/signup/js/signup.js
@@ -243,7 +243,7 @@
       if (verifySentBox) verifySentBox.classList.add("hidden");
 
       try {
-        const res = await fetch(`${contextPath}/api/auth/email/issue`, {
+        const res = await csrfFetch(`${contextPath}/api/auth/email/issue`, {
           method: "POST",
           headers: {
             "Content-Type": "application/x-www-form-urlencoded;charset=UTF-8",
@@ -321,7 +321,7 @@
           email,
           attemptId: attemptIdHidden?.value || "",
         });
-        const res = await fetch(`${contextPath}/api/auth/email/status?${query.toString()}`);
+        const res = await csrfFetch(`${contextPath}/api/auth/email/status?${query.toString()}`);
 
         if (!res.ok) {
           if (verifyErrorStatus) {
@@ -507,7 +507,7 @@
         if (smsErrorStatus) smsErrorStatus.classList.add("hidden");
 
         try {
-            const res = await fetch(`${contextPath}/api/sms/send?phoneNumber=${encodeURIComponent(phone)}`, {
+            const res = await csrfFetch(`${contextPath}/api/sms/send?phoneNumber=${encodeURIComponent(phone)}`, {
                 method: "POST"
             });
             const data = await res.json();
@@ -560,7 +560,7 @@
 
             try {
                 const params = new URLSearchParams({ phoneNumber: phone, code: code });
-                const res = await fetch(`${contextPath}/api/sms/verify?${params.toString()}`, {
+                const res = await csrfFetch(`${contextPath}/api/sms/verify?${params.toString()}`, {
                     method: "POST"
                 });
                 const data = await res.json();

--- a/src/test/java/com/flyway/auth/service/AuthTokenServiceImplTest.java
+++ b/src/test/java/com/flyway/auth/service/AuthTokenServiceImplTest.java
@@ -33,6 +33,7 @@ class AuthTokenServiceImplTest {
     private JwtProperties jwtProperties;
     private RefreshTokenRepository refreshTokenRepository;
     private TokenHasher tokenHasher;
+    private RefreshTokenRevocationService refreshTokenRevocationService;
     private AuthTokenServiceImpl service;
 
     @BeforeEach
@@ -41,12 +42,14 @@ class AuthTokenServiceImplTest {
         jwtProperties = Mockito.mock(JwtProperties.class);
         refreshTokenRepository = Mockito.mock(RefreshTokenRepository.class);
         tokenHasher = Mockito.mock(TokenHasher.class);
+        refreshTokenRevocationService = Mockito.mock(RefreshTokenRevocationService.class);
 
         service = new AuthTokenServiceImpl(
                 jwtProvider,
                 jwtProperties,
                 refreshTokenRepository,
-                tokenHasher
+                tokenHasher,
+                refreshTokenRevocationService
         );
     }
 
@@ -92,5 +95,30 @@ class AuthTokenServiceImplTest {
         assertThatThrownBy(() -> service.refresh(request, response))
                 .isInstanceOf(BusinessException.class)
                 .hasMessage(ErrorCode.AUTH_REFRESH_TOKEN_MISSING.getMessage());
+    }
+
+    @Test
+    @DisplayName("재사용 감지된 refresh token이면 REQUIRES_NEW revoke를 호출하고 예외를 던진다")
+    void refresh_reusedToken_callsRevocationServiceAndThrows() {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setCookies(new Cookie("refreshToken", "raw-refresh"));
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        when(tokenHasher.hash("raw-refresh")).thenReturn("hash-refresh");
+        RefreshToken reused = RefreshToken.builder()
+                .refreshTokenId("refresh-id")
+                .userId("user-1")
+                .tokenHash("hash-refresh")
+                .issuedAt(LocalDateTime.now().minusMinutes(5))
+                .expiresAt(LocalDateTime.now().plusMinutes(5))
+                .rotatedAt(LocalDateTime.now().minusSeconds(10))
+                .build();
+        when(refreshTokenRepository.findByTokenHash("hash-refresh")).thenReturn(reused);
+
+        assertThatThrownBy(() -> service.refresh(request, response))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage(ErrorCode.AUTH_REFRESH_TOKEN_REUSED.getMessage());
+
+        verify(refreshTokenRevocationService).revokeAllByUserTokens(eq("user-1"), any(LocalDateTime.class));
     }
 }

--- a/src/test/java/com/flyway/auth/service/SignUpServiceImplTest.java
+++ b/src/test/java/com/flyway/auth/service/SignUpServiceImplTest.java
@@ -56,6 +56,8 @@ class SignUpServiceImplTest {
                 passwordEncoder,
                 smsVerificationService
         );
+
+        when(smsVerificationService.isVerified(anyString())).thenReturn(true);
     }
 
     @Test
@@ -66,6 +68,7 @@ class SignUpServiceImplTest {
                 .email("test@example.com")
                 .rawPassword("password")
                 .attemptId("attempt-1")
+                .phoneNumber("01012345678")
                 .build();
 
         when(signUpAttemptRepository.consumeIfVerified(eq("attempt-1"), eq("test@example.com"), any()))
@@ -101,6 +104,7 @@ class SignUpServiceImplTest {
                 .email("test@example.com")
                 .rawPassword("password")
                 .attemptId("attempt-1")
+                .phoneNumber("01012345678")
                 .build();
 
         when(signUpAttemptRepository.consumeIfVerified(anyString(), anyString(), any()))
@@ -121,6 +125,7 @@ class SignUpServiceImplTest {
                 .email("test@example.com")
                 .rawPassword("password")
                 .attemptId("attempt-1")
+                .phoneNumber("01012345678")
                 .build();
 
         when(signUpAttemptRepository.consumeIfVerified(eq("attempt-1"), eq("test@example.com"), any()))
@@ -142,6 +147,7 @@ class SignUpServiceImplTest {
                 .email("test@example.com")
                 .rawPassword("password")
                 .attemptId("attempt-1")
+                .phoneNumber("01012345678")
                 .build();
 
         when(signUpAttemptRepository.consumeIfVerified(eq("attempt-1"), eq("test@example.com"), any()))

--- a/src/test/java/com/flyway/auth/service/UserAuthServiceImplTest.java
+++ b/src/test/java/com/flyway/auth/service/UserAuthServiceImplTest.java
@@ -55,6 +55,8 @@ class UserAuthServiceImplTest {
                 passwordEncoder,
                 smsVerificationService
         );
+
+        when(smsVerificationService.isVerified(anyString())).thenReturn(true);
     }
 
     @Test
@@ -66,6 +68,7 @@ class UserAuthServiceImplTest {
         req.setEmail("dup@example.com");
         req.setRawPassword("password1234");
         req.setAttemptId("AttemptId");
+        req.setPhoneNumber("01012345678");
 
         when(userIdentityRepository.existsEmailIdentity("dup@example.com"))
                 .thenReturn(true);
@@ -100,6 +103,7 @@ class UserAuthServiceImplTest {
         req.setEmail("test@example.com");
         req.setRawPassword("password1234");
         req.setAttemptId("AttemptId");
+        req.setPhoneNumber("01012345678");
 
         when(userIdentityRepository.existsEmailIdentity("test@example.com"))
                 .thenReturn(false);
@@ -165,6 +169,7 @@ class UserAuthServiceImplTest {
         req.setEmail("test@example.com");
         req.setRawPassword("password1234");
         req.setAttemptId("AttemptId");
+        req.setPhoneNumber("01012345678");
 
         when(signUpAttemptRepository.consumeIfVerified(
                 eq("AttemptId"),
@@ -264,6 +269,7 @@ class UserAuthServiceImplTest {
         req.setEmail("test@example.com");
         req.setRawPassword("password1234");
         req.setAttemptId("AttemptId");
+        req.setPhoneNumber("01012345678");
 
         when(userIdentityRepository.existsEmailIdentity(anyString()))
                 .thenReturn(false);

--- a/src/test/java/com/flyway/security/filter/CsrfProtectionTest.java
+++ b/src/test/java/com/flyway/security/filter/CsrfProtectionTest.java
@@ -1,0 +1,84 @@
+package com.flyway.security.filter;
+
+import com.flyway.auth.controller.AuthController;
+import com.flyway.auth.service.AuthTokenService;
+import com.flyway.auth.service.KakaoLoginService;
+import com.flyway.auth.service.SignUpService;
+import com.flyway.security.service.EmailUserDetailsService;
+import com.flyway.security.service.UserIdUserDetailsService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.security.web.csrf.CookieCsrfTokenRepository;
+import org.springframework.security.web.csrf.CsrfFilter;
+import org.springframework.security.web.csrf.CsrfToken;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import javax.servlet.http.Cookie;
+
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+class CsrfProtectionTest {
+
+    private MockMvc mockMvc;
+    private AuthTokenService authTokenService;
+    private CookieCsrfTokenRepository csrfTokenRepository;
+
+    @BeforeEach
+    void setUp() {
+        SignUpService signUpService = mock(SignUpService.class);
+        KakaoLoginService kakaoLoginService = mock(KakaoLoginService.class);
+        EmailUserDetailsService emailUserDetailsService = mock(EmailUserDetailsService.class);
+        UserIdUserDetailsService userIdUserDetailsService = mock(UserIdUserDetailsService.class);
+        authTokenService = mock(AuthTokenService.class);
+
+        AuthController controller = new AuthController(
+                signUpService,
+                kakaoLoginService,
+                emailUserDetailsService,
+                userIdUserDetailsService,
+                authTokenService
+        );
+
+        csrfTokenRepository = CookieCsrfTokenRepository.withHttpOnlyFalse();
+        CsrfFilter csrfFilter = new CsrfFilter(csrfTokenRepository);
+
+        mockMvc = MockMvcBuilders.standaloneSetup(controller)
+                .addFilters(csrfFilter)
+                .build();
+    }
+
+    @Test
+    @DisplayName("CSRF 토큰 없이 POST /auth/refresh 요청하면 403을 반환한다")
+    void refresh_withoutCsrfToken_returnsForbidden() throws Exception {
+        mockMvc.perform(post("/auth/refresh"))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @DisplayName("유효한 CSRF 쿠키+헤더로 POST /auth/refresh 요청하면 통과한다")
+    void refresh_withValidCsrfToken_passes() throws Exception {
+        doNothing().when(authTokenService).refresh(org.mockito.ArgumentMatchers.any(), org.mockito.ArgumentMatchers.any());
+
+        String token = newTokenValue();
+
+        mockMvc.perform(post("/auth/refresh")
+                        .cookie(new Cookie("XSRF-TOKEN", token))
+                        .header("X-XSRF-TOKEN", token))
+                .andExpect(status().isNoContent());
+
+        verify(authTokenService).refresh(org.mockito.ArgumentMatchers.any(), org.mockito.ArgumentMatchers.any());
+    }
+
+    private String newTokenValue() {
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/auth/csrf");
+        CsrfToken token = csrfTokenRepository.generateToken(request);
+        return token.getToken();
+    }
+}

--- a/src/test/java/com/flyway/security/filter/OriginRefererCheckFilterTest.java
+++ b/src/test/java/com/flyway/security/filter/OriginRefererCheckFilterTest.java
@@ -6,6 +6,9 @@ import org.springframework.mock.web.MockFilterChain;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 
+import java.util.Arrays;
+import java.util.List;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -15,7 +18,7 @@ class OriginRefererCheckFilterTest {
     @Test
     @DisplayName("API POST + 허용 Origin이면 통과한다")
     void apiPost_withAllowedOrigin_passes() throws Exception {
-        OriginRefererCheckFilter filter = OriginRefererCheckFilter.forApi();
+        OriginRefererCheckFilter filter = apiFilter();
         MockFilterChain chain = new MockFilterChain();
         MockHttpServletRequest request = apiRequest("POST", "/api/auth/refresh");
         MockHttpServletResponse response = new MockHttpServletResponse();
@@ -29,7 +32,7 @@ class OriginRefererCheckFilterTest {
     @Test
     @DisplayName("API POST + 비허용 Origin이면 403 차단한다")
     void apiPost_withDisallowedOrigin_blocks() throws Exception {
-        OriginRefererCheckFilter filter = OriginRefererCheckFilter.forApi();
+        OriginRefererCheckFilter filter = apiFilter();
         MockFilterChain chain = new MockFilterChain();
         MockHttpServletRequest request = apiRequest("POST", "/api/auth/refresh");
         MockHttpServletResponse response = new MockHttpServletResponse();
@@ -44,7 +47,7 @@ class OriginRefererCheckFilterTest {
     @Test
     @DisplayName("API POST + Origin 없고 허용 Referer면 통과한다")
     void apiPost_withAllowedReferer_passes() throws Exception {
-        OriginRefererCheckFilter filter = OriginRefererCheckFilter.forApi();
+        OriginRefererCheckFilter filter = apiFilter();
         MockFilterChain chain = new MockFilterChain();
         MockHttpServletRequest request = apiRequest("POST", "/api/payments/confirm");
         MockHttpServletResponse response = new MockHttpServletResponse();
@@ -58,7 +61,7 @@ class OriginRefererCheckFilterTest {
     @Test
     @DisplayName("API POST + Origin/Referer 모두 없으면 403 차단한다")
     void apiPost_withoutOriginAndReferer_blocks() throws Exception {
-        OriginRefererCheckFilter filter = OriginRefererCheckFilter.forApi();
+        OriginRefererCheckFilter filter = apiFilter();
         MockFilterChain chain = new MockFilterChain();
         MockHttpServletRequest request = apiRequest("POST", "/api/auth/refresh");
         MockHttpServletResponse response = new MockHttpServletResponse();
@@ -72,7 +75,7 @@ class OriginRefererCheckFilterTest {
     @Test
     @DisplayName("OPTIONS 요청은 무조건 통과한다")
     void optionsRequest_alwaysPasses() throws Exception {
-        OriginRefererCheckFilter filter = OriginRefererCheckFilter.forApi();
+        OriginRefererCheckFilter filter = apiFilter();
         MockFilterChain chain = new MockFilterChain();
         MockHttpServletRequest request = apiRequest("OPTIONS", "/api/auth/refresh");
         MockHttpServletResponse response = new MockHttpServletResponse();
@@ -86,7 +89,7 @@ class OriginRefererCheckFilterTest {
     @Test
     @DisplayName("Web 필터는 비대상 경로에서는 동작하지 않는다")
     void webFilter_nonTargetPath_isSkipped() throws Exception {
-        OriginRefererCheckFilter filter = OriginRefererCheckFilter.forWeb();
+        OriginRefererCheckFilter filter = webFilter();
         MockFilterChain chain = new MockFilterChain();
         MockHttpServletRequest request = apiRequest("POST", "/search/flights");
         MockHttpServletResponse response = new MockHttpServletResponse();
@@ -100,7 +103,7 @@ class OriginRefererCheckFilterTest {
     @Test
     @DisplayName("Web 필터는 대상 경로의 비허용 Origin을 403 차단한다")
     void webFilter_targetPath_disallowedOrigin_blocks() throws Exception {
-        OriginRefererCheckFilter filter = OriginRefererCheckFilter.forWeb();
+        OriginRefererCheckFilter filter = webFilter();
         MockFilterChain chain = new MockFilterChain();
         MockHttpServletRequest request = apiRequest("POST", "/reservations/abc/passengers/api");
         MockHttpServletResponse response = new MockHttpServletResponse();
@@ -115,7 +118,7 @@ class OriginRefererCheckFilterTest {
     @Test
     @DisplayName("Web 필터는 예외 경로(/auth/**)는 검사하지 않는다")
     void webFilter_excludedPath_isSkipped() throws Exception {
-        OriginRefererCheckFilter filter = OriginRefererCheckFilter.forWeb();
+        OriginRefererCheckFilter filter = webFilter();
         MockFilterChain chain = new MockFilterChain();
         MockHttpServletRequest request = apiRequest("POST", "/auth/refresh");
         MockHttpServletResponse response = new MockHttpServletResponse();
@@ -129,7 +132,7 @@ class OriginRefererCheckFilterTest {
     @Test
     @DisplayName("contextPath가 있어도 경로 판별이 정상 동작한다")
     void resolvesPathWithContextPath() throws Exception {
-        OriginRefererCheckFilter filter = OriginRefererCheckFilter.forApi();
+        OriginRefererCheckFilter filter = apiFilter();
         MockFilterChain chain = new MockFilterChain();
         MockHttpServletRequest request = apiRequest("POST", "/flyway/api/auth/refresh");
         MockHttpServletResponse response = new MockHttpServletResponse();
@@ -155,5 +158,17 @@ class OriginRefererCheckFilterTest {
 
     private String requestAppBase(MockHttpServletRequest request) {
         return requestOrigin(request) + request.getContextPath();
+    }
+
+    private OriginRefererCheckFilter apiFilter() {
+        return OriginRefererCheckFilter.forApi(defaultAllowedOrigins());
+    }
+
+    private OriginRefererCheckFilter webFilter() {
+        return OriginRefererCheckFilter.forWeb(defaultAllowedOrigins());
+    }
+
+    private List<String> defaultAllowedOrigins() {
+        return Arrays.asList("https://flyway.kr", "http://localhost:8080");
     }
 }

--- a/src/test/java/com/flyway/security/filter/OriginRefererCheckFilterTest.java
+++ b/src/test/java/com/flyway/security/filter/OriginRefererCheckFilterTest.java
@@ -59,6 +59,20 @@ class OriginRefererCheckFilterTest {
     }
 
     @Test
+    @DisplayName("API POST + Origin 없고 대소문자 혼합 Referer여도 통과한다")
+    void apiPost_withMixedCaseAllowedReferer_passes() throws Exception {
+        OriginRefererCheckFilter filter = apiFilter();
+        MockFilterChain chain = new MockFilterChain();
+        MockHttpServletRequest request = apiRequest("POST", "/api/payments/confirm");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        request.addHeader("Referer", "HTTPS://LOCALHOST:8080/Reservations/abc/booking");
+
+        filter.doFilter(request, response, chain);
+
+        assertNotNull(chain.getRequest());
+    }
+
+    @Test
     @DisplayName("API POST + Origin/Referer 모두 없으면 403 차단한다")
     void apiPost_withoutOriginAndReferer_blocks() throws Exception {
         OriginRefererCheckFilter filter = apiFilter();

--- a/src/test/java/com/flyway/security/filter/OriginRefererCheckFilterTest.java
+++ b/src/test/java/com/flyway/security/filter/OriginRefererCheckFilterTest.java
@@ -1,0 +1,159 @@
+package com.flyway.security.filter;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockFilterChain;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+class OriginRefererCheckFilterTest {
+
+    @Test
+    @DisplayName("API POST + 허용 Origin이면 통과한다")
+    void apiPost_withAllowedOrigin_passes() throws Exception {
+        OriginRefererCheckFilter filter = OriginRefererCheckFilter.forApi();
+        MockFilterChain chain = new MockFilterChain();
+        MockHttpServletRequest request = apiRequest("POST", "/api/auth/refresh");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        request.addHeader("Origin", requestOrigin(request));
+
+        filter.doFilter(request, response, chain);
+
+        assertNotNull(chain.getRequest());
+    }
+
+    @Test
+    @DisplayName("API POST + 비허용 Origin이면 403 차단한다")
+    void apiPost_withDisallowedOrigin_blocks() throws Exception {
+        OriginRefererCheckFilter filter = OriginRefererCheckFilter.forApi();
+        MockFilterChain chain = new MockFilterChain();
+        MockHttpServletRequest request = apiRequest("POST", "/api/auth/refresh");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        request.addHeader("Origin", "https://evil.com");
+
+        filter.doFilter(request, response, chain);
+
+        assertEquals(403, response.getStatus());
+        assertNull(chain.getRequest());
+    }
+
+    @Test
+    @DisplayName("API POST + Origin 없고 허용 Referer면 통과한다")
+    void apiPost_withAllowedReferer_passes() throws Exception {
+        OriginRefererCheckFilter filter = OriginRefererCheckFilter.forApi();
+        MockFilterChain chain = new MockFilterChain();
+        MockHttpServletRequest request = apiRequest("POST", "/api/payments/confirm");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        request.addHeader("Referer", requestAppBase(request) + "/reservations/abc/booking");
+
+        filter.doFilter(request, response, chain);
+
+        assertNotNull(chain.getRequest());
+    }
+
+    @Test
+    @DisplayName("API POST + Origin/Referer 모두 없으면 403 차단한다")
+    void apiPost_withoutOriginAndReferer_blocks() throws Exception {
+        OriginRefererCheckFilter filter = OriginRefererCheckFilter.forApi();
+        MockFilterChain chain = new MockFilterChain();
+        MockHttpServletRequest request = apiRequest("POST", "/api/auth/refresh");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        filter.doFilter(request, response, chain);
+
+        assertEquals(403, response.getStatus());
+        assertNull(chain.getRequest());
+    }
+
+    @Test
+    @DisplayName("OPTIONS 요청은 무조건 통과한다")
+    void optionsRequest_alwaysPasses() throws Exception {
+        OriginRefererCheckFilter filter = OriginRefererCheckFilter.forApi();
+        MockFilterChain chain = new MockFilterChain();
+        MockHttpServletRequest request = apiRequest("OPTIONS", "/api/auth/refresh");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        request.addHeader("Origin", "https://evil.com");
+
+        filter.doFilter(request, response, chain);
+
+        assertNotNull(chain.getRequest());
+    }
+
+    @Test
+    @DisplayName("Web 필터는 비대상 경로에서는 동작하지 않는다")
+    void webFilter_nonTargetPath_isSkipped() throws Exception {
+        OriginRefererCheckFilter filter = OriginRefererCheckFilter.forWeb();
+        MockFilterChain chain = new MockFilterChain();
+        MockHttpServletRequest request = apiRequest("POST", "/search/flights");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        request.addHeader("Origin", "https://evil.com");
+
+        filter.doFilter(request, response, chain);
+
+        assertNotNull(chain.getRequest());
+    }
+
+    @Test
+    @DisplayName("Web 필터는 대상 경로의 비허용 Origin을 403 차단한다")
+    void webFilter_targetPath_disallowedOrigin_blocks() throws Exception {
+        OriginRefererCheckFilter filter = OriginRefererCheckFilter.forWeb();
+        MockFilterChain chain = new MockFilterChain();
+        MockHttpServletRequest request = apiRequest("POST", "/reservations/abc/passengers/api");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        request.addHeader("Origin", "https://evil.com");
+
+        filter.doFilter(request, response, chain);
+
+        assertEquals(403, response.getStatus());
+        assertNull(chain.getRequest());
+    }
+
+    @Test
+    @DisplayName("Web 필터는 예외 경로(/auth/**)는 검사하지 않는다")
+    void webFilter_excludedPath_isSkipped() throws Exception {
+        OriginRefererCheckFilter filter = OriginRefererCheckFilter.forWeb();
+        MockFilterChain chain = new MockFilterChain();
+        MockHttpServletRequest request = apiRequest("POST", "/auth/refresh");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        request.addHeader("Origin", "https://evil.com");
+
+        filter.doFilter(request, response, chain);
+
+        assertNotNull(chain.getRequest());
+    }
+
+    @Test
+    @DisplayName("contextPath가 있어도 경로 판별이 정상 동작한다")
+    void resolvesPathWithContextPath() throws Exception {
+        OriginRefererCheckFilter filter = OriginRefererCheckFilter.forApi();
+        MockFilterChain chain = new MockFilterChain();
+        MockHttpServletRequest request = apiRequest("POST", "/flyway/api/auth/refresh");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        request.setContextPath("/flyway");
+        request.addHeader("Origin", requestOrigin(request));
+
+        filter.doFilter(request, response, chain);
+
+        assertNotNull(chain.getRequest());
+    }
+
+    private MockHttpServletRequest apiRequest(String method, String requestUri) {
+        MockHttpServletRequest request = new MockHttpServletRequest(method, requestUri);
+        request.setScheme("http");
+        request.setServerName("localhost");
+        request.setServerPort(8080);
+        return request;
+    }
+
+    private String requestOrigin(MockHttpServletRequest request) {
+        return request.getScheme() + "://" + request.getServerName() + ":" + request.getServerPort();
+    }
+
+    private String requestAppBase(MockHttpServletRequest request) {
+        return requestOrigin(request) + request.getContextPath();
+    }
+}

--- a/src/test/java/com/flyway/security/handler/LoginSuccessHandlerTest.java
+++ b/src/test/java/com/flyway/security/handler/LoginSuccessHandlerTest.java
@@ -1,11 +1,8 @@
 package com.flyway.security.handler;
 
 import com.flyway.auth.service.AuthTokenService;
-import com.flyway.security.jwt.JwtProperties;
-import com.flyway.security.jwt.JwtProvider;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.http.HttpHeaders;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.security.core.Authentication;
@@ -13,8 +10,6 @@ import org.springframework.security.core.userdetails.User;
 import org.springframework.security.core.userdetails.UserDetails;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;


### PR DESCRIPTION
## 📌 PR 설명

쿠키 기반 인증(JWT Cookie) 환경에서 상태 변경 요청(POST/PUT/PATCH/DELETE)에 대한 CSRF 방어를 강화하고, 추가로 Origin/Referer 검증 레이어를 도입하여 교차 출처 요청 위조를 이중 방어하도록 개선했습니다.

또한 CSRF 토큰을 안정적으로 전달하기 위해 토큰 부트스트랩 엔드포인트 및 프론트 유틸을 추가하고, 검증 필터에 대한 단위 테스트를 함께 작성했습니다.


### 상태 변경 요청에 대한 동작 과정
* Origin/Referer 검증 → CSRF 검증 → JWT 인증 → 온보딩 접근 제어


### 팀 공용 `csrfFetch` 함수 추가
* **로그인(인증)이 필요 없는 요청 → `csrfFetch` 사용**
* **로그인(인증)이 필요한 요청 → 기존 `fetchWithRefresh` 사용**
`fetchWithRefresh` 내부에는 이미 **CSRF 검증 로직(XSRF 쿠키 확인 + X-XSRF-TOKEN 헤더 첨부)** 이 포함되어 있으므로
  인증 요청에서는 `csrfFetch`를 따로 사용할 필요 없습니다.
* 예시
  ```js
  import { csrfFetch } from "/resources/common/js/csrfFetch.js";
  
  await csrfFetch("/api/sms/send?phoneNumber=01012345678", {
    method: "POST",
  });
  ```

<br>

## ✅ 완료한 기능 명세
* CSRF 보호 활성화 (Web + API)
  * [x] Web Security 체인에서 CSRF 보호 활성화
  * [x] API Security 체인(`/api/**`)에도 CSRF 보호 활성화
  * [x] CSRF 토큰 부트스트랩 엔드포인트 추가
    * `GET /auth/csrf` 호출 시 CSRF 토큰 쿠키 발급/갱신 가능
* 프론트 CSRF 요청 유틸 추가 및 적용
  * [x] 공통 유틸 `csrfFetch.js` 추가
    * 상태 변경 메서드(POST/PUT/PATCH/DELETE) 요청 시 자동 처리:
      * `XSRF-TOKEN` 쿠키 존재 여부 확인
      * 없을 경우 `/auth/csrf` 호출하여 토큰 부트스트랩
      * `X-XSRF-TOKEN` 헤더 자동 첨부 후 fetch 실행
  * [x] 기존 인증 요청 유틸 `authFetch.js`가 `csrfFetch`를 사용하도록 변경
    * 인증/인가 요청에서도 CSRF 검증이 자동으로 적용되도록 통합
* JSP/Form 기반 CSRF 적용 확대
  * [x] 주요 JSP 페이지 및 폼에 `<sec:csrfInput/>` 적용
* Origin/Referer 검증 필터 신규 도입
  * [x] `OriginRefererCheckFilter` 신규 구현
    * CSRF 토큰 외 추가적인 방어 레이어 제공
    * 브라우저 기반 Cross-Origin 요청 위조 차단 강화
  * [x] 상태 변경 메서드만 검증하도록 제한
    * POST / PUT / PATCH / DELETE만 검사
    * GET 요청 및 정적 리소스 영향 최소화
    * `OPTIONS` 요청은 CORS preflight 고려하여 검사 제외
  * [x] 검증 우선순위 적용
    * `Origin` 헤더가 존재하면 Origin 우선 검증
    * Origin이 없을 경우 `Referer` 기반 fallback 검증
  * [x] 허용되지 않은 출처 요청은 즉시 차단
    * 검증 실패 시 `403 Forbidden` 응답 처리
* Security FilterChain 반영 (API/Web 분리 적용)
  * [x] API Security 체인에서 필터 적용
    * `/api/**` 요청에서 `CsrfFilter` 이전 단계로 Origin/Referer 검증 필터 실행
    * API 요청의 출처 검증 → CSRF 검증 → JWT 인증 순으로 실행되도록 구성
  * [x] Web Security 체인에서 필터 적용
    * Web 환경에서는 **특정 경로만 검사**
      * 검사 대상: `/mypage`, `/reservations`, `/payment`, `/payments`
      * 예외 경로: `/oauth/**`, `/auth/**`, `/loginProc`


<br>

## 📸 스크린샷
### API Chain - Origin/Referer + CSRF 검증 흐름
<img width="6897" height="4330" alt="API(1)" src="https://github.com/user-attachments/assets/30a04484-2570-4295-899d-7d786023c924" />

### CSRF 토큰 발급 과정
<img width="8192" height="4762" alt="csrfFetch 동작 과정" src="https://github.com/user-attachments/assets/48c1e202-52ac-4159-9639-3ece2d3c4c28" />


<br>

## 💭 고민과 해결과정

### 1) CSRF 보호 적용 범위 확장

쿠키 기반 인증(JWT Cookie) 구조에서는 브라우저가 자동으로 쿠키를 포함해 요청을 전송하기 때문에, 상태 변경 요청이 CSRF 공격에 취약해질 수 있었습니다.

이를 해결하기 위해 다음을 적용했습니다.

* Web Security에 CSRF 활성화 및 `CookieCsrfTokenRepository.withHttpOnlyFalse()` 적용
* API Security(`/api/**`)에도 동일하게 CSRF 활성화 적용
* CSRF 토큰을 최초 발급받을 수 있도록 부트스트랩 엔드포인트 추가 (`GET /auth/csrf`)
* 프론트에서 상태 변경 요청 시 `XSRF-TOKEN` 쿠키 확보 후 `X-XSRF-TOKEN` 헤더 자동 첨부하도록 `csrfFetch.js` 유틸 추가
* 기존 `authFetch.js`가 `csrfFetch`를 사용하도록 반영
* 주요 JSP/Form 페이지에 `<sec:csrfInput/>` 적용 (login, signup, home, reservations 등)



### 2) Origin/Referer 검증 필터 추가 (이중 방어)

CSRF 토큰 검증만으로는 토큰 탈취/오용 가능성을 완전히 배제하기 어렵기 때문에, 추가적으로 요청 출처를 확인하는 방식을 도입했습니다.

* `OriginRefererCheckFilter` 신규 구현
* 상태 변경 메서드(POST/PUT/PATCH/DELETE)만 검사, `OPTIONS`는 제외
* `Origin` 헤더 우선 검증, 없으면 `Referer` fallback 검증
* 허용되지 않은 출처 요청은 `403 Forbidden` 처리
* API/Web 보안 체인에 `CsrfFilter` 이전 단계로 필터 적용

또한 Web 환경에서는 전체 경로를 무조건 검사할 경우 불필요한 영향이 생길 수 있어,
검사 범위를 제한했습니다.

* Web 대상 경로만 검사: `/mypage`, `/reservations`, `/payment`, `/payments`
* 예외 처리: `/oauth/**`, `/auth/**`, `/loginProc`


<br>

### 🔗 관련 이슈

Closes #100 

<br>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 검색 엔드포인트가 POST→GET으로 변경되어 쿼리 매개변수로 검색 가능
  * /auth/csrf 읽기용 엔드포인트 추가
  * 로그인 시 안전한 returnUrl 리다이렉트 지원
  * csrfFetch 유틸 글로벌 도입 및 클라이언트 전면 적용
  * 리프레시 토큰 강제 로그아웃 및 토큰 일괄 폐기 기능 추가

* **보안 개선**
  * JSP 폼과 JS 호출에 CSRF 토큰 적용
  * Origin/Referer 검사 필터 추가(웹/API)
  * 리프레시 토큰 동기화 필터로 세션·인증 정리 강화

* **테스트**
  * CSRF 및 Origin/Referer 동작 검증 단위 테스트 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai --> 
     